### PR TITLE
update version number in conda-recipe

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -8,6 +8,7 @@ How to do a release
 - Update the whatsnew.rst document. Use the github view that shows all the
   commits to master since the last release to write it.
 - Update the version number in `setup.py`, change `ISRELEASED` to `True`
+- Update the version number in `devtools/conda-recipe/meta.yaml`
 - Commit to master, and [tag](https://github.com/mdtraj/mdtraj/releases) the
   release on github
 - To push the source to PyPI, use `python setup.py sdist --formats=gztar,zip upload`

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: mdtraj-dev
-  version: !!str 1.1.X
+  version: !!str 1.2.X
 
 build:
   entry_points:


### PR DESCRIPTION
The `-dev` conda recipe's version number wasn't updated.