### PR TITLE
Make vmd-readable .gro

### DIFF
--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -352,7 +352,7 @@ class GroTrajectoryFile(object):
             comment += ', t= %s' % time
 
         assert topology.n_atoms == coordinates.shape[0]
-        lines = [comment, '  %d' % topology.n_atoms]
+        lines = [comment, ' %d' % topology.n_atoms]
         if box is None:
             box = np.zeros((3,3))
 


### PR DESCRIPTION
VMD Doesn't like two spaces before the number of atoms.
It fails with `gromacsplugin) Warning, error reading box, unexpected
end-of-file reached`.