### PR TITLE
Fix Gromacs box vectors

### DIFF
--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -341,8 +341,8 @@ class GroTrajectoryFile(object):
         box = [boxvectors[i] if i < len(boxvectors) else 0 for i in range(9)]
         unitcell_vectors = np.array([
             [box[0], box[3], box[4]],
-            [box[1], box[5], box[6]],
-            [box[2], box[7], box[8]]])
+            [box[5], box[1], box[6]],
+            [box[7], box[8], box[2]]])
 
         return xyz, unitcell_vectors, time
 


### PR DESCRIPTION
This PR re-orders the unit cell vectors that are parsed from `gro.py`, because the previous version was assigning the values incorrectly.