### PR TITLE
Fix reading in an Amber prmtop file as a topology when it has an ATOMIC_NUMBER section

### DIFF
--- a/MDTraj/core/element.py
+++ b/MDTraj/core/element.py
@@ -114,6 +114,11 @@ class Element(tuple):
         s = symbol.strip().upper()
         return Element._elements_by_symbol[s]
 
+    @staticmethod
+    def getByAtomicNumber(number):
+        """ Get the element with a particular atomic number """
+        return Element._elements_by_atomic_number[number]
+
     @property
     def number(self):
         return tuple.__getitem__(self, 0)

--- a/MDTraj/formats/prmtop.py
+++ b/MDTraj/formats/prmtop.py
@@ -199,7 +199,7 @@ def load_prmtop(filename):
         # Get the element from the prmtop file if available
         if 'ATOMIC_NUMBER' in raw_data:
             try:
-                element = elem.Element.get_by_atomic_number(int(raw_data['ATOMIC_NUMBER'][index]))
+                element = elem.Element.getByAtomicNumber(int(raw_data['ATOMIC_NUMBER'][index]))
             except KeyError:
                 element = None
         else:


### PR DESCRIPTION
Fixes the following exception:

```
/.../mdtraj/formats/prmtop.pyc
in load_prmtop(filename)
    200         if 'ATOMIC_NUMBER' in raw_data:
    201             try:
--> 202                 element = elem.Element.get_by_atomic_number(int(raw_data['ATOMIC_NUMBER'][index]))
    203             except KeyError:
    204                 element = None

AttributeError: type object 'Element' has no attribute 'get_by_atomic_number'
```
