### PR TITLE
Import reporters at top level.

### DIFF
--- a/MDTraj/__init__.py
+++ b/MDTraj/__init__.py
@@ -47,6 +47,7 @@ from mdtraj.core.topology import Topology
 from mdtraj.geometry import *
 from mdtraj.core.trajectory import *
 from mdtraj.nmr import *
+import mdtraj.reporters
 
 def test(label='full', verbose=2):
     """Run tests for mdtraj using nose.


### PR DESCRIPTION
To keep the namespace clean, I did 

```
import mdtraj.reporters
```

instead of 

```
from mdtraj.reporters import *
```
