### PR TITLE
fix issue reported in #95 and improve the typechecking of the xyz setter

### DIFF
--- a/MDTraj/test/test_trajectory.py
+++ b/MDTraj/test/test_trajectory.py
@@ -226,3 +226,14 @@ def test_restrict_atoms():
     eq(len(traj.top._bonds), 2)
     eq(traj.n_residues, traj.topology._numResidues)
     eq(traj.n_atoms, traj.topology._numAtoms)
+
+
+def test_array_vs_matrix():
+    top = load(get_fn('native.pdb')).topology
+    xyz = np.random.randn(1, 22, 3)
+    xyz_mat = np.matrix(xyz)
+    t1 = mdtraj.trajectory.Trajectory(xyz, top)
+    t2 = mdtraj.trajectory.Trajectory(xyz_mat, top)
+
+    eq(t1.xyz, xyz)
+    eq(t2.xyz, xyz)

--- a/MDTraj/trajectory.py
+++ b/MDTraj/trajectory.py
@@ -29,7 +29,7 @@ import numpy as np
 from mdtraj import (DCDTrajectoryFile, BINPOSTrajectoryFile, XTCTrajectoryFile,
                     TRRTrajectoryFile, HDF5TrajectoryFile, NetCDFTrajectoryFile)
 from mdtraj.pdb import pdbfile
-from mdtraj.utils import unitcell, arrays
+from mdtraj.utils import unitcell, ensure_type
 import mdtraj.topology
 
 try:
@@ -764,7 +764,7 @@ class Trajectory(object):
             The distances a, b, and c that define the shape of the unit cell in
             each frame.
         """
-        self._unitcell_lengths = arrays.ensure_type(value, np.float32, 2,
+        self._unitcell_lengths = ensure_type(value, np.float32, 2,
             'unitcell_lengths', can_be_none=True, shape=(len(self), 3),
             warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
 
@@ -778,7 +778,7 @@ class Trajectory(object):
             The angles alpha, beta and gamma that define the shape of the
             unit cell in each frame. The angles should be in **degrees*
         """
-        self._unitcell_angles = arrays.ensure_type(value, np.float32, 2,
+        self._unitcell_angles = ensure_type(value, np.float32, 2,
             'unitcell_angles', can_be_none=True, shape=(len(self), 3),
             warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
 
@@ -788,23 +788,14 @@ class Trajectory(object):
 
     @xyz.setter
     def xyz(self, value):
-        #TODO control the precision of xyz
-        if value.ndim == 2:
-            n_frames = 1
-            n_atoms, n_dims = value.shape
-            assert n_dims == 3
-
-            xyz = value.reshape((n_frames, n_atoms, n_dims))
-        elif value.ndim == 3:
-            xyz = value
+        if hasattr(self, 'topology'):
+            shape = (None, self.topology._numAtoms, 3)
         else:
-            raise ValueError('xyz is wrong shape')
+            shape = (None, None, 3)
 
-        if hasattr(self, 'topology') and self.topology._numAtoms != xyz.shape[1]:
-            raise ValueError("Number of atoms in xyz (%s) and "
-                "in topology (%s) don't match" % (xyz.shape[1], self.topology._numAtoms))
-
-        self._xyz = xyz
+        value = ensure_type(value, np.float32, 3, 'xyz', shape=shape,
+                            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        self._xyz = value
 
     def __len__(self):
         return self.n_frames
@@ -1207,6 +1198,6 @@ class Trajectory(object):
         ----------
         atom_indices : list([int])
             List of atom indices to keep.
-        """        
+        """
         self.top.restrict_atoms(atom_indices)
         self._xyz = self.xyz[:,atom_indices]


### PR DESCRIPTION
Ensure that if xyz is set with a np.matrix or an np.array, that we still get the right results. Thanks for the tip, @dermen

the xyzsetter code is now using utils.arrays.ensure_type, which handles the nitty gritty.
