### PR TITLE
Add .ncdf as a recognized suffix for the NetCDF loader

### DIFF
--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -52,6 +52,7 @@ __all__ = ['NetCDFTrajectoryFile', 'load_netcdf']
 
 @_FormatRegistry.register_loader('.nc')
 @_FormatRegistry.register_loader('.netcdf')
+@_FormatRegistry.register_loader('.ncdf')
 def load_netcdf(filename, top=None, stride=None, atom_indices=None, frame=None):
     """Load an AMBER NetCDF file. Since the NetCDF format doesn't contain
     information to specify the topology, you need to supply a topology
@@ -109,6 +110,7 @@ def load_netcdf(filename, top=None, stride=None, atom_indices=None, frame=None):
 
 @_FormatRegistry.register_fileobject('.nc')
 @_FormatRegistry.register_fileobject('.netcdf')
+@_FormatRegistry.register_fileobject('.ncdf')
 class NetCDFTrajectoryFile(object):
     """Interface for reading and writing to AMBER NetCDF files. This is a
     file-like object, that supports both reading or writing depending


### PR DESCRIPTION
It's supported in Trajectory.save, and it's not like another format has any
kind of claim on that suffix.

Closes #807 