### PR TITLE
Allow numbers in literals, but not in 1st character

### DIFF
--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -28,8 +28,8 @@ from copy import deepcopy
 from collections import namedtuple
 from mdtraj.utils.six import PY2
 from mdtraj.utils.external.pyparsing import (Word, ParserElement, MatchFirst,
-    Keyword, opAssoc, quotedString, alphas, infixNotation, Group, Optional,
-    ParseException)
+    Keyword, opAssoc, quotedString, alphas, alphanums, infixNotation, Group,
+    Optional, ParseException)
 from mdtraj.utils.external.astor import codegen
 ParserElement.enablePackrat()
 
@@ -279,7 +279,7 @@ class parse_selection(object):
         # but we exclude any of the logical operands (e.g. 'or') from being
         # parsed literals
         literal = ~(keywords(BinaryInfixOperand) | keywords(UnaryInfixOperand)) + \
-                  (Word(NUMS) | quotedString | Word(alphas))
+                  (Word(NUMS) | quotedString | Word(alphas, alphanums))
         literal.setParseAction(Literal)
 
         # these are the other 'root' expressions, the selection keywords (resname, resid, mass, etc)

--- a/mdtraj/tests/test_selection.py
+++ b/mdtraj/tests/test_selection.py
@@ -275,3 +275,13 @@ def test_sidechain():
 
     eq(np.asarray(sidechain), np.asarray(ref_sidechain))
     eq(np.asarray(is_sidechain), np.asarray(ref_sidechain))
+
+def test_literal():
+    name_og1_0 = gbp.topology.select('name "OG1"')
+    name_og1_1 = gbp.topology.select("name 'OG1'")
+    name_og1_2 = gbp.topology.select("name OG1")
+
+    ref_og1 = np.asarray([a.index for a in gbp.topology.atoms if a.name == 'OG1'])
+    eq(name_og1_0, ref_og1)
+    eq(name_og1_2, ref_og1)
+    eq(name_og1_0, ref_og1)


### PR DESCRIPTION
For #706. Using the following section from the pyparsing docs.

> Word - one or more contiguous characters; construct with a string containing the set of allowed initial characters, and an optional second string of allowed body characters; for instance, a common Word construct is to match a code identifier - in C, a valid identifier must start with an alphabetic character or an underscore ('_'), followed by a body that can also include numeric digits. That is, a, i, MAX_LENGTH, _a1, b_109_, and plan9FromOuterSpace are all valid identifiers; 9b7z, $a, .section, and 0debug are not. To define an identifier using a Word, use either of the following:
- Word( alphas+"_", alphanums+"_" )
- Word( srange("[a-zA-Z_]"), srange("[a-zA-Z0-9_]") )