### PR TITLE
PEP440 version number

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -4,6 +4,16 @@ What's New?
 
 These are new features and improvements of note in each release.
 
+v1.3 (development)
+------------------
+- New functions to calculate various statistical mechanical properties
+  (``unitcell_volumes``, ``dipole_moments``, ``static_dielectric``,
+   ``isothermal_compressability_kappa_T``, ``thermal_expansion_alpha_P``,
+   ``density``) (Kyle A. Beauchamp)
+- Fix for PDB parser to handle more than 100K atoms. (Peter Eastman + ChayaSt)
+- Include nitrogen atoms as h-bond acceptors in hydrogen bond detection (Gert Kiss)
+
+
 v1.2 (December 1, 2014)
 -----------------------
 We're pleased to announce the 1.2 release of MDTraj! This release brings

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ else:
 
 
 ##########################
-VERSION = "1.2.X"
+VERSION = "1.3.0.dev0"
 ISRELEASED = False
 __version__ = VERSION
 ##########################
@@ -155,7 +155,7 @@ def rmsd_extensions():
         export_include=['MDTraj/rmsd/include/theobald_rmsd.h',
                         'MDTraj/rmsd/include/center.h'],
         # don't enable OpenMP
-        extra_compile_args=(compiler.compiler_args_sse2 + 
+        extra_compile_args=(compiler.compiler_args_sse2 +
                             compiler.compiler_args_sse3 +
                             compiler.compiler_args_opt))
 


### PR DESCRIPTION
Changed 1.2.X to 1.3.0.dev0, which should be more appropriate now that pip has switched to following [PEP440](https://www.python.org/dev/peps/pep-0440/#developmental-releases).