### PR TITLE
Fix compute_rdf r_range argument

### DIFF
--- a/mdtraj/geometry/rdf.py
+++ b/mdtraj/geometry/rdf.py
@@ -63,7 +63,7 @@ def compute_rdf(traj, pairs=None, r_range=None, bin_width=0.005,
     Topology.select_pairs
 
     """
-    if not r_range:
+    if r_range is None:
         r_range = np.array([0.0, 1.0])
     r_range = ensure_type(r_range, dtype=np.float64, ndim=1, name='r_range',
                           shape=(2,), warn_on_cast=False)


### PR DESCRIPTION
Current code complains when a numpy array is passed instead of a list because the truth value is ambiguous.