### PR TITLE
SSE3

### DIFF
--- a/MDTraj/geometry/angle.py
+++ b/MDTraj/geometry/angle.py
@@ -71,14 +71,14 @@ def compute_angles(traj, angle_indices, periodic=True, opt=True):
     out = np.zeros((xyz.shape[0], triplets.shape[0]), dtype=np.float32)
     if periodic is True and traj._have_unitcell:
         box = ensure_type(traj.unitcell_vectors, dtype=np.float32, ndim=3, name='unitcell_vectors', shape=(len(xyz), 3, 3))
-        if opt and _geometry._processor_supports_sse41():
+        if opt:
             _geometry._angle_mic(xyz, triplets, box, out)
             return out
         else:
             _angle(traj, triplets, periodic, out)
             return out
 
-    if opt and _geometry._processor_supports_sse41():
+    if opt:
         _geometry._angle(xyz, triplets, out)
     else:
         _angle(traj, triplets, periodic, out)

--- a/MDTraj/geometry/dihedral.py
+++ b/MDTraj/geometry/dihedral.py
@@ -113,14 +113,14 @@ def compute_dihedrals(traj, indices, periodic=True, opt=True):
     out = np.zeros((xyz.shape[0], quartets.shape[0]), dtype=np.float32)
     if periodic is True and traj._have_unitcell:
         box = ensure_type(traj.unitcell_vectors, dtype=np.float32, ndim=3, name='unitcell_vectors', shape=(len(xyz), 3, 3))
-        if opt and _geometry._processor_supports_sse41():
+        if opt:
             _geometry._dihedral_mic(xyz, quartets, box, out)
             return out
         else:
             _dihedral(traj, quartets, periodic, out)
             return out
 
-    if opt and _geometry._processor_supports_sse41():
+    if opt:
         _geometry._dihedral(xyz, quartets, out)
     else:
         _dihedral(traj, quartets, periodic, out)
@@ -359,8 +359,8 @@ def compute_psi(traj, periodic=True, opt=True):
 
 
 def compute_chi1(traj, periodic=True, opt=True):
-    """Calculate the chi1 torsions of a trajectory. chi1 is the first side chain torsion angle 
-    formed between the 4 atoms over the CA-CB axis. 
+    """Calculate the chi1 torsions of a trajectory. chi1 is the first side chain torsion angle
+    formed between the 4 atoms over the CA-CB axis.
 
     Parameters
     ----------
@@ -392,7 +392,7 @@ def compute_chi1(traj, periodic=True, opt=True):
 
 
 def compute_chi2(traj, periodic=True, opt=True):
-    """Calculate the chi2 torsions of a trajectory. chi2 is the second side chain torsion angle 
+    """Calculate the chi2 torsions of a trajectory. chi2 is the second side chain torsion angle
     formed between the corresponding 4 atoms  over the CB-CG axis.
 
     Parameters
@@ -426,7 +426,7 @@ def compute_chi2(traj, periodic=True, opt=True):
 
 def compute_chi3(traj, periodic=True, opt=True):
     """Calculate the chi3 torsions of a trajectory. chi3 is the third side chain torsion angle
-    formed between the corresponding 4 atoms over the CG-CD axis 
+    formed between the corresponding 4 atoms over the CG-CD axis
     (only the residues ARG, GLN, GLU, LYS & MET have these atoms)
 
     Parameters
@@ -460,7 +460,7 @@ def compute_chi3(traj, periodic=True, opt=True):
 
 def compute_chi4(traj, periodic=True, opt=True):
     """Calculate the chi4 torsions of a trajectory. chi4 is the fourth side chain torsion angle
-    formed between the corresponding 4 atoms over the CD-CE or CD-NE axis 
+    formed between the corresponding 4 atoms over the CD-CE or CD-NE axis
     (only ARG & LYS residues have these atoms)
 
     Parameters

--- a/MDTraj/geometry/distance.py
+++ b/MDTraj/geometry/distance.py
@@ -72,7 +72,7 @@ def compute_distances(traj, atom_pairs, periodic=True, opt=True):
 
     if periodic is True and traj._have_unitcell:
         box = ensure_type(traj.unitcell_vectors, dtype=np.float32, ndim=3, name='unitcell_vectors', shape=(len(xyz), 3, 3))
-        if opt and _geometry._processor_supports_sse41():
+        if opt:
             out = np.empty((xyz.shape[0], pairs.shape[0]), dtype=np.float32)
             _geometry._dist_mic(xyz, pairs, box, out)
             return out
@@ -80,7 +80,7 @@ def compute_distances(traj, atom_pairs, periodic=True, opt=True):
             return _distance_mic(xyz, pairs, box)
 
     # either there are no unitcell vectors or they dont want to use them
-    if opt and _geometry._processor_supports_sse41():
+    if opt:
         out = np.empty((xyz.shape[0], pairs.shape[0]), dtype=np.float32)
         _geometry._dist(xyz, pairs, out)
         return out
@@ -118,7 +118,7 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
 
     if periodic is True and traj._have_unitcell:
         box = ensure_type(traj.unitcell_vectors, dtype=np.float32, ndim=3, name='unitcell_vectors', shape=(len(xyz), 3, 3))
-        if opt and _geometry._processor_supports_sse41():
+        if opt:
             out = np.empty((xyz.shape[0], pairs.shape[0], 3), dtype=np.float32)
             _geometry._dist_mic_displacement(xyz, pairs, box, out)
             return out
@@ -126,7 +126,7 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
             return _displacement_mic(xyz, pairs, box)
 
     # either there are no unitcell vectors or they dont want to use them
-    if opt and _geometry._processor_supports_sse41():
+    if opt:
         out = np.empty((xyz.shape[0], pairs.shape[0], 3), dtype=np.float32)
         _geometry._dist_displacement(xyz, pairs, out)
         return out

--- a/MDTraj/geometry/dssp.py
+++ b/MDTraj/geometry/dssp.py
@@ -29,7 +29,7 @@ __all__ = ['compute_dssp']
 
 def compute_dssp(traj, simplified=True):
     """Compute Dictionary of protein secondary structure (DSSP) secondary structure assignments
-    
+
     Parameters
     ----------
     traj : md.Trajectory
@@ -74,9 +74,7 @@ def compute_dssp(traj, simplified=True):
     """
     if traj.topology is None:
         raise ValueError('kabsch_sander requires topology')
-    if not _geometry._processor_supports_sse41():
-        raise RuntimeError('This CPU does not support the required instruction set (SSE4.1)')
-    
+
     xyz, nco_indices, ca_indices, proline_indices = _prep_kabsch_sander_arrays(traj)
     chain_ids = np.array([r.chain.index for r in traj.top.residues], dtype=np.int32)
 

--- a/MDTraj/geometry/hbond.py
+++ b/MDTraj/geometry/hbond.py
@@ -340,8 +340,6 @@ def kabsch_sander(traj):
     """
     if traj.topology is None:
         raise ValueError('kabsch_sander requires topology')
-    if not _geometry._processor_supports_sse41():
-        raise RuntimeError('This CPU does not support the required instruction set (SSE4.1)')
 
     import scipy.sparse
     xyz, nco_indices, ca_indices, proline_indices = _prep_kabsch_sander_arrays(traj)

--- a/MDTraj/geometry/include/geometryutils.h
+++ b/MDTraj/geometry/include/geometryutils.h
@@ -2,10 +2,10 @@
 #define _GEOMETRY_UTILS_H_
 
 #include "msvccompat.h"
-#include <smmintrin.h>
+#include "ssetools.h"
 
 
-/** 
+/**
  * Compute the cross-product of two 3D vectors stored the first three float
  * elements of `a` and `b`.
  */
@@ -84,7 +84,7 @@ static INLINE void loadBoxMatrix(const float M[9], __m128 (*h)[3], __m128 (*hinv
  * where h and h^{-1} are the 3x3 matrix of box vectors and the inverse
  * of that matrix respectively.
  * -------------------------------------------------------------------
- * For this function, r is supplied in the first three elements of float4 
+ * For this function, r is supplied in the first three elements of float4
  * vector (__m128) `r`. `h` and `hinv` are pointers to arrays of three
  * float4s which specify the matricies H and H^{-1} in column-major order.
  * That is, the first float4 (*h)[0] gives [H[0,0], H[1,0], H[2,0]. 0],
@@ -102,7 +102,8 @@ static INLINE __m128 minimum_image(__m128 r, const __m128 (*h)[3], const __m128 
        _mm_mul_ps((*hinv)[2], _mm_shuffle_ps(r, r, _MM_SHUFFLE(2,2,2,2))));
 
     /* s = s - NEAREST_INTEGER(s) */
-    s = _mm_sub_ps(s, _mm_round_ps(s, _MM_FROUND_TO_NEAREST_INT));
+    /* s = _mm_sub_ps(s, _mm_round_ps(s, _MM_FROUND_TO_NEAREST_INT)); */
+    s = _mm_sub_ps(s, _mm_round_ps2(s));
 
     r = _mm_add_ps(_mm_add_ps(
         _mm_mul_ps((*h)[0], _mm_shuffle_ps(s, s, _MM_SHUFFLE(0,0,0,0))),

--- a/MDTraj/geometry/include/ssetools.h
+++ b/MDTraj/geometry/include/ssetools.h
@@ -4,10 +4,86 @@
 #include "msvccompat.h"
 #include <stdio.h>
 #include <pmmintrin.h>
+#include <smmintrin.h>
+
+/* Macros from http://sseplus.sourceforge.net/_s_s_e_plus__platform_8h-source.html */
+
+#ifdef _MSC_VER
+#define __CNST32I28I_( x ) \
+    ((unsigned __int8)((x) & 0xFF)), ((unsigned __int8)(((x) >> 8) & 0xFF)), ((unsigned __int8)(((x) >> 16) & 0xFF)), ((unsigned __int8)(((x) >> 24) & 0xFF))
+
+#define SSP_CONST_SETR_32I( a, b, c, d ) \
+    { __CNST32I28I_((a)), __CNST32I28I_((b)), __CNST32I28I_((c)), __CNST32I28I_((d)) }
+
+#define SSP_CONST_SET_32I( a, b, c, d ) \
+    SSP_CONST_SETR_32I( (d), (c), (b), (a) )
+#else
+#define __CNST32TO64_( a, b ) \
+        ( ((b)<<32) | ((a) & 0xFFFFFFFF) )
+
+#define SSP_CONST_SETR_32I( a, b, c, d ) \
+    { __CNST32TO64_( (unsigned long long)(a), (unsigned long long)(b) ), \
+      __CNST32TO64_( (unsigned long long)(c), (unsigned long long)(d) ) }
+
+#define SSP_CONST_SET_32I( a, b, c, d ) \
+    SSP_CONST_SETR_32I( (d), (c), (b), (a) )
+#endif
+
 
 /****************************************************************************/
 /* Utilities                                                                */
 /****************************************************************************/
+
+static INLINE __m128 _mm_hsum_ps(__m128 v) {
+    v = _mm_hadd_ps(v, v);
+    v = _mm_hadd_ps(v, v);
+    return v;
+}
+
+static INLINE __m128 _mm_round_ps2(const __m128 a){
+    /* http://dss.stephanierct.com/DevBlog/?p=8 */
+    __m128 v0 = _mm_setzero_ps();             /* generate the highest value < 2 */
+    __m128 v1 = _mm_cmpeq_ps(v0,v0);
+    __m128i srli = _mm_srli_epi32( *(__m128i*)& v1, 2);
+    __m128 vNearest2 = *(__m128*)& srli;
+    __m128i i = _mm_cvttps_epi32(a);
+    __m128 aTrunc = _mm_cvtepi32_ps(i);        /* truncate a */
+    __m128 rmd = _mm_sub_ps(a, aTrunc);        /* get remainder */
+    __m128 rmd2 = _mm_mul_ps( rmd, vNearest2); /* mul remainder by near 2 will yield the needed offset */
+    __m128i rmd2i = _mm_cvttps_epi32(rmd2);    /* after being truncated of course */
+    __m128 rmd2Trunc = _mm_cvtepi32_ps(rmd2i);
+    __m128 r =_mm_add_ps(aTrunc, rmd2Trunc);
+    return r;
+}
+
+
+static INLINE __m128 _mm_dp_ps2( __m128 a, __m128 b, const int mask ) {
+    /*
+     Copyright (c) 2006-2008 Advanced Micro Devices, Inc. All Rights Reserved.
+     This software is subject to the Apache v2.0 License.
+    */
+
+    /* Shift mask multiply moves 0,1,2,3 bits to left, becomes MSB */
+    const static __m128i mulShiftImm_0123 = SSP_CONST_SET_32I(0x010000, 0x020000, 0x040000, 0x080000);
+    /* Shift mask multiply moves 4,5,6,7 bits to left, becomes MSB */
+    const static __m128i mulShiftImm_4567 = SSP_CONST_SET_32I(0x100000, 0x200000, 0x400000, 0x800000);
+
+    /* Begin mask preparation */
+    __m128i mHi, mLo;
+    mLo = _mm_set1_epi32(mask);    /* Load the mask into register */
+    mLo = _mm_slli_si128(mLo, 3);  /* Shift into reach of the 16 bit multiply */
+    mHi = _mm_mullo_epi16(mLo, mulShiftImm_0123);  /* Shift the bits */
+    mLo = _mm_mullo_epi16(mLo, mulShiftImm_4567);  /* Shift the bits */
+    mHi = _mm_cmplt_epi32(mHi, _mm_setzero_si128()); /* FFFFFFFF if bit set, 00000000 if not set */
+    mLo = _mm_cmplt_epi32(mLo, _mm_setzero_si128()); /* FFFFFFFF if bit set, 00000000 if not set */
+    /* End mask preparation - Mask bits 0-3 in mLo, 4-7 in mHi */
+    a = _mm_and_ps(a, *(__m128*)& mHi);   /* Clear input using the high bits of the mask */
+    a = _mm_mul_ps(a, b);
+    a = _mm_hsum_ps(a);                  /* Horizontally add the 4 values */
+    a = _mm_and_ps(a, *(__m128*)& mLo);  /* Clear output using low bits of the mask */
+    return a;
+}
+
 
 static INLINE __m128 load_float3(const float* value) {
     /* Load (x,y,z) into a SSE register, leaving the last entry */

--- a/MDTraj/geometry/include/ssetools.h
+++ b/MDTraj/geometry/include/ssetools.h
@@ -4,7 +4,6 @@
 #include "msvccompat.h"
 #include <stdio.h>
 #include <pmmintrin.h>
-#include <smmintrin.h>
 
 /* Macros from http://sseplus.sourceforge.net/_s_s_e_plus__platform_8h-source.html */
 

--- a/MDTraj/geometry/sasa.py
+++ b/MDTraj/geometry/sasa.py
@@ -34,7 +34,7 @@ __all__ = ['shrake_rupley']
 
 # these van der waals radii are taken from GROMACS 4.5.3
 # and the file share/gromacs/top/vdwradii.dat
-#using the the same vdw radii for P and S based upon 
+#using the the same vdw radii for P and S based upon
 #http://en.wikipedia.org/wiki/Van_der_Waals_radius
 _ATOMIC_RADII = {'C': 0.15,  'F': 0.12,  'H': 0.04,
                  'N': 0.110, 'O': 0.105, 'S': 0.16,
@@ -101,8 +101,6 @@ def shrake_rupley(traj, probe_radius=0.14, n_sphere_points=960, mode='atom'):
     ----------
     .. [1] Shrake, A; Rupley, JA. (1973) J Mol Biol 79 (2): 351--71.
     """
-    if not _geometry._processor_supports_sse41():
-        raise RuntimeError('This CPU does not support the required instruction set (SSE4.1)')
 
     xyz = ensure_type(traj.xyz, dtype=np.float32, ndim=3, name='traj.xyz', shape=(None, None, 3), warn_on_cast=False)
     if mode == 'atom':

--- a/MDTraj/geometry/src/_geometry.pyx
+++ b/MDTraj/geometry/src/_geometry.pyx
@@ -21,6 +21,7 @@
 ##############################################################################
 
 import sys
+import warnings
 import cython
 import numpy as np
 
@@ -46,13 +47,13 @@ cdef extern from "geometry.h":
                  int n_frames, int n_atoms,  int n_quartets) nogil
 
     int dihedral_mic(const float* xyz, const int* quartets, float* out,
-                     const float* box_matrix, int n_frames, int n_atoms, 
+                     const float* box_matrix, int n_frames, int n_atoms,
                      int n_quartets) nogil
 
     int kabsch_sander(float* xyz, int* nco_indices, int* ca_indices,
                       const int* is_proline, int n_frames, int n_atoms,
                       int n_residues, int* hbonds, float* henergies) nogil
-    
+
     int dssp(const float* xyz, const int* nco_indices, const int* ca_indices,
              const int* is_proline, const int* chains_ids, const int n_frames,
              const int n_atoms, const int n_residues, char* secondary) nogil
@@ -65,15 +66,15 @@ cdef extern from "sasa.h":
 cdef extern from "hardware.h":
     int processorSupportsSSE41()
 
-
 ##############################################################################
 # Wrappers
 ##############################################################################
 
 def _processor_supports_sse41():
     """Does the current processor support SSE4.1 instructions?"""
+    warnings.warn(('_processor_supports_sse41 is depicrated, and will be '
+                  'removed in MDTraj 1.4'), DeprecationWarning)
     return processorSupportsSSE41()
-
 
 @cython.boundscheck(False)
 def _dist(float[:, :, ::1] xyz,

--- a/MDTraj/geometry/src/kernels/anglekernels.h
+++ b/MDTraj/geometry/src/kernels/anglekernels.h
@@ -58,11 +58,11 @@ int angle(const float* xyz, const int* triplets, float* out,
 #endif
 
       /* normalize the vectors u_prime and v_prime */
-      u = _mm_div_ps(u_prime, _mm_sqrt_ps(_mm_dp_ps(u_prime, u_prime, 0x7F)));
-      v = _mm_div_ps(v_prime, _mm_sqrt_ps(_mm_dp_ps(v_prime, v_prime, 0x7F)));
+      u = _mm_div_ps(u_prime, _mm_sqrt_ps(_mm_dp_ps2(u_prime, u_prime, 0x7F)));
+      v = _mm_div_ps(v_prime, _mm_sqrt_ps(_mm_dp_ps2(v_prime, v_prime, 0x7F)));
 
       /* compute the arccos of the dot product, and store the result. */
-      *(out++) = (float) acos(CLIP(_mm_cvtss_f32(_mm_dp_ps(u, v, 0x71)), -1, 1));
+      *(out++) = (float) acos(CLIP(_mm_cvtss_f32(_mm_dp_ps2(u, v, 0x71)), -1, 1));
     }
     /* advance to the next frame */
     xyz += n_atoms*3;

--- a/MDTraj/geometry/src/kernels/dihedralkernels.h
+++ b/MDTraj/geometry/src/kernels/dihedralkernels.h
@@ -63,8 +63,8 @@ int dihedral(const float* xyz, const int* quartets, float* out,
       c1 = cross(b2, b3);
       c2 = cross(b1, b2);
 
-      p1 = _mm_mul_ps(_mm_dp_ps(b1, c1, 0x71), _mm_sqrt_ps(_mm_dp_ps(b2, b2, 0x71)));
-      p2 = _mm_dp_ps(c1, c2, 0x71);
+      p1 = _mm_mul_ps(_mm_dp_ps2(b1, c1, 0x71), _mm_sqrt_ps(_mm_dp_ps2(b2, b2, 0x71)));
+      p2 = _mm_dp_ps2(c1, c2, 0x71);
 
       *(out++) = (float) atan2(_mm_cvtss_f32(p1), _mm_cvtss_f32(p2));
     };

--- a/MDTraj/geometry/src/kernels/distancekernels.h
+++ b/MDTraj/geometry/src/kernels/distancekernels.h
@@ -76,15 +76,10 @@ int dist(const float* xyz, const int* pairs, float* distance_out,
       if (store_distance) {
         /* r12_2 = r12*r12 */
         r12_2 = _mm_mul_ps(r12, r12);
-        /* horizontal add the components of d2 with */
-        /* two instructions. note: it's critical */
-        /* here that the last entry of x1 and x2 was 0 */
-        /* so that d2.w = 0 */
-        s = _mm_hadd_ps(r12_2, r12_2);
-        s = _mm_hadd_ps(s, s);
+        /* horizontal add the components of d2 (last one is zero)*/
+        s = _mm_hsum_ps(r12_2);
         /* sqrt our final answer */
         s = _mm_sqrt_ps(s);
-
         /* s now contains our answer in all four elements, because */
         /* of the way the hadd works. we only want to store one */
         /* element. */

--- a/MDTraj/geometry/src/neighbors.cpp
+++ b/MDTraj/geometry/src/neighbors.cpp
@@ -1,7 +1,6 @@
 #include "stdio.h"
 #include <vector>
 #include <pmmintrin.h>
-#include <smmintrin.h>
 #include "ssetools.h"
 #include "msvccompat.h"
 #include "geometryutils.h"
@@ -33,12 +32,8 @@ template<bool periodic> float get_dist(float* frame_xyz, int i, int j,
 
     /* r12_2 = r12*r12 */
     r12_2 = _mm_mul_ps(r12, r12);
-    /* horizontal add the components of d2 with */
-    /* two instructions. note: it's critical */
-    /* here that the last entry of x1 and x2 was 0 */
-    /* so that d2.w = 0 */
-    s = _mm_hadd_ps(r12_2, r12_2);
-    s = _mm_hadd_ps(s, s);
+    /* horizontal add the components of d2 (last one is zero)*/
+    s = _mm_hsum_ps(r12_2);
     /* sqrt our final answer */
     s = _mm_sqrt_ps(s);
 

--- a/MDTraj/geometry/tests/test_dssp.py
+++ b/MDTraj/geometry/tests/test_dssp.py
@@ -5,7 +5,6 @@ import itertools
 import tempfile
 import subprocess
 from distutils.spawn import find_executable
-from mdtraj.geometry._geometry import _processor_supports_sse41
 
 
 import numpy as np
@@ -13,10 +12,8 @@ import mdtraj as md
 from mdtraj.testing import get_fn, eq, DocStringFormatTester, skipif
 
 HAVE_DSSP = find_executable('mkdssp')
-SUPPORT_SSE41 = _processor_supports_sse41()
 DSSP_MSG =  "This tests required mkdssp to be installed, from http://swift.cmbi.ru.nl/gv/dssp/"
 tmpdir = None
-SSE41_MSG = "This CPU does not support the required instructions"
 
 
 def setup():
@@ -56,7 +53,6 @@ def assert_(a, b):
 
 
 @skipif(not HAVE_DSSP, DSSP_MSG)
-@skipif(not SUPPORT_SSE41, SSE41_MSG)
 def test_1():
     for fn in ['1bpi.pdb', '1vii.pdb', '4K6Q.pdb', '1am7_protein.pdb']:
         t = md.load_pdb(get_fn(fn))
@@ -67,7 +63,6 @@ def test_1():
 
 
 @skipif(not HAVE_DSSP, DSSP_MSG)
-@skipif(not SUPPORT_SSE41, SSE41_MSG)
 def test_2():
     t = md.load(get_fn('2EQQ.pdb'))
     for i in range(len(t)):
@@ -75,7 +70,6 @@ def test_2():
 
 
 @skipif(not HAVE_DSSP, DSSP_MSG)
-@skipif(not SUPPORT_SSE41, SSE41_MSG)
 def test_3():
     # 1COY gives a small error, due to a broken chain.
     pdbids = ['1GAI', '6gsv', '2AAC']
@@ -86,7 +80,6 @@ def test_3():
         f.description = 'test_1: %s' % pdbid
         yield f
 
-@skipif(not SUPPORT_SSE41, SSE41_MSG)
 def test_4():
     t = md.load_pdb(get_fn('1am7_protein.pdb'))
     a = md.compute_dssp(t, simplified=True)

--- a/MDTraj/geometry/tests/test_hbonds.py
+++ b/MDTraj/geometry/tests/test_hbonds.py
@@ -28,7 +28,6 @@ import subprocess
 from distutils.spawn import find_executable
 
 import mdtraj as md
-from mdtraj.geometry._geometry import _processor_supports_sse41
 from mdtraj.testing import get_fn, eq, DocStringFormatTester, skipif
 
 import numpy as np
@@ -49,7 +48,6 @@ def setup():
 def teardown():
     shutil.rmtree(tmpdir)
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_hbonds():
     t = md.load(get_fn('2EQQ.pdb'))
     ours = md.geometry.hbond.kabsch_sander(t)
@@ -91,7 +89,7 @@ def test_hbonds_against_dssp():
 
 def test_baker_hubbard_0():
      t = md.load(get_fn('2EQQ.pdb'))
-     
+
      # print('to view the hbonds defined in 2EQQ by baker_hubbard()')
      # print('put these commands into pymol on top of the pdb:\n')
      # for e in md.geometry.hbond.baker_hubbard(t):

--- a/MDTraj/geometry/tests/test_sasa.py
+++ b/MDTraj/geometry/tests/test_sasa.py
@@ -28,7 +28,6 @@
 import numpy as np
 from numpy.testing import *
 
-from mdtraj.geometry._geometry import _processor_supports_sse41
 import mdtraj as md
 from mdtraj import element
 from mdtraj.testing import get_fn, skipif, eq
@@ -54,7 +53,6 @@ topology2.add_atom('H', element.hydrogen, _res2)
 # Tests
 ##############################################################################
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_sasa_0():
     # make one atom at the origin
     traj = md.Trajectory(xyz=np.zeros((1,1,3)), topology=topology1)
@@ -66,7 +64,6 @@ def test_sasa_0():
     assert_approx_equal(calc_area, true_area)
 
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_sasa_1():
     # two atoms
     traj = md.Trajectory(xyz=np.zeros((1,2,3)), topology=topology2)
@@ -92,7 +89,6 @@ def test_sasa_1():
     assert_array_less(areas[0:8], areas[1:9])
 
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_sasa_2():
     t = md.load(get_fn('frame0.h5'))
     val1 = np.sum(md.geometry.shrake_rupley(t[0])) # calculate only frame 0
@@ -103,7 +99,6 @@ def test_sasa_2():
     assert_approx_equal(true_frame_0_sasa, val2)
 
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_sasa_3():
     traj_ref = np.loadtxt(get_fn('g_sas_ref.dat'))
     traj = md.load(get_fn('frame0.h5'))
@@ -114,7 +109,6 @@ def test_sasa_3():
     assert_array_almost_equal(traj_sasa, traj_ref, decimal=2)
 
 
-@skipif(not _processor_supports_sse41(), "This CPU does not support the required instructions")
 def test_sasa_4():
     def _test_atom_group(t, value):
         sasa = md.shrake_rupley(t, mode='atom')

--- a/MDTraj/tests/test_capi.py
+++ b/MDTraj/tests/test_capi.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import mdtraj
 
 
@@ -6,4 +7,7 @@ def test_1():
     capi = mdtraj.capi()
     assert os.path.isdir(capi['lib_dir'])
     assert os.path.isdir(capi['include_dir'])
-    assert os.path.isfile(os.path.join(capi['lib_dir'], 'libtheobald.a'))
+    if sys.platform == 'win32':
+        assert os.path.isfile(os.path.join(capi['lib_dir'], 'libtheobald.lib'))
+    else:
+        assert os.path.isfile(os.path.join(capi['lib_dir'], 'libtheobald.a'))

--- a/devtools/c-tests/Makefile
+++ b/devtools/c-tests/Makefile
@@ -1,17 +1,17 @@
 all: valgrind clang-run
 
 test-geom-gcc: test_geometry.c
-	gcc -g -O0 test_geometry.c ../../MDTraj/geometry/src/geometry.c ../../MDTraj/geometry/src/sasa.c -I../../MDTraj/geometry/include -I../../MDTraj/geometry/src/kernels -mssse3 -msse4 -lm -o test-geom-gcc
+	gcc -g -O0 test_geometry.c ../../MDTraj/geometry/src/geometry.c ../../MDTraj/geometry/src/sasa.c -I../../MDTraj/geometry/include -I../../MDTraj/geometry/src/kernels -mssse3 -lm -o test-geom-gcc
 
 test-rmsd-gcc: test_rmsd.c
-	gcc -g -O0 test_rmsd.c ../../MDTraj/rmsd/src/theobald_rmsd.c  -I../../MDTraj/rmsd/include/ -lm -mssse3 -msse4 -lm -o test-rmsd-gcc
+	gcc -g -O0 test_rmsd.c ../../MDTraj/rmsd/src/theobald_rmsd.c  -I../../MDTraj/rmsd/include/ -lm -mssse3 -lm -o test-rmsd-gcc
 
 valgrind: test-geom-gcc test-rmsd-gcc
 	valgrind ./test-geom-gcc --error-exitcode=1
 	valgrind ./test-rmsd-gcc --error-exitcode=1
 
 test-clang: test_geometry.c
-	clang -g -O0 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls test_geometry.c ../../MDTraj/geometry/src/geometry.c ../../MDTraj/geometry/src/sasa.c -I../../MDTraj/geometry/include -mssse3 -msse4 -lm -o test-clang
+	clang -g -O0 -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls test_geometry.c ../../MDTraj/geometry/src/geometry.c ../../MDTraj/geometry/src/sasa.c -I../../MDTraj/geometry/include -mssse3 -lm -o test-clang
 
 clang-run: test-clang
 	./test-clang

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -16,11 +16,10 @@ Supported Hardware
 ------------------
 Some components of MDTraj are written in C / C++ and make use of `SSE
 intrinsics <http://en.wikipedia.org/wiki/Streaming_SIMD_Extensions>`_ for
-maximum performance. The SSE4.1 instruction set (the latest we use) was released
-in 2007, so most recent x86 machines should have no problem with this
+maximum performance. The SSE3 instruction set (the latest we use) was released
+in early 2004, so most recent x86 machines should have no problem with this
 requirement. Utilization of these features also requires using a suitably modern
-compiler. This is only really a question on Linux, where gcc >= 4.3 is a
-prerequisite.
+compiler.
 
 
 Install with Conda
@@ -43,7 +42,7 @@ Install with Pip
 On a Mac or Linux machine, just run ::
 
   $ pip install mdtraj
-  
+
 Or, if you want the bleeding-edge source code, use ::
 
   $ pip install git+git://github.com/rmcgibbo/mdtraj.git
@@ -98,11 +97,11 @@ Optional packages:
 Avoid Hassles with Anaconda or Canopy
 -------------------------------------
 
-The easiest way to get all of the dependencies is to install one of the 
-pre-packaged scientific python distributes like `Enthought's Canopy 
-<https://www.enthought.com/products/canopy/>`_ or `Continuum's Anaconda 
-<https://store.continuum.io/>`_. These distributions already contain all of 
-the dependences, and are distributed via 1-click installers for Windows, Mac 
+The easiest way to get all of the dependencies is to install one of the
+pre-packaged scientific python distributes like `Enthought's Canopy
+<https://www.enthought.com/products/canopy/>`_ or `Continuum's Anaconda
+<https://store.continuum.io/>`_. These distributions already contain all of
+the dependences, and are distributed via 1-click installers for Windows, Mac
 and Linux.
 
 .. note:: I (RTM) personally recommend Continuum's Anaconda. It's free, includes the **AWESOME** conda package manager, and quite simple to use.
@@ -194,7 +193,7 @@ suite uses `nose <https://nose.readthedocs.org/en/latest/>`_, which you can pick
 up via ``pip`` if you don't already have it. ::
 
   pip install nose
-  
+
 Then, to run the tests, open a python shell and do ::
 
   >>> import mdtraj

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -12,6 +12,7 @@ v1.3 (development)
    ``density``) (Kyle A. Beauchamp)
 - Fix for PDB parser to handle more than 100K atoms. (Peter Eastman + ChayaSt)
 - Include nitrogen atoms as h-bond acceptors in hydrogen bond detection (Gert Kiss)
+- SSE4.1 support not required. The latest CPU feature now required is SSE3. (Robert T. McGibbon)
 
 
 v1.2 (December 1, 2014)

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,10 @@ def rmsd_extensions():
 
 
 def geometry_extensions():
-    compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 + compiler.compiler_args_sse41 +
+    compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
+                     compiler.compiler_args_opt)
+    define_macros = None
+    compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
                      compiler.compiler_args_opt + compiler.compiler_args_sse41)
     define_macros = compiler.define_macros_sse41
 

--- a/setup.py
+++ b/setup.py
@@ -192,9 +192,6 @@ def geometry_extensions():
     compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
                      compiler.compiler_args_opt)
     define_macros = None
-    compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
-                     compiler.compiler_args_opt + compiler.compiler_args_sse41)
-    define_macros = compiler.define_macros_sse41
 
     return [
         Extension('mdtraj.geometry._geometry',


### PR DESCRIPTION
Remove SSE4.1 requirement. We were only using two SSE4 functions, the dot product `_mm_dp_ps` and the rounding. Easy enough to reimplement them in SSE3 using material from around the web 
- http://dss.stephanierct.com/DevBlog/?p=8
- http://sseplus.sourceforge.net/group__emulated___s_s_e3.html

This should simplify the windows issues, as well as the issues with deploying on old compilers (gcc 4.1).