### PR TITLE
[iterload] added skip keyword to skip first n frames.

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -431,6 +431,8 @@ def iterload(filename, chunk=100, **kwargs):
         If not none, then read only a subset of the atoms coordinates from the
         file. This may be slightly slower than the standard read because it
         requires an extra copy, but will save memory.
+    skip : int, default=0
+        Skip first n frames.
 
     See Also
     --------
@@ -450,6 +452,8 @@ def iterload(filename, chunk=100, **kwargs):
     stride = kwargs.pop('stride', 1)
     atom_indices = cast_indices(kwargs.pop('atom_indices', None))
     top = kwargs.pop('top', None)
+    skip = kwargs.pop('skip', 0)
+
     extension = _get_extension(filename)
     if extension not in _TOPOLOGY_EXTS:
         topology = _parse_topology(top)
@@ -460,29 +464,40 @@ def iterload(filename, chunk=100, **kwargs):
     if chunk == 0:
         # If chunk was 0 then we want to avoid filetype-specific code
         # in case of undefined behavior in various file parsers.
-        yield load(filename, **kwargs)
-
+        # TODO: this will first apply stride, then skip!
+        if extension not in _TOPOLOGY_EXTS:
+            kwargs['top'] = top
+        yield load(filename, **kwargs)[skip:]
     elif extension in ('.pdb', '.pdb.gz'):
         # the PDBTrajectortFile class doesn't follow the standard API. Fixing it
         # to support iterload could be worthwhile, but requires a deep refactor.
         t = load(filename, stride=stride, atom_indices=atom_indices)
         for i in range(0, len(t), chunk):
-            yield  t[i:i+chunk]
+            yield t[i:i+chunk]
 
     else:
         with (lambda x: open(x, n_atoms=topology.n_atoms)
               if extension in ('.crd', '.mdcrd')
               else open(filename))(filename) as f:
+            skipped = 0
             while True:
                 if extension not in _TOPOLOGY_EXTS:
                     traj = f.read_as_traj(topology, n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
                 else:
                     traj = f.read_as_traj(n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
 
-                if len(traj) == 0:
+                orig_len = len(traj)
+                if orig_len == 0:
                     raise StopIteration()
 
-                yield traj
+                if skip > 0 and skipped < skip:
+                    to_skip = abs(skipped - skip)
+                    # this might yield zero frames!
+                    traj = traj[to_skip:]
+                    skipped += orig_len - len(traj)
+
+                if skipped == skip and len(traj) > 0:
+                    yield traj
 
 
 class Trajectory(object):

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -479,25 +479,18 @@ def iterload(filename, chunk=100, **kwargs):
         with (lambda x: open(x, n_atoms=topology.n_atoms)
               if extension in ('.crd', '.mdcrd')
               else open(filename))(filename) as f:
-            skipped = 0
+            if skip > 0:
+                f.seek(skip)
             while True:
                 if extension not in _TOPOLOGY_EXTS:
                     traj = f.read_as_traj(topology, n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
                 else:
                     traj = f.read_as_traj(n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
 
-                orig_len = len(traj)
-                if orig_len == 0:
+                if len(traj) == 0:
                     raise StopIteration()
 
-                if skip > 0 and skipped < skip:
-                    to_skip = abs(skipped - skip)
-                    # this might yield zero frames!
-                    traj = traj[to_skip:]
-                    skipped += orig_len - len(traj)
-
-                if skipped == skip and len(traj) > 0:
-                    yield traj
+                yield traj
 
 
 class Trajectory(object):

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -502,6 +502,26 @@ def test_iterload():
             yield test
 
 
+def test_iterload_skip():
+    files = ['frame0.nc', 'frame0.h5', 'frame0.xtc', 'frame0.trr',
+             'frame0.dcd', 'frame0.binpos', 'legacy_msmbuilder_trj0.lh5',
+             'frame0.xyz', 'frame0.lammpstrj']
+
+    err_msg = "failed for file %s with chunksize %i and skip %i"
+
+    for file in files:
+        for cs in [0, 1, 11, 100]:
+            for skip in [0, 1, 20, 101]:
+                print("testing file %s with skip=%i" % (file, skip))
+                t_ref = md.load(get_fn(file), top=get_fn('native.pdb'))
+                t = functools.reduce(lambda a, b: a.join(b),
+                                     md.iterload(get_fn(file), skip=skip,
+                                                 top=get_fn('native.pdb'), chunk=cs))
+                eq(t_ref.xyz[skip:], t.xyz, err_msg=err_msg % (file, cs, skip))
+                eq(t_ref.time[skip:], t.time, err_msg=err_msg % (file, cs, skip))
+                eq(t_ref.topology, t.topology, err_msg=err_msg % (file, cs, skip))
+
+
 def test_save_load():
     # this cycles all the known formats you can save to, and then tries
     # to reload, using just a single-frame file.


### PR DESCRIPTION
added a skip keyword to generate time lagged iterators. Currently the NetCDF loader complains about this new keyword, but I dont know how to fix this properly.