### PR TITLE
[WIP] Atom selection language

### DIFF
--- a/MDTraj/core/selection.py
+++ b/MDTraj/core/selection.py
@@ -46,6 +46,8 @@ class _RewriteNames(ast.NodeTransformer):
     def visit_Name(self, node):
         _safe_names = {'None': None, 'True': True, 'False': False}
         if node.id in _safe_names:
+            if not PY2:
+                return ast.NameConstant(value=_safe_names[node.id])
             return node
 
         if node.id == ATOM_NAME:
@@ -57,7 +59,6 @@ class _RewriteNames(ast.NodeTransformer):
         # like parse_selection('name CA') properly resolves CA as a string
         # literal, not a barename to be loaded from the global scope!
         return ast.Str(s=node.id)
-
 
 
 def _chain(*attrs):
@@ -299,10 +300,10 @@ class parse_selection(object):
             signature = ast.arguments(args=args, vararg=None, kwarg=None,
                                       defaults=[])
         else:
-            args =[ast.arg(arg='atom', annotation=None)]
+            args = [ast.arg(arg='atom', annotation=None)]
             signature = ast.arguments(args=args, vararg=None, kwarg=None,
-                                      kwonlyargs=[], defaults=[], kw_defaults=[])
-
+                                      kwonlyargs=[], defaults=[],
+                                      kw_defaults=[])
 
         func = ast.Expression(body=ast.Lambda(signature, astnode))
 

--- a/MDTraj/core/topology.py
+++ b/MDTraj/core/topology.py
@@ -774,10 +774,11 @@ class Topology(object):
         """
         return _topology_from_subset(self, atom_indices)
 
-
     def select_expression(self, select_string, top_name='top'):
-        return parse_selection(select_string).source
-
+        condition = parse_selection(select_string).source
+        fmt_string = "[atom.index for atom in {top_name}.atoms if {condition}]"
+        fmt_dict = dict(top_name=top_name, condition=condition)
+        return fmt_string.format(**fmt_dict)
 
     def select(self, selection_string):
         filter_func = parse_selection(selection_string).expr


### PR DESCRIPTION
The goal is to be able to get atom indices using a natural query string:

```
indices = traj.select("name O and water")
```

I've based my implemetation loosely on VMD. The idea is that queries should closely follow the API. Therefore, all keywords map to a property of Atom, Element, Residue, Chain, etc. Multiple keywords (aliases) can be mapped to the same property. We parse the input string and generate a valid python list comprehension:

```
[a.index for a in top.atoms if a.name == 'O' and a.residue.is_water]
```

Which is then exec'ed

For this pull request, I'm going to stick to static, topology-based selections (e.g. no "water within 10 of protein" _just_ yet)

I've also included a sphinx extension that auto-generates a table of valid keywords, what property they map to, and aliases for the keywords. 

If you want to play around with it, use the `topology.select()` and `topology.select_expression()` methods. I haven't exposed them on `Trajectory` objects yet. 

TODO:
- [ ] Figure out what properties we want to expose. Feedback needed! @rmcgibbo @kyleabeauchamp @cxhernandez 
- [ ] Figure out how to generate documentation for attributes that are not properties. e.g. residue.index, etc.
- [ ] Refactor `select_atom_indices`, `remove_solvent` to be consistent with my paradigm by exposing some new properties (e.g. `Residue.is_solvent`)
- [ ] Lazy import
- [ ] Generate code tree object instead of code string
- [ ] General cleanup; add docstrings
