### PR TITLE
[TRAVIS] Travis not running on merge commits?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: c
 
-branches:
-  only:
-    - master
-
 install:
   - source devtools/travis-ci/install.sh
   - export PYTHONUNBUFFERED=true


### PR DESCRIPTION
If you look at https://travis-ci.org/mdtraj/mdtraj/builds, travis hasn't run on a merge commit in the last 19 days. I don't know why. It's been running on PRs, but not on the master branch after the merge commit. This is important for updating the docs.