### PR TITLE
Make the return values of compute_phi/psi/omega consistent with their do...

### DIFF
--- a/MDTraj/geometry/dihedral.py
+++ b/MDTraj/geometry/dihedral.py
@@ -4,7 +4,7 @@
 # Copyright 2012-2013 Stanford University and the Authors
 #
 # Authors: Robert McGibbon
-# Contributors: Kyle A Beauchamp
+# Contributors: Kyle A Beauchamp, Ravi Ramanathan
 #
 # MDTraj is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -300,7 +300,7 @@ def compute_phi(trajectory, opt=True):
     rid, indices = _get_indices_phi(trajectory)
     if len(indices) == 0:
         return np.empty(shape=(0,4), dtype=np.int), np.empty(shape=(len(trajectory), 0), dtype=np.float32)
-    return rid, compute_dihedrals(trajectory, indices, opt=opt)
+    return indices, compute_dihedrals(trajectory, indices, opt=opt)
 
 
 def compute_psi(trajectory, opt=True):
@@ -324,7 +324,7 @@ def compute_psi(trajectory, opt=True):
     rid, indices = _get_indices_psi(trajectory)
     if len(indices) == 0:
         return np.empty(shape=(0,4), dtype=np.int), np.empty(shape=(len(trajectory), 0), dtype=np.float32)
-    return rid, compute_dihedrals(trajectory, indices, opt=opt)
+    return indices, compute_dihedrals(trajectory, indices, opt=opt)
 
 
 def compute_chi1(trajectory, opt=True):
@@ -466,4 +466,4 @@ def compute_omega(trajectory, opt=True):
     rid, indices = _get_indices_omega(trajectory)
     if len(indices) == 0:
         return np.empty(shape=(0,4), dtype=np.int), np.empty(shape=(len(trajectory), 0), dtype=np.float32)
-    return rid, compute_dihedrals(trajectory, indices, opt=opt)
+    return indices, compute_dihedrals(trajectory, indices, opt=opt)

--- a/MDTraj/geometry/tests/test_geometry.py
+++ b/MDTraj/geometry/tests/test_geometry.py
@@ -113,20 +113,21 @@ def test_dihedral_index_offset_generation():
 def test_dihedral_0():
     """We compared phi and psi angles from pymol to MDTraj output."""
     traj = md.load(get_fn('1bpi.pdb'))[0]
-    rid, phi = mdtraj.geometry.dihedral.compute_phi(traj)
+    indices, phi = mdtraj.geometry.dihedral.compute_phi(traj)
     phi0 = np.array([-34.50956, -50.869690]) * np.pi / 180.  # Pymol
     eq(phi[0,0:2], phi0, decimal=4)
-    eq(int(rid[0]), 1)
+    eq(indices[0], np.array([2,  11,  12,  13]))
 
-    rid, psi = mdtraj.geometry.dihedral.compute_psi(traj)
+
+    indices, psi = mdtraj.geometry.dihedral.compute_psi(traj)
     psi0 = np.array([134.52554, 144.880173]) * np.pi / 180.  # Pymol
     eq(psi[0,0:2], psi0, decimal=4)
-    eq(int(rid[0]), 0)
+    eq(indices[0], np.array([0, 1, 2, 11]))
 
-    rid, chi = mdtraj.geometry.dihedral.compute_chi1(traj)
+    indices, chi = mdtraj.geometry.dihedral.compute_chi1(traj)
     chi0 = np.array([-43.37841, -18.14592]) * np.pi / 180.  # Pymol
     eq(chi[0,0:2], chi0, decimal=4)
-    eq(int(rid[0,0]), 0)
+    eq(indices[0], np.array([0, 1, 4, 5]))
 
 
 def test_dihedral_1():


### PR DESCRIPTION
...cstring and return the ATOM indices as opposed to the residue indices

Fixed #233 
