### PR TITLE
Switch sse_swizzle to the MIT license after email with Imran

### DIFF
--- a/mdtraj/rmsd/include/sse_swizzle.h
+++ b/mdtraj/rmsd/include/sse_swizzle.h
@@ -3,11 +3,26 @@
  *                using SSE2 PSHUFD instruction
  * modified to add sse shuffle instructions too
  *
+ * MIT License
  * Copyright 2011 Imran Haque (ihaque@cs.stanford.edu)
  * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * This code is released into the public domain and bears no
- * warranty whatsoever.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * This file defines SSE intrinsic-style functions for doing vector swizzling
  * according to the usual notation. For example, swizzles that in GLSL might


### PR DESCRIPTION
In order to use this software at Google, we need an OSI license and not public domain so I asked Imran if we could switch the license.

Forwarded conversation
Subject: License for sse_swizzle.h
------------------------

From: Patrick Riley <pfr@google.com>
Date: Thu, Feb 26, 2015 at 1:07 PM
To: Imran Haque <ihaque@cs.stanford.edu>

Imran,

I've been working with Bharath Ramsundar and Steven Kearnes as part of a Stanford-Google collaboration.

I'd like to use mdtraj at Google. mdtraj includes 
sse_swizzle.h
https://github.com/mdtraj/mdtraj/blob/master/mdtraj/rmsd/include/sse_swizzle.h
which you have tried to put into the public domain. 

Google is very careful with its open source licenses and we'd like to have an explicit OSI approved license for this code in order to use it (due to legal things I don't understand, it can be difficult to put things into the public domain even when you want to).

Are you willing to let us use this code under an OSI license, perhaps MIT
http://opensource.org/licenses/mit-license.php
or BSD
http://opensource.org/licenses/bsd-license.php

Thank you very much.

--
Patrick Riley
pfr@google.com

----------
From: Imran Haque <ihaque@alumni.stanford.edu>
Date: Thu, Feb 26, 2015 at 1:33 PM
To: Patrick Riley <pfr@google.com>

Either MIT or BSD would be fine with me, whatever's more convenient for the rest of the project. WTFPL is also an option :)

Imran