### PR TITLE
force upload

### DIFF
--- a/tools/ci/after_sucess.sh
+++ b/tools/ci/after_sucess.sh
@@ -14,7 +14,7 @@ fi
 
 if [[ "2.7 3.3 3.4" =~ "$python" ]]; then
     conda install --yes binstar
-    binstar -t $BINSTAR_TOKEN  upload -u omnia -p mdtraj-dev $HOME/miniconda/conda-bld/linux-64/mdtraj-dev-*
+    binstar -t $BINSTAR_TOKEN  upload --force -u omnia -p mdtraj-dev $HOME/miniconda/conda-bld/linux-64/mdtraj-dev-*
 fi
 
 if [[ "$python" != "2.7" ]]; then


### PR DESCRIPTION
from the current travis log during `binstar upload`:

`Distribution already exists. Please use the -i/--interactive or --force options or `binstar remove omnia/mdtraj-dev/dev/linux-64/mdtraj-dev-py27_0.tar.bz2`
