### PR TITLE
Fix compiler detection using a CC env variable

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -19,4 +19,12 @@ Frequently Asked Questions
    packages, or getting a more modern compiler. (When building MDTraj from
    source, you can set the ``CC`` environment variable to point to a different
    compiler.)
+
+   .. note::
    
+   For pande lab members on vsp-compute, set the environment variable ``CC`` to
+   ``gcc44``, and then recompile from source ::
+
+       export CC=gcc44
+
+    

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ import shutil
 import tempfile
 import subprocess
 from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
 try:
     from setuptools import setup, Extension
 except ImportError:
@@ -177,6 +178,8 @@ if not release:
 class CompilerDetection(object):
     def __init__(self, disable_openmp):
         cc = new_compiler()
+        customize_compiler(cc)
+
         self.msvc = cc.compiler_type == 'msvc'
         self._print_compiler_version(cc)
 
@@ -265,6 +268,7 @@ class CompilerDetection(object):
     def _detect_openmp(self):
         self._print_support_start('OpenMP')
         compiler = new_compiler()
+        customize_compiler(compiler)
         hasopenmp = self.hasfunction(compiler, 'omp_get_num_threads()', extra_postargs=['-fopenmp', '/openmp'])
         needs_gomp = hasopenmp
         if not hasopenmp:
@@ -277,6 +281,7 @@ class CompilerDetection(object):
     def _detect_sse3(self):
         "Does this compiler support SSE3 intrinsics?"
         compiler = new_compiler()
+        customize_compiler(compiler)
         self._print_support_start('SSE3')
         result = self.hasfunction(compiler, '__m128 v; _mm_hadd_ps(v,v)',
                            include='<pmmintrin.h>',
@@ -287,6 +292,7 @@ class CompilerDetection(object):
     def _detect_sse41(self):
         "Does this compiler support SSE4.1 intrinsics?"
         compiler = new_compiler()
+        customize_compiler(compiler)
         self._print_support_start('SSE4.1')
         result = self.hasfunction(compiler, '__m128 v; _mm_round_ps(v,0x00)',
                            include='<smmintrin.h>',


### PR DESCRIPTION
When you have `CC` exported to a different compiler, the compiler features detection code in setup.py wasn't looking at the non-default compiler.

With this change, `export CC=gcc44` on vsp-compute (or other centos 5 machines whose default compiler is gcc4.1, but which have a more recent gcc installed) now works.
