### PR TITLE
Add the failing test case and a fix

### DIFF
--- a/MDTraj/geometry/src/geometry.c
+++ b/MDTraj/geometry/src/geometry.c
@@ -23,6 +23,10 @@
 
 #include <stdlib.h>
 #include <math.h>
+#define MIN(X,Y) ((X) < (Y) ? (X) : (Y))
+#define MAX(X,Y) ((X) > (Y) ? (X) : (Y))
+#define CLIP(X, X_min, X_max) (MIN(MAX(X, X_min), X_max))
+
 /* Only compile this file if you have SSE4.1 */
 #ifndef __SSE4_1__
 
@@ -300,7 +304,7 @@ int angle(const float* xyz, const int* triplets, float* out,
       v = _mm_mul_ps(v_prime, _mm_rsqrt_ps(_mm_dp_ps(v_prime, v_prime, 0x7F)));
 
       /* compute the arccos of the dot product, and store the result. */
-      *(out++) = acos(_mm_cvtss_f32(_mm_dp_ps(u, v, 0x71)));
+      *(out++) = acos(CLIP(_mm_cvtss_f32(_mm_dp_ps(u, v, 0x71)), -1, 1));
     }
     /* advance to the next frame */
     xyz += n_atoms*3;

--- a/MDTraj/geometry/tests/test_geometry.py
+++ b/MDTraj/geometry/tests/test_geometry.py
@@ -216,6 +216,7 @@ def test_dihedral_performance():
     print('numpy:   %f s' % (t2 - t1))
     print('opt sse: %f s' % (t3 - t2))
 
+
 @skipif(not RUN_PERFOMANCE_TESTS, 'Not doing performance testing')
 def test_angle_performance():
     n_atoms = 20
@@ -232,3 +233,13 @@ def test_angle_performance():
     print('\nangle performance:')
     print('numpy:   %f s' % (t2 - t1))
     print('opt sse: %f s' % (t3 - t2))
+
+
+def test_angle_nan():
+    t = md.Trajectory(topology=None, xyz=np.array([
+        [0, 0, 0.2],
+        [0, 0, 0.3],
+        [0, 0, 0.0]
+    ]))
+    angles = md.compute_angles(t, [[0, 1, 2]], opt=True)
+    np.testing.assert_array_almost_equal(angles, [[0]])


### PR DESCRIPTION
cc @leeping. This is the same test as #474, but just put in a different file and without a needing an extra file in the reference data. I tracked down the bug, and the problem was just from floating point roundoff, the angle is computed from the law of cosines, and the argument was like 1.000004, which is just outside the range. clipping here seems to make the most sense to me.
