### PR TITLE
Enable generators to be passed to `md.compute_distances`

### DIFF
--- a/MDTraj/geometry/angle.py
+++ b/MDTraj/geometry/angle.py
@@ -61,7 +61,7 @@ def compute_angles(traj, angle_indices, periodic=True, opt=True):
         The angles are in radians
     """
     xyz = ensure_type(traj.xyz, dtype=np.float32, ndim=3, name='traj.xyz', shape=(None, None, 3), warn_on_cast=False)
-    triplets = ensure_type(np.asarray(angle_indices), dtype=np.int32, ndim=2, name='angle_indices', shape=(None, 3), warn_on_cast=False)
+    triplets = ensure_type(angle_indices, dtype=np.int32, ndim=2, name='angle_indices', shape=(None, 3), warn_on_cast=False)
     if not np.all(np.logical_and(triplets < traj.n_atoms, triplets >= 0)):
         raise ValueError('angle_indices must be between 0 and %d' % traj.n_atoms)
 

--- a/MDTraj/geometry/dihedral.py
+++ b/MDTraj/geometry/dihedral.py
@@ -103,7 +103,7 @@ def compute_dihedrals(traj, indices, periodic=True, opt=True):
 
     """
     xyz = ensure_type(traj.xyz, dtype=np.float32, ndim=3, name='traj.xyz', shape=(None, None, 3), warn_on_cast=False)
-    quartets = ensure_type(np.asarray(indices), dtype=np.int32, ndim=2, name='indices', shape=(None, 4), warn_on_cast=False)
+    quartets = ensure_type(indices, dtype=np.int32, ndim=2, name='indices', shape=(None, 4), warn_on_cast=False)
     if not np.all(np.logical_and(quartets < traj.n_atoms, quartets >= 0)):
         raise ValueError('indices must be between 0 and %d' % traj.n_atoms)
 

