### PR TITLE
Add compilation fixes for extension modules

### DIFF
--- a/mdtraj/formats/dcd/include/dcdplugin.h
+++ b/mdtraj/formats/dcd/include/dcdplugin.h
@@ -71,6 +71,7 @@ dcdhandle* open_dcd_write(const char *path, const char *filetype, const int nato
                           const int with_unitcell);
 int write_timestep(dcdhandle *v, const molfile_timestep_t *ts);
 void close_file_write(dcdhandle *v);
+int dcd_nsets(dcdhandle* v);
 int dcd_rewind(dcdhandle* dcd);
   
 #endif

--- a/mdtraj/formats/xtc/include/xdrfile_xtc.h
+++ b/mdtraj/formats/xtc/include/xdrfile_xtc.h
@@ -43,6 +43,8 @@ extern "C" {
   /* This function returns the number of atoms in the xtc file in *natoms */
   extern int read_xtc_natoms(char *fn,int *natoms);
   
+  int read_xtc_nframes(char* fn, unsigned long *nframes);
+
   /* Read one frame of an open xtc file */
   extern int read_xtc(XDRFILE *xd,int natoms,int *step,float *time,
 		      matrix box,rvec *x,float *prec);

--- a/mdtraj/geometry/include/dridkernels.h
+++ b/mdtraj/geometry/include/dridkernels.h
@@ -1,6 +1,14 @@
 #ifndef _MDTRAJ_DRIDKERNELS_H_
 #define _MDTRAJ_DRIDKERNELS_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int drid_moments(float* coords, int index, int* partners, int n_partners, double* moments);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
* dcdplugin.h and xdrfile_xtc.h: include missing function declarations
* dridkernels.h: include #ifdef'd controlled extern "C" so a C++ compilier can
  read the header and successfully link.