### PR TITLE
Overwrite not being passed to HDF5 and .lammpstrj and some small stuff (doc strings, pep8)

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -641,7 +641,7 @@ class Topology(object):
 
     @property
     def n_residues(self):
-        "Get the number of residues in the Topology"
+        """Get the number of residues in the Topology. """
         return len(self._residues)
 
     def atom(self, index):

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -641,7 +641,7 @@ class Topology(object):
 
     @property
     def n_residues(self):
-        """Get the number of residues in the Topology"""
+        "Get the number of residues in the Topology"
         return len(self._residues)
 
     def atom(self, index):
@@ -934,7 +934,7 @@ class Chain(object):
         return iter(self._residues)
 
     def residue(self, index):
-        """Get a specific residue in this Chain
+        """Get a specific residue in this Chain.
 
         Returns
         -------
@@ -944,7 +944,7 @@ class Chain(object):
 
     @property
     def n_residues(self):
-        "Get the number of residues in this Chain"
+        """Get the number of residues in this Chain. """
         return len(self._residues)
 
     @property
@@ -961,7 +961,7 @@ class Chain(object):
                 yield atom
 
     def atoms_by_name(self, name):
-        """Iterator over all Atoms in the Chain with a specified name
+        """Iterator over all Atoms in the Chain with a specified name.
 
         Example
         -------
@@ -977,7 +977,7 @@ class Chain(object):
                 yield atom
 
     def atom(self, index):
-        """Get a specific atom in this Chain
+        """Get a specific atom in this Chain.
 
         Returns
         -------
@@ -1162,7 +1162,7 @@ class Atom(object):
         return True
 
     def __hash__(self):
-        """ A quick comparison. """
+        """A quick comparison. """
         return self.index
 
     def __str__(self):

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1215,7 +1215,7 @@ class Trajectory(object):
         force_overwrite : bool, default=True
             Overwrite anything that exists at filename, if its already there
         """
-        with HDF5TrajectoryFile(filename, 'w', force_overwrite=True) as f:
+        with HDF5TrajectoryFile(filename, 'w', force_overwrite=force_overwrite) as f:
             f.write(coordinates=self.xyz, time=self.time,
                     cell_angles=self.unitcell_angles,
                     cell_lengths=self.unitcell_lengths)
@@ -1231,7 +1231,7 @@ class Trajectory(object):
         force_overwrite : bool, default=True
             Overwrite anything that exists at filename, if its already there
         """
-        with LAMMPSTrajectoryFile(filename, 'w', force_overwrite=True) as f:
+        with LAMMPSTrajectoryFile(filename, 'w', force_overwrite=force_overwrite) as f:
             f.write(xyz=self.xyz,
                     cell_angles=self.unitcell_angles,
                     cell_lengths=self.unitcell_lengths)

--- a/mdtraj/formats/lammpstrj.py
+++ b/mdtraj/formats/lammpstrj.py
@@ -147,8 +147,7 @@ class LAMMPSTrajectoryFile(object):
     distance_unit = 'angstroms'
 
     def __init__(self, filename, mode='r', force_overwrite=True):
-        """Open a LAMMPS lammpstrj file for reading/writing.
-        """
+        """Open a LAMMPS lammpstrj file for reading/writing. """
         self._is_open = False
         self._filename = filename
         self._mode = mode
@@ -189,7 +188,7 @@ class LAMMPSTrajectoryFile(object):
         self.close()
 
     def read(self, n_frames=None, stride=None, atom_indices=None):
-        """Read data from a lammpstrj file
+        """Read data from a lammpstrj file.
 
         Parameters
         ----------
@@ -223,7 +222,7 @@ class LAMMPSTrajectoryFile(object):
             stride = 1
 
         all_coords, all_lengths, all_angles = [], [], []
-        for i in frame_counter:
+        for _ in frame_counter:
             try:
                 frame_coords, frame_lengths, frame_angles = self._read()
                 if atom_indices is not None:
@@ -333,7 +332,7 @@ class LAMMPSTrajectoryFile(object):
         # --- end header ---
 
         xyz = np.empty(shape=(self._n_atoms, 3))
-        types = np.empty(shape=(self._n_atoms), dtype='int')
+        types = np.empty(shape=self._n_atoms, dtype='int')
 
         # --- begin body ---
         for _ in xrange(self._n_atoms):
@@ -404,7 +403,7 @@ class LAMMPSTrajectoryFile(object):
             self._fh.write('{0} {1} {2}\n'.format(zlo_bound, zhi_bound, yz))
 
     def write(self, xyz, cell_lengths, cell_angles=None, types=None, unit_set='real'):
-        """Write one or more frames of data to a lammpstrj file
+        """Write one or more frames of data to a lammpstrj file.
 
         Parameters
         ----------
@@ -470,7 +469,7 @@ class LAMMPSTrajectoryFile(object):
             # --- end body ---
 
     def seek(self, offset, whence=0):
-        """Move to a new file position
+        """Move to a new file position.
 
         Parameters
         ----------
@@ -515,7 +514,7 @@ class LAMMPSTrajectoryFile(object):
             raise NotImplementedError('offsets in write mode are not supported yet')
 
     def tell(self):
-        """Current file position
+        """Current file position.
 
         Returns
         -------

--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -173,6 +173,8 @@ def _parse_mol2_sections(x):
     return _parse_mol2_sections.key
 
 
+
+
 gaff_elements = {
     'br': 'Br',
     'c': 'C',

--- a/mdtraj/tests/test_lammpstrj.py
+++ b/mdtraj/tests/test_lammpstrj.py
@@ -22,18 +22,18 @@
 
 
 import tempfile, os
+
 import numpy as np
-from mdtraj.utils import (lengths_and_angles_to_box_vectors,
-                          box_vectors_to_lengths_and_angles)
+
 import mdtraj as md
 from mdtraj.formats import LAMMPSTrajectoryFile, lammpstrj
-from mdtraj.testing import get_fn, eq, DocStringFormatTester, raises
+from mdtraj.testing import get_fn, eq, DocStringFormatTester
 TestDocstrings = DocStringFormatTester(lammpstrj, error_on_none=True)
 
 fd, temp = tempfile.mkstemp(suffix='.lammpstrj')
 def teardown_module(module):
-    """remove the temporary file created by tests in this file
-    this gets automatically called by nose"""
+    """Remove the temporary file created by tests in this file
+    this gets automatically called by nose. """
     os.close(fd)
     os.unlink(temp)
 


### PR DESCRIPTION
Quick question: there are several docstrings with single quotes lying around with single quotes, e.g.:
https://github.com/mdtraj/mdtraj/blob/master/mdtraj/core/topology.py#L947

Is that intentional or just go ahead and fix it if I find em?