### PR TITLE
typo in code example

### DIFF
--- a/docs/api/reporters.rst
+++ b/docs/api/reporters.rst
@@ -24,7 +24,7 @@ Example Usage
    simulation = Simulation(pdb.topology, system, integrator)
    simulation.context.setPositions(pdb.positions)
    simulation.minimizeEnergy()
-   simulation.reporters.append(NetCDFReporter('output.nc'), 1000)   # <-- AMBER compatible
+   simulation.reporters.append(NetCDFReporter('output.nc', 1000))   # <-- AMBER compatible
    simulation.step(10000)
 
 .. currentmodule:: mdtraj.reporters


### PR DESCRIPTION
`reportInterval` is an argument of `NetCDFReporter`