### PR TITLE
Silence pending deprication warning

### DIFF
--- a/MDTraj/geometry/contact.py
+++ b/MDTraj/geometry/contact.py
@@ -172,7 +172,7 @@ def compute_contacts(traj, contacts='all', scheme='closest-heavy', ignore_nonpro
         n_residue_pairs = len(residue_pairs)
         distances = np.zeros((len(traj), n_residue_pairs), dtype=np.float32)
         for i in xrange(n_residue_pairs):
-            index = np.sum(n_atom_pairs_per_residue_pair[:i])
+            index = int(np.sum(n_atom_pairs_per_residue_pair[:i]))
             n = n_atom_pairs_per_residue_pair[i]
             distances[:, i] = atom_distances[:, index : index + n].min(axis=1)
 


### PR DESCRIPTION
Currently, `compute_contacts` with numpy 1.8.1 warns:

```
/home/rmcgibbo/miniconda2/lib/python2.7/site-packages/mdtraj-0.8.1-py2.7-linux-x86_64.egg/mdtraj/geometry/contact.py:177: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  distances[:, i] = atom_distances[:, index : index + n].min(axis=1)
```

I'm not really sure what the purpose of this is, since `index` is a numpy.int64. But turning it into a python int seems to do the trick to remove the warning.
