### PR TITLE
Added -pH and -temperature arguments to ShiftX2 wrapper.

### DIFF
--- a/MDTraj/nmr/shift_wrappers.py
+++ b/MDTraj/nmr/shift_wrappers.py
@@ -103,6 +103,10 @@ def chemical_shifts_shiftx2(trj, pH=5.0, temperature=298.00):
     ----------
     trj : Trajectory
         Trajectory to predict shifts for.
+    pH : float, optional, default=5.0
+        pH value which gets passed to the ShiftX2 predictor.
+    temperature : float, optional, default=298.00
+        Temperature which gets passed to the ShiftX2 predictor.
 
     Returns
     -------


### PR DESCRIPTION
The shiftx2.py program takes temperature and pH as input arguments, which affects the predicted chemical shift output.  I'm not sure what's going on under the hood, but it makes sense for MDTraj to pass these arguments to the ShiftX2 system call.
