### PR TITLE
Fix for xtc segfault

### DIFF
--- a/MDTraj/formats/xtc/src/xdrfile.c
+++ b/MDTraj/formats/xtc/src/xdrfile.c
@@ -908,7 +908,7 @@ xdrfile_decompress_coord_float(float     *ptr,
 			run -= is_smaller;
 			is_smaller--;
 		}
-		if ((lfp-ptrstart)+3*run > size3)
+		if ((lfp-ptrstart)+run > size3)
 		{
 			fprintf(stderr, "(xdrfile error) Buffer overrun during decompression.\n");
 			return 0;


### PR DESCRIPTION
#606

segfault fixed:

```
In [2]: md.open('/home/rmcgibbo/vagrant/precise64/3064-5-95-58.xtc').read()
(xdrfile error) Buffer overrun during decompression.
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-7ffba1853f92> in <module>()
----> 1 md.open('/home/rmcgibbo/vagrant/precise64/3064-5-95-58.xtc').read()

/home/rmcgibbo/miniconda/lib/python2.7/site-packages/mdtraj-1.X.0-py2.7-linux-x86_64.egg/mdtraj/formats/xtc.so in xtc.XTCTrajectoryFile.read (MDTraj/formats/xtc/xtc.c:4111)()

/home/rmcgibbo/miniconda/lib/python2.7/site-packages/mdtraj-1.X.0-py2.7-linux-x86_64.egg/mdtraj/formats/xtc.so in xtc.XTCTrajectoryFile._read (MDTraj/formats/xtc/xtc.c:5560)()

RuntimeError: XTC read error: Compressed 3d coordinate
```

we should contribute this fix back upstream to gromacs too.
