### PR TITLE
changed Trajectory.join's way of deciding if two frames are redundant

### DIFF
--- a/MDTraj/trajectory.py
+++ b/MDTraj/trajectory.py
@@ -807,7 +807,7 @@ class Trajectory(object):
         if discard_overlapping_frames:
             x0 = self.xyz[-1]
             x1 = other.xyz[0]
-            start_frame = 1 if np.linalg.norm(x1 - x0) < 1e-8 else 0
+            start_frame = 1 if np.all(np.abs(x1 - x0) < 2e-3) else 0
         else:
             start_frame = 0
 


### PR DESCRIPTION
For a FAH dataset I needed to make this change in order for it to discard the frames correctly.

Does this belong in mdtraj? Or should we say, you need to preprocess your data so that there are no redundant frames?
