### PR TITLE
Associate .parm7 extension with Amber prmtop

### DIFF
--- a/MDTraj/core/trajectory.py
+++ b/MDTraj/core/trajectory.py
@@ -95,7 +95,7 @@ def _parse_topology(top):
     if isinstance(top, string_types) and (ext in ['.pdb', '.h5','.lh5']):
         _traj = load_frame(top, 0)
         topology = _traj.topology
-    elif isinstance(top, string_types) and (ext == '.prmtop'):
+    elif isinstance(top, string_types) and (ext in ['.prmtop', '.parm7']):
         topology = load_prmtop(top)
     elif isinstance(top, Trajectory):
         topology = top.topology


### PR DESCRIPTION
".prmtop" is a rather antiquated extension for Amber.  Most programs these days use ".parm7" (including VMD, etc.).  I would say that ".prmtop" is more standard for _old_-style topology files (pre-Amber 7, from back in the late 1700s).  While old-style topology files can still be created and used for explicit solvent calculations, they're rare.

If you want to be able to read old-style topologies, though, the `AmberParm` class from ParmEd can do it.  Probably not worth it though.
