### PR TITLE
Fix autosummary of trajectory file objects

### DIFF
--- a/docs/api/trajectory_files.rst
+++ b/docs/api/trajectory_files.rst
@@ -1,7 +1,7 @@
 File Objects
 ------------
 
-.. currentmodule:: mdtraj
+.. currentmodule:: mdtraj.formats
 .. autosummary::
     :toctree: generated/
     


### PR DESCRIPTION
#325 broke the file objects page on the docs http://mdtraj.org/0.8.0/api/trajectory_files.html
