### PR TITLE
Make virtual site a new element

### DIFF
--- a/mdtraj/core/element.py
+++ b/mdtraj/core/element.py
@@ -189,6 +189,13 @@ class Element(tuple):
         """Atomic number"""
         return tuple.__getitem__(self, 0)
 
+    # Make it so only virtual sites evaluate to boolean False (since it's really
+    # *not* an element)
+    def __bool__(self):
+        return bool(self.mass)
+
+    def __nonzero__(self):
+        return bool(self.mass)
 
 
 
@@ -207,6 +214,7 @@ def get_by_symbol(symbol):
 # The radii for Ions (Na, K, Cl, Ca, Mg, and Cs are based on the CHARMM27
 # Rmin/2 parameters for (SOD, POT, CLA, CAL, MG, CES) by default.
 
+virtual =        Element(  0,"virtual site","VS", 0.0, 0.0)
 hydrogen =       Element(  1,"hydrogen","H", 1.007947, 0.12)
 deuterium =      Element(  1,"deuterium","D", 2.0135532127, 0.12)
 helium =         Element(  2,"helium","He", 4.003, 0.14)
@@ -329,3 +337,4 @@ ununhexium =     Element(116,"ununhexium","Uuh", 292, 0.2)
 # relational operators will work with any chosen name
 sulphur = sulfur
 aluminium = aluminum
+virtual_site = virtual

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -283,7 +283,11 @@ class Topology(object):
             for residue in chain.residues:
                 r = out.addResidue(residue.name, c)
                 for atom in residue.atoms:
-                    a = out.addAtom(atom.name, app.Element.getBySymbol(atom.element.symbol), r)
+                    if atom.element is elem.virtual:
+                        element = None
+                    else:
+                        element = app.Element.getBySymbol(atom.element.symbol)
+                    a = out.addAtom(atom.name, element, r)
                     atom_mapping[atom] = a
 
         for a1, a2 in self.bonds:
@@ -324,7 +328,11 @@ class Topology(object):
             for residue in chain.residues():
                 r = out.add_residue(residue.name, c)
                 for atom in residue.atoms():
-                    a = out.add_atom(atom.name, elem.get_by_symbol(atom.element.symbol), r)
+                    if atom.element is None:
+                        element = elem.virtual
+                    else:
+                        element = elem.get_by_symbol(atom.element.symbol)
+                    a = out.add_atom(atom.name, element, r)
                     atom_mapping[atom] = a
 
         for a1, a2 in value.bonds():
@@ -344,15 +352,9 @@ class Topology(object):
             of the indices of the atoms involved in each bond.
         """
         pd = import_('pandas')
-        data = []
-        for atom in self.atoms:
-            if atom.element is None:
-                element_symbol = ""
-            else:
-                element_symbol = atom.element.symbol
-            data.append((atom.serial, atom.name, element_symbol,
-                         atom.residue.resSeq, atom.residue.name,
-                         atom.residue.chain.index))
+        data = [(atom.serial, atom.name, atom.element.symbol,
+                 atomm.residue.resSeq, atom.residue.name,
+                 atom.residue.chain.index) for atom in self.atoms]
 
         atoms = pd.DataFrame(data, columns=["serial", "name", "element",
                                             "resSeq", "resName", "chainID"])
@@ -418,12 +420,8 @@ class Topology(object):
 
                 for atom_index, atom in residue_atoms.iterrows():
                     atom_index = int(atom_index)  # Fixes bizarre hashing issue on Py3K.  See #545
-                    serial = atom["serial"]
-                    if atom['element'] == "":
-                        element = None
-                    else:
-                        element = elem.get_by_symbol(atom['element'])
-                    a = Atom(atom['name'], element, atom_index, r, serial=serial)
+                    a = Atom(atom['name'], elem.get_by_symbol(atom['element']),
+                             r, serial=atom['serial'])
                     out._atoms[atom_index] = a
                     r._atoms.append(a)
 
@@ -493,12 +491,10 @@ class Topology(object):
                 for a1, a2 in zip(r1.atoms, r2.atoms):
                     if (a1.index != a2.index)  or (a1.name != a2.name):
                         return False
-                    if a1.element is not None and a2.element is not None:
-                        if a1.element != a2.element:
-                            return False
-                        #for attr in ['atomic_number', 'name', 'symbol']:
-                        #    if getattr(a1.element, attr) != getattr(a2.element, attr):
-                        #        return False
+                    if a1.element is not a2.element: return False
+                    #for attr in ['atomic_number', 'name', 'symbol']:
+                    #    if getattr(a1.element, attr) != getattr(a2.element, attr):
+                    #        return False
 
         if len(self._bonds) != len(other._bonds):
             return False

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -353,7 +353,7 @@ class Topology(object):
         """
         pd = import_('pandas')
         data = [(atom.serial, atom.name, atom.element.symbol,
-                 atomm.residue.resSeq, atom.residue.name,
+                 atom.residue.resSeq, atom.residue.name,
                  atom.residue.chain.index) for atom in self.atoms]
 
         atoms = pd.DataFrame(data, columns=["serial", "name", "element",

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -568,6 +568,7 @@ class Topology(object):
         atom : mdtraj.topology.Atom
             the newly created Atom
         """
+        if element is None: element = elem.virtual
         atom = Atom(name, element, self._numAtoms, residue, serial=serial)
         self._atoms.append(atom)
         self._numAtoms += 1

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -421,7 +421,7 @@ class Topology(object):
                 for atom_index, atom in residue_atoms.iterrows():
                     atom_index = int(atom_index)  # Fixes bizarre hashing issue on Py3K.  See #545
                     a = Atom(atom['name'], elem.get_by_symbol(atom['element']),
-                             r, serial=atom['serial'])
+                             atom_index, r, serial=atom['serial'])
                     out._atoms[atom_index] = a
                     r._atoms.append(a)
 

--- a/mdtraj/formats/arc.py
+++ b/mdtraj/formats/arc.py
@@ -282,7 +282,7 @@ class ArcTrajectoryFile(object):
     def _read(self):
         "Read a single frame"
         from mdtraj.core.topology import Topology
-        from mdtraj.core.element import Element
+        from mdtraj.core.element import Element, virtual
         # Read in the number of atoms.
         line = self._fh.readline()
         if line == '':
@@ -338,7 +338,7 @@ class ArcTrajectoryFile(object):
                     try:
                         elem = Element.getBySymbol(at[0])
                     except KeyError:
-                        elem = None
+                        elem = virtual
                 top.add_atom(at, elem, res)
             # Now add the bonds
             atoms = list(top.atoms)

--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -277,13 +277,12 @@ class GroTrajectoryFile(object):
                         atomReplacements = {}
 
                 thiselem = thisatomname
-                element = None
                 if len(thiselem) > 1:
                     thiselem = thiselem[0] + sub('[A-Z0-9]','',thiselem[1:])
                 try:
                     element = elem.get_by_symbol(thiselem)
                 except KeyError:
-                    pass
+                    element = elem.virtual
                 if thisatomname in atomReplacements:
                     thisatomname = atomReplacements[thisatomname]
 

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -333,7 +333,7 @@ class HDF5TrajectoryFile(object):
                     try:
                         element = elem.get_by_symbol(atom_dict['element'])
                     except KeyError:
-                        element = None
+                        element = elem.virtual
                     topology.add_atom(atom_dict['name'], element, residue)
 
         atoms = list(topology.atoms)

--- a/mdtraj/formats/lh5.py
+++ b/mdtraj/formats/lh5.py
@@ -82,7 +82,7 @@ def _topology_from_arrays(AtomID, AtomNames, ChainID, ResidueID, ResidueNames):
         try:
             element = elem.get_by_symbol(element_symbol)
         except KeyError:
-            element = None
+            element = elem.virtual
         
         topology.add_atom(atom_name, element,
                           registered_residues[ResidueID[i]])

--- a/mdtraj/formats/prmtop.py
+++ b/mdtraj/formats/prmtop.py
@@ -199,7 +199,7 @@ def load_prmtop(filename):
             try:
                 element = elem.Element.getByAtomicNumber(int(raw_data['ATOMIC_NUMBER'][index]))
             except KeyError:
-                element = None
+                element = elem.virtual
         else:
             # Try to guess the element from the atom name.
 
@@ -216,7 +216,7 @@ def load_prmtop(filename):
                 try:
                     element = elem.get_by_symbol(atom_name[0])
                 except KeyError:
-                    element = None
+                    element = elem.virtual
 
         top.add_atom(atom_name, element, r)
 

--- a/mdtraj/formats/psf.py
+++ b/mdtraj/formats/psf.py
@@ -258,7 +258,7 @@ def load_psf(fname):
         elif upper == 'CAL':
             element = elem.calcium
         elif mass == 0:
-            element = None
+            element = elem.virtual
         else:
             element = elem.Element.getByMass(mass*u.dalton)
         top.add_atom(name, element, r)


### PR DESCRIPTION
This aims to make it so no element will raise a `NameError` when a virtual site is present (since that is fairly rare so far).  The goal is to make it just as easy to identify them (`atom.element is elem.virtual` instead of `atom.element is None`) while removing the need to special-case virtually every element inspection for virtual sites before trying to access an attribute of the element.