### PR TITLE
ENH: Recognize .ncrst and .rst7 for trajectory save extensions

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1473,9 +1473,9 @@ class Trajectory(object):
         if self.n_frames == 1:
             with AmberNetCDFRestartFile(filename, 'w', force_overwrite=force_overwrite) as f:
                 coordinates = in_units_of(self._xyz, Trajectory._distance_unit,
-                                          NetCDFRestartFile.distance_unit)
+                                          AmberNetCDFRestartFile.distance_unit)
                 lengths = in_units_of(self.unitcell_lengths, Trajectory._distance_unit,
-                                      NetCDFRestartFile.distance_unit)
+                                      AmberNetCDFRestartFile.distance_unit)
                 f.write(coordinates=coordinates, time=self.time[0],
                         cell_lengths=lengths, cell_angles=self.unitcell_angles)
         else:
@@ -1483,11 +1483,11 @@ class Trajectory(object):
             for i in xrange(self.n_frames):
                 with AmberNetCDFRestartFile(fmt % (i+1), 'w', force_overwrite=force_overwrite) as f:
                     coordinates = in_units_of(self._xyz, Trajectory._distance_unit,
-                                              NetCDFRestartFile.distance_unit)
+                                              AmberNetCDFRestartFile.distance_unit)
                     lengths = in_units_of(self.unitcell_lengths, Trajectory._distance_unit,
-                                          NetCDFRestartFile.distance_unit)
-                    f.write(coordinates=coordinates, time=self.time[0],
-                            cell_lengths=lengths, cell_angles=self.unitcell_angles)
+                                          AmberNetCDFRestartFile.distance_unit)
+                    f.write(coordinates=coordinates[i], time=self.time[i],
+                            cell_lengths=lengths[i], cell_angles=self.unitcell_angles[i])
 
     def save_amberrst7(self, filename, force_overwrite=True):
         """Save trajectory in AMBER ASCII restart format
@@ -1510,9 +1510,9 @@ class Trajectory(object):
         if self.n_frames == 1:
             with AmberRestartFile(filename, 'w', force_overwrite=force_overwrite) as f:
                 coordinates = in_units_of(self._xyz, Trajectory._distance_unit,
-                                          NetCDFRestartFile.distance_unit)
+                                          AmberRestartFile.distance_unit)
                 lengths = in_units_of(self.unitcell_lengths, Trajectory._distance_unit,
-                                      NetCDFRestartFile.distance_unit)
+                                      AmberRestartFile.distance_unit)
                 f.write(coordinates=coordinates, time=self.time[0],
                         cell_lengths=lengths, cell_angles=self.unitcell_angles)
         else:
@@ -1520,11 +1520,11 @@ class Trajectory(object):
             for i in xrange(self.n_frames):
                 with AmberRestartFile(fmt % (i+1), 'w', force_overwrite=force_overwrite) as f:
                     coordinates = in_units_of(self._xyz, Trajectory._distance_unit,
-                                              NetCDFRestartFile.distance_unit)
+                                              AmberRestartFile.distance_unit)
                     lengths = in_units_of(self.unitcell_lengths, Trajectory._distance_unit,
-                                          NetCDFRestartFile.distance_unit)
-                    f.write(coordinates=coordinates, time=self.time[0],
-                            cell_lengths=lengths, cell_angles=self.unitcell_angles)
+                                          AmberRestartFile.distance_unit)
+                    f.write(coordinates=coordinates[i], time=self.time[0],
+                            cell_lengths=lengths[i], cell_angles=self.unitcell_angles[i])
 
     def save_lh5(self, filename):
         """Save trajectory in deprecated MSMBuilder2 LH5 (lossy HDF5) format.

--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -448,7 +448,7 @@ class AmberNetCDFRestartFile(object):
     """
     distance_unit = 'angstroms'
 
-    def __init__(self, filename, mode='r', force_overwrite=True):
+    def __init__(self, filename, mode='r', force_overwrite=False):
         self._closed = True
         self._mode = mode
         if StrictVersion(import_('scipy.version').short_version) < StrictVersion('0.12.0'):

--- a/mdtraj/tests/test_restart.py
+++ b/mdtraj/tests/test_restart.py
@@ -39,8 +39,8 @@ def teardown_module(module):
     this gets automatically called by nose"""
     os.close(fd1)
     os.close(fd2)
-    os.unlink(temp1)
-    os.unlink(temp2)
+    if os.path.exists(temp1): os.unlink(temp1)
+    if os.path.exists(temp2): os.unlink(temp2)
 
 def test_read_after_close():
     f = AmberNetCDFRestartFile(get_fn('ncinpcrd.rst7'))

--- a/mdtraj/tests/test_restart.py
+++ b/mdtraj/tests/test_restart.py
@@ -27,10 +27,10 @@ Tests for the AMBER netcdf reader/writer code
 
 from mdtraj.formats import AmberRestartFile, AmberNetCDFRestartFile
 import os, tempfile
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_true
 import numpy as np
 import mdtraj as md
-from mdtraj.testing import get_fn, eq
+from mdtraj.testing import get_fn, eq, assert_allclose
 
 fd1, temp1 = tempfile.mkstemp(suffix='.rst7')
 fd2, temp2 = tempfile.mkstemp(suffix='.ncrst')
@@ -103,3 +103,27 @@ def test_read_write_2():
         yield lambda: eq(b, time)
         yield lambda: eq(c, boxlengths)
         yield lambda: eq(d, boxangles)
+
+def test_read_write_3():
+    traj = md.load(get_fn('frame0.nc'), top=get_fn('native.pdb'))
+    traj[0].save(temp1)
+    yield lambda: assert_true(os.path.exists(temp1))
+    rsttraj = md.load(temp1, top=get_fn('native.pdb'))
+    assert_allclose(rsttraj.xyz, traj[0].xyz)
+    os.unlink(temp1)
+    traj.save(temp1)
+    for i in range(traj.n_frames):
+        yield lambda: assert_true(os.path.exists('%s.%03d' % (temp1, i+1)))
+        os.unlink('%s.%03d' % (temp1, i+1))
+
+def test_read_write_4():
+    traj = md.load(get_fn('frame0.nc'), top=get_fn('native.pdb'))
+    traj[0].save(temp2)
+    yield lambda: assert_true(os.path.exists(temp2))
+    rsttraj = md.load(temp2, top=get_fn('native.pdb'))
+    assert_allclose(rsttraj.xyz, traj[0].xyz)
+    os.unlink(temp2)
+    traj.save(temp2)
+    for i in range(traj.n_frames):
+        yield lambda: assert_true(os.path.exists('%s.%03d' % (temp2, i+1)))
+        os.unlink('%s.%03d' % (temp2, i+1))


### PR DESCRIPTION
This commit adds the ability to write Amber NetCDF and ASCII restart files
automatically based on the .ncrst and .rst7 extensions, respectively.  Since
these are single-frame formats (*only*), single-frame trajectories will write
out the requested file-name while multi-frame trajectories will write out
0-padded filenames with a .# appended (so all #'s have the same width).  e.g.,
with 10 frames, the suffixes will be .01, .02, ... .10 and with 1000 frames, the
suffixes will be .0001, .0002, ..., .1000.