### PR TITLE
fix IPython 3.0 compatibility issues

### DIFF
--- a/mdtraj/html/install.py
+++ b/mdtraj/html/install.py
@@ -50,9 +50,10 @@ def enable_notebook():
     """
     libs = ['iview.js','surface.min.js','objexporter.js','filesaver.js','context.js']
     fns = [resource_filename('mdtraj', os.path.join('html', 'static', f)) for f in libs]
-    install_nbextension(fns, verbose=0)
+    for fn in fns:
+        install_nbextension(fn, verbose=0, user=True)
     display(_REQUIRE_CONFIG)
-    
+
     widgets = ['widget_trajectory.js', 'widget_imagebutton.js']
     for fn in widgets:
         fn = resource_filename('mdtraj', os.path.join('html', 'static', fn))

--- a/mdtraj/html/static/widget_imagebutton.js
+++ b/mdtraj/html/static/widget_imagebutton.js
@@ -1,5 +1,5 @@
-require(["widgets/js/widget"], function(WidgetManager){
-    var ImageButtonView = IPython.DOMWidgetView.extend({
+require(["widgets/js/widget", "widgets/js/manager"], function(widget, manager){
+    var ImageButtonView = widget.DOMWidgetView.extend({
         render : function(){
             // Called when view is rendered.
             this.setElement($("<img />"));
@@ -52,5 +52,5 @@ require(["widgets/js/widget"], function(WidgetManager){
     });
 
     // Register the DatePickerView with the widget manager.
-    WidgetManager.register_widget_view('ImageButtonView', ImageButtonView);
+    manager.WidgetManager.register_widget_view('ImageButtonView', ImageButtonView);
 });

--- a/mdtraj/html/static/widget_trajectory.js
+++ b/mdtraj/html/static/widget_trajectory.js
@@ -8,6 +8,7 @@ propagate here and modify `this.model.attributes`, and re-call `update`.
 require([
     "jquery",
     "widgets/js/widget",
+    "widgets/js/manager",
     "iview",
     "exporter",
     "filesaver",
@@ -16,13 +17,13 @@ require([
     'jqueryui',
     ],
 
-function($, WidgetManager, iview) {
+function($, widget, manager, iview) {
     var HEIGHT = 300,
         WIDTH = 300,
         HEIGHT_PX = '300px',
         WIDTH_PX = '300px';
 
-    var TrajectoryView = IPython.DOMWidgetView.extend({
+    var TrajectoryView = widget.DOMWidgetView.extend({
         render : function() {
             var canvas = $("<canvas/>").height(HEIGHT).width(WIDTH);
             var iv = new iview(canvas);
@@ -159,5 +160,5 @@ function($, WidgetManager, iview) {
     });
 
 
-    WidgetManager.register_widget_view('TrajectoryView', TrajectoryView);
+    manager.WidgetManager.register_widget_view('TrajectoryView', TrajectoryView);
 });


### PR DESCRIPTION
Hi, 
the new version of IPython 3.0 introduced [some changes] (https://github.com/ipython/ipython/wiki/IPython-3.0-comm-and-widget-migration-document) into the widget interface, so that TrajectoryView notebook widget stopped working. This commit seems to fix all of the issues and restores TrajectoryView functionality in the notebook.

Anton.