### PR TITLE
cython fix for #394

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,10 @@ if 'setuptools' in sys.modules:
               ['mdconvert = mdtraj.scripts.mdconvert:entry_point',
                'mdinspect = mdtraj.scripts.mdinspect:entry_point']}
 
-    # required to fix cythoninze() for old versions of setuptools
-    m = sys.modules['setuptools.extension']
-    m.Extension.__dict__ = m._Extension.__dict__
+    if sys.version_info[0] == 2:
+        # required to fix cythoninze() for old versions of setuptools
+        m = sys.modules['setuptools.extension']
+        m.Extension.__dict__ = m._Extension.__dict__
 else:
     setup_kwargs['scripts'] = ['scripts/mdconvert.py', 'scripts/mdinspect.py']
 


### PR DESCRIPTION
I tested this with cython 0.19 and cython 0.20 with a lot of versions of setuptools (below) and it works.

I tried with cython 0.18 and got some compile failures

```
set -e

for v in 0.6c11 0.6c2 0.6c3 0.6c4 0.6c5 0.6c6 0.6c7 0.6c8 0.6c9 0.7.2 0.7.3 0.7.4 0.7.5 0.7.6 0.7.7 0.7.8 0.8 0.9.1 0.9.2 0.9.3 0.9.4 0.9.5 0.9.6 0.9.7 0.9.8 0.9 1.0 1.1.1 1.1.2 1.1.3 1.1.4 1.1.5 1.1.6 1.1.7 1.1 1.2 1.3.1 1.3.2 1.3 1.4.1 1.4.2 1.4 2.0.1 2.0.2 2.0 2.1.1 2.1.2 2.1 2.2 3.0.1 3.0.1 3.0.2 3.0.2 3.0 3.0 3.1 3.1 3.2 3.2 3.3 3.3
do
    git clean -x -f
    pip install setuptools==$v
    python setup.py build
done
```
