### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 graft examples
-graft MDTraj
+graft mdtraj
 include basesetup.py


### PR DESCRIPTION
I think this should be changed with the folder being renamed. Not sure if it actually has an effect but it fixes this warning during `setup.py`:

```
reading manifest template 'MANIFEST.in'
warning: no directories found matching 'MDTraj'
```