### PR TITLE
test_rmsd_memmap: use tempfile to make directory for tmp files rather th...

### DIFF
--- a/mdtraj/tests/test_rmsd_memmap.py
+++ b/mdtraj/tests/test_rmsd_memmap.py
@@ -1,5 +1,7 @@
 import os
+import os.path
 import numpy as np
+import tempfile
 import mdtraj as md
 from mdtraj.testing import get_fn, assert_raises
 
@@ -7,10 +9,12 @@ from mdtraj.testing import get_fn, assert_raises
 def test_1():
     # https://github.com/rmcgibbo/mdtraj/issues/438
     try:
+        dir = tempfile.mkdtemp()
+        fn = os.path.join(dir, 'temp.npy')
         traj = md.load(get_fn('frame0.h5'))
-        np.save('temp.npy', traj.xyz)
+        np.save(fn, traj.xyz)
 
-        traj.xyz = np.load('temp.npy', mmap_mode='r')
+        traj.xyz = np.load(fn, mmap_mode='r')
 
         # since traj isn't precentered, this requires centering
         # the coordinates which is done inplace. but that's not possible
@@ -18,23 +22,26 @@ def test_1():
         assert_raises(ValueError, md.rmsd, traj, traj, 0)
 
         # this should work
-        traj.xyz = np.load('temp.npy', mmap_mode='c')
+        traj.xyz = np.load(fn, mmap_mode='c')
         md.rmsd(traj, traj, 0)
 
     finally:
         del traj
-        os.unlink('temp.npy')
+        os.unlink(fn)
+        os.rmdir(dir)
 
 
 def test_2():
     # https://github.com/rmcgibbo/mdtraj/issues/438
     try:
+        dir = tempfile.mkdtemp()
+        fn = os.path.join(dir, 'temp.npy')
         traj = md.load(get_fn('frame0.h5'))
         # precenter the coordinates
         traj.center_coordinates()
         traces = traj._rmsd_traces
-        np.save('temp.npy', traj.xyz)
-        traj.xyz = np.load('temp.npy', mmap_mode='r')
+        np.save(fn, traj.xyz)
+        traj.xyz = np.load(fn, mmap_mode='r')
         traj._rmsd_traces = traces
 
         # this should work, since we don't need to modify the
@@ -43,4 +50,5 @@ def test_2():
 
     finally:
         del traj
-        os.unlink('temp.npy')
+        os.unlink(fn)
+        os.rmdir(dir)


### PR DESCRIPTION
test_rmsd_memmap: use tempfile to make directory for tmp files rather than assuming current working directory is writable.
