### PR TITLE
Fixed bug in trajectory join when discard_overlapping_frames is True, but frames are not identical

### DIFF
--- a/MDTraj/trajectory.py
+++ b/MDTraj/trajectory.py
@@ -1055,7 +1055,7 @@ class Trajectory(object):
 
         if discard_overlapping_frames:
             x0 = self.xyz[-1]
-            x1 = other.xyz[-1]
+            x1 = other.xyz[0]
             start_frame = 0 if np.linalg.norm(x1 - x0) < 1e-8 else 1
         else: 
             start_frame = 0


### PR DESCRIPTION
The logic in the `join` method in trajectory.py did not correctly handle the case when `discard_overlapping_frames` was set to `True`, but the frames were not identical:

``` python
Traceback (most recent call last):
  File "CalculateTracerCounts.py", line 87, in <module>
    run(args)
  File "CalculateTracerCounts.py", line 28, in run
    traj_data = mdtraj.load(traj_files, top=args.pdb, discard_overlapping_frames=True, atom_indices=atomind)
  File "/home/jadelman/anaconda/lib/python2.7/site-packages/mdtraj/trajectory.py", line 180, in load
    return functools.reduce(lambda a, b: a.join(b, discard_overlapping_frames=discard_overlapping_frames), (load(f,**kwargs) for f in filename_or_filenames))
  File "/home/jadelman/anaconda/lib/python2.7/site-packages/mdtraj/trajectory.py", line 180, in <lambda>
    return functools.reduce(lambda a, b: a.join(b, discard_overlapping_frames=discard_overlapping_frames), (load(f,**kwargs) for f in filename_or_filenames))
  File "/home/jadelman/anaconda/lib/python2.7/site-packages/mdtraj/trajectory.py", line 1072, in join
    xyz = np.concatenate((self.xyz, xyz))
UnboundLocalError: local variable 'xyz' referenced before assignment
```

I did not write a test for this, although I can if necessary. Also, I didn't change it, but it seems like there should be an additional change of 

```
x0 = self.xyz[-1]
x1 = other.xyz[0]
```

So that the last frame of `self` is compared to the first frame of `other`. I can amend the pull request to fix that as well pending your ok.
