### PR TITLE
Fix NetCDF trajectory file object docstring.

### DIFF
--- a/MDTraj/formats/netcdf.py
+++ b/MDTraj/formats/netcdf.py
@@ -192,7 +192,7 @@ class NetCDFTrajectoryFile(object):
         stride : int, optional
             If stride is not None, read only every stride-th frame from disk.
         atom_indices : np.ndarray, dtype=int, optional
-            The specific indices of the atoms you'd like to retreive. If not
+            The specific indices of the atoms you'd like to retrieve. If not
             supplied, all of the atoms will be retrieved.
 
         Returns


### PR DESCRIPTION
When documentation and code disagree...

Well, in this case I think the incorrect documentation was left over from the netCDF4 -> scipy.io.netcdf migration.  Minor cleanups and clarifications here.
