### PR TITLE
Topology convenience methods

### DIFF
--- a/MDTraj/tests/test_topology.py
+++ b/MDTraj/tests/test_topology.py
@@ -25,6 +25,7 @@ import tempfile
 import mdtraj as md
 from mdtraj.utils.six.moves import cPickle
 from mdtraj.testing import get_fn, eq, DocStringFormatTester, skipif
+from nose.tools import assert_raises
 import numpy as np
 
 try:
@@ -122,3 +123,17 @@ def test_nonconsective_resSeq():
 def test_pickle():
     # test pickling of topology (bug #391)
     cPickle.loads(cPickle.dumps(md.load(get_fn('bpti.pdb')).topology))
+
+def test_atoms_by_name():
+    top = md.load(get_fn('bpti.pdb')).topology
+
+    atoms = list(top.atoms)
+    for atom1, atom2 in zip(top.atoms_by_name('CA'), top.chain(0).atoms_by_name('CA')):
+        assert atom1 == atom2
+        assert atom1 in atoms
+        assert atom1.name == 'CA'
+
+    assert len(list(top.atoms_by_name('CA'))) == sum(1 for _ in atoms if _.name == 'CA')
+    assert top.residue(15).atom('CA') == [a for a in top.residue(15).atoms if a.name == 'CA'][0]
+
+    assert_raises(KeyError, lambda: top.residue(15).atom('sdfsdsdf'))


### PR DESCRIPTION
- adds `atoms_by_name`. (e.g. `trajectory.top.atoms_by_name('CA')`)
- I didn't add `residues_by_name`,  but that would be a reasonable thing to add to `Topology` and `Chain`
- I also changed the `Residue.atom(self, index)` method to allow the argument to be a string (argument renamed `index_or_name`, in which case the first atom with the matching name is returned. This seems reasonable on Residue, since by convention the atom names are unique within a residue, but it didn't seem like a really useful extension to add to `Topology.atom(self, index)` or `Chain.atom(self, index)`, since the atom names are not unique within those groupings.