--- a/MDTraj/geometry/distance.py
+++ b/MDTraj/geometry/distance.py
@@ -63,7 +63,7 @@ def compute_distances(traj, atom_pairs, periodic=True, opt=True):
         The distance, in each frame, between each pair of atoms.
     """
     xyz = ensure_type(traj.xyz, dtype=np.float32, ndim=3, name='traj.xyz', shape=(None, None, 3), warn_on_cast=False)
-    pairs = ensure_type(np.asarray(atom_pairs), dtype=np.int32, ndim=2, name='atom_pairs', shape=(None, 2), warn_on_cast=False)
+    pairs = ensure_type(atom_pairs, dtype=np.int32, ndim=2, name='atom_pairs', shape=(None, 2), warn_on_cast=False)
     if not np.all(np.logical_and(pairs < traj.n_atoms, pairs >= 0)):
         raise ValueError('atom_pairs must be between 0 and %d' % traj.n_atoms)
 

--- a/MDTraj/geometry/tests/test_angles.py
+++ b/MDTraj/geometry/tests/test_angles.py
@@ -1,4 +1,6 @@
+import itertools
 import mdtraj as md
+from mdtraj.testing import eq
 import numpy as np
 
 def test_angle_pbc_0():
@@ -27,3 +29,15 @@ def test_angle_pbc_0():
     np.testing.assert_array_almost_equal(r0, r1, decimal=4)
     np.testing.assert_array_almost_equal(r2, r3, decimal=4)
     np.testing.assert_array_almost_equal(r0, r3, decimal=4)
+
+def test_generator():
+    N_FRAMES = 2
+    N_ATOMS = 5
+    xyz = np.asarray(np.random.randn(N_FRAMES, N_ATOMS, 3), dtype=np.float32)
+    ptraj = md.Trajectory(xyz=xyz, topology=None)
+
+    triplets = np.array(list(itertools.combinations(range(N_ATOMS), 3)), dtype=np.int32)
+    triplets2 = itertools.combinations(range(N_ATOMS), 3)
+    a = md.compute_angles(ptraj, triplets)
+    b = md.compute_angles(ptraj, triplets2)
+    eq(a, b)

--- a/MDTraj/geometry/tests/test_dihedral.py
+++ b/MDTraj/geometry/tests/test_dihedral.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import itertools
 from distutils.spawn import find_executable
 import tempfile
 
@@ -191,3 +192,14 @@ def test_dihedral_2chains():
         # chain
         assert any(i in chain_indices for i in np.concatenate(phi_indices))
 
+def test_generator():
+    N_FRAMES = 2
+    N_ATOMS = 5
+    xyz = np.asarray(np.random.randn(N_FRAMES, N_ATOMS, 3), dtype=np.float32)
+    ptraj = md.Trajectory(xyz=xyz, topology=None)
+
+    quartets = np.array(list(itertools.combinations(range(N_ATOMS), 4)), dtype=np.int32)
+    quartets2 = itertools.combinations(range(N_ATOMS), 4)
+    a = md.compute_dihedrals(ptraj, quartets)
+    b = md.compute_dihedrals(ptraj, quartets2)
+    eq(a, b)

--- a/MDTraj/geometry/tests/test_distance.py
+++ b/MDTraj/geometry/tests/test_distance.py
@@ -38,6 +38,12 @@ pairs = np.array(list(itertools.combinations(range(N_ATOMS), 2)), dtype=np.int32
 ptraj = md.Trajectory(xyz=xyz, topology=None)
 ptraj.unitcell_vectors = np.ascontiguousarray(np.random.randn(N_FRAMES, 3, 3) + 2*np.eye(3,3), dtype=np.float32)
 
+def test_generator():
+    pairs2 = itertools.combinations(range(N_ATOMS), 2)
+    a = compute_distances(ptraj, pairs)
+    b = compute_distances(ptraj, pairs2)
+    eq(a, b)
+
 def test_0():
     a = compute_distances(ptraj, pairs, periodic=False, opt=True)
     b = compute_distances(ptraj, pairs, periodic=False, opt=False)

--- a/MDTraj/utils/test.py
+++ b/MDTraj/utils/test.py
@@ -34,6 +34,7 @@ from mdtraj.utils.unit import in_units_of, _str_to_unit
 from mdtraj.utils import import_, lengths_and_angles_to_box_vectors
 from mdtraj.testing import raises, eq
 import warnings
+from itertools import combinations
 
 ##############################################################################
 # globals
@@ -111,7 +112,7 @@ def test_ensure_type_8():
 def test_ensure_type_9():
     c = ensure_type(np.zeros((5,11)), np.float32, ndim=2, name='', shape=(None, 10))
 
-@raises(TypeError)
+@raises(ValueError)
 def test_ensure_type_10():
     c = ensure_type([0,1], np.float32, ndim=2, name='')
 
@@ -126,6 +127,20 @@ def test_ensure_type_12():
 @raises(ValueError)
 def test_ensure_type_13():
     ensure_type(np.zeros((2,2)), np.float32, ndim=2, name='', shape=(None, None, None))
+
+def test_ensure_type_14():
+    # test that the generators work
+    value = ensure_type(combinations(range(10), 2), int, ndim=2, name='')
+    assert isinstance(value, np.ndarray)
+    ref = np.array(list(combinations(range(10), 2)))
+    eq(value, ref)
+
+def test_ensure_type_15():
+    # test that lists
+    x = [1, 2, 3]
+    value = ensure_type(x, int, ndim=1, name='')
+    ref = np.array(x)
+    eq(value, ref)
 
 @raises(ImportError)
 def test_delay_import_fail_1():

--- a/MDTraj/utils/validation.py
+++ b/MDTraj/utils/validation.py
@@ -29,6 +29,7 @@ from __future__ import print_function, division
 import warnings
 import numbers
 import numpy as np
+import collections
 from mdtraj.utils.six.moves import zip_longest
 
 ##############################################################################
@@ -93,10 +94,18 @@ def ensure_type(val, dtype, ndim, name, length=None, can_be_none=False, shape=No
         return None
 
     if not isinstance(val, np.ndarray):
-        # special case: if the user is looking for a 1d array, and
-        # they request newaxis upconversion, and provided a scalar
-        # then we should reshape the scalar to be a 1d length-1 array
-        if add_newaxis_on_deficient_ndim and ndim == 1 and np.isscalar(val):
+        if isinstance(val, collections.Iterable):
+            # If they give us an iterator, let's try...
+            if isinstance(val, collections.Sequence):
+                # sequences are easy. these are like lists and stuff
+                val = np.array(val, dtype=dtype)
+            else:
+                # this is a generator...
+                val = np.array(list(val), dtype=dtype)
+        elif np.isscalar(val) and add_newaxis_on_deficient_ndim and ndim == 1:
+            # special case: if the user is looking for a 1d array, and
+            # they request newaxis upconversion, and provided a scalar
+            # then we should reshape the scalar to be a 1d length-1 array
             val = np.array([val])
         else:
             raise TypeError(("%s must be numpy array. "


### PR DESCRIPTION
This is useful so that `md.compute_distances(t, itertools.combinations(range(n_atoms), 2))` works.
