### PR TITLE
Calculate some more NMR J-couplings

### DIFF
--- a/mdtraj/nmr/__init__.py
+++ b/mdtraj/nmr/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import absolute_import
 from .shift_wrappers import compute_chemical_shifts, chemical_shifts_shiftx2, chemical_shifts_ppm, chemical_shifts_spartaplus, reindex_dataframe_by_atoms
-from .scalar_couplings import compute_J3_HN_HA
+from .scalar_couplings import compute_J3_HN_HA, compute_J3_HN_C, compute_J3_HN_CB

--- a/mdtraj/nmr/scalar_couplings.py
+++ b/mdtraj/nmr/scalar_couplings.py
@@ -68,7 +68,7 @@ J3_HN_HA_uncertainties = {
     "Bax2007": 0.36,
     "Bax1997": 0.39
 }
- 
+
 ##############################################################################
 # Functions
 ##############################################################################
@@ -76,6 +76,7 @@ J3_HN_HA_uncertainties = {
 def _J3_function(phi, A, B, C, phi0):
     """Return a scalar couplings with a given choice of karplus coefficients.  USES RADIANS!"""
     return A * np.cos(phi + phi0) ** 2. + B * np.cos(phi + phi0) + C
+
 
 def compute_J3_HN_HA(traj, model="Bax2007"):
     """Calculate the scalar coupling between HN and H_alpha.
@@ -96,7 +97,7 @@ def compute_J3_HN_HA(traj, model="Bax2007"):
     -------
     indices : np.ndarray, shape=(n_phi, 4), dtype=int
         Atom indices (zero-based) of the phi dihedrals
-    J : np.ndarray, shape=(n_phi, n_frames)
+    J : np.ndarray, shape=(n_frames, n_phi)
         Scalar couplings (J3_HN_HA, in [Hz]) of this trajectory.
         `J[k]` corresponds to the phi dihedral associated with
         atoms `indices[k]`
@@ -132,6 +133,7 @@ def compute_J3_HN_HA(traj, model="Bax2007"):
     J = _J3_function(phi, **J3_HN_HA_coefficients[model])
     return indices, J
 
+
 def compute_J3_HN_C(traj, model="Bax2007"):
     """Calculate the scalar coupling between HN and C_prime.
 
@@ -150,7 +152,7 @@ def compute_J3_HN_C(traj, model="Bax2007"):
     -------
     indices : np.ndarray, shape=(n_phi, 4), dtype=int
         Atom indices (zero-based) of the phi dihedrals
-    J : np.ndarray, shape=(n_phi, n_frames)
+    J : np.ndarray, shape=(n_frames, n_phi)
         Scalar couplings (J3_HN_C, in [Hz]) of this trajectory.
         `J[k]` corresponds to the phi dihedral associated with
         atoms `indices[k]`
@@ -176,6 +178,7 @@ def compute_J3_HN_C(traj, model="Bax2007"):
     J = _J3_function(phi, **J3_HN_C_coefficients[model])
     return indices, J
 
+
 def compute_J3_HN_CB(traj, model="Bax2007"):
     """Calculate the scalar coupling between HN and C_beta.
 
@@ -194,7 +197,7 @@ def compute_J3_HN_CB(traj, model="Bax2007"):
     -------
     indices : np.ndarray, shape=(n_phi, 4), dtype=int
         Atom indices (zero-based) of the phi dihedrals
-    J : np.ndarray, shape=(n_phi, n_frames)
+    J : np.ndarray, shape=(n_frames, n_phi)
         Scalar couplings (J3_HN_CB, in [Hz]) of this trajectory.
         `J[k]` corresponds to the phi dihedral associated with
         atoms `indices[k]`

--- a/mdtraj/nmr/scalar_couplings.py
+++ b/mdtraj/nmr/scalar_couplings.py
@@ -38,6 +38,23 @@ from mdtraj.geometry import compute_phi
 # Globals
 ##############################################################################
 
+J3_HN_CB_coefficients = {  # See full citations below in docstring references.
+    "Bax2007": dict(phi0=+60 * np.pi/180., A=3.71, B=-0.59, C=0.08),  # From Table 1. in paper
+    }
+
+J3_HN_CB_uncertainties = {
+    # Values in [Hz]
+    "Bax2007": 0.22,
+}
+
+J3_HN_C_coefficients = {  # See full citations below in docstring references.
+    "Bax2007": dict(phi0=+180 * np.pi/180., A=4.36, B=-1.08, C=-0.01),  # From Table 1. in paper
+    }
+
+J3_HN_C_uncertainties = {
+    # Values in [Hz]
+    "Bax2007": 0.30,
+}
 
 J3_HN_HA_coefficients = {  # See full citations below in docstring references.
     "Ruterjans1999": dict(phi0=-60 * np.pi/180., A=7.90, B=-1.05, C=0.65),  # From Table 1. in paper.
@@ -51,7 +68,7 @@ J3_HN_HA_uncertainties = {
     "Bax2007": 0.36,
     "Bax1997": 0.39
 }
-
+ 
 ##############################################################################
 # Functions
 ##############################################################################
@@ -59,7 +76,6 @@ J3_HN_HA_uncertainties = {
 def _J3_function(phi, A, B, C, phi0):
     """Return a scalar couplings with a given choice of karplus coefficients.  USES RADIANS!"""
     return A * np.cos(phi + phi0) ** 2. + B * np.cos(phi + phi0) + C
-
 
 def compute_J3_HN_HA(traj, model="Bax2007"):
     """Calculate the scalar coupling between HN and H_alpha.
@@ -114,4 +130,92 @@ def compute_J3_HN_HA(traj, model="Bax2007"):
         raise(KeyError("model must be one of %s" % J3_HN_HA_coefficients.keys()))
 
     J = _J3_function(phi, **J3_HN_HA_coefficients[model])
+    return indices, J
+
+def compute_J3_HN_C(traj, model="Bax2007"):
+    """Calculate the scalar coupling between HN and C_prime.
+
+    This function does not take into account periodic boundary conditions (it
+    will give spurious results if the three atoms which make up any angle jump
+    across a PBC (are not "wholed"))
+
+    Parameters
+    ----------
+    traj : mdtraj.Trajectory
+        Trajectory to compute J3_HN_C for
+    model : string, optional, default="Bax2007"
+        Which scalar coupling model to use.  Must be one of Bax2007
+
+    Returns
+    -------
+    indices : np.ndarray, shape=(n_phi, 4), dtype=int
+        Atom indices (zero-based) of the phi dihedrals
+    J : np.ndarray, shape=(n_phi, n_frames)
+        Scalar couplings (J3_HN_C, in [Hz]) of this trajectory.
+        `J[k]` corresponds to the phi dihedral associated with
+        atoms `indices[k]`
+
+    Notes
+    -----
+    The coefficients are taken from the references below--please cite them.
+
+    References
+    ----------
+    .. [1] Hu, J. S., & Bax, A.
+       "Determination of ϕ and ξ1 Angles in Proteins from 13C-13C
+       Three-Bond J Couplings Measured by Three-Dimensional Heteronuclear NMR.
+       How Planar Is the Peptide Bond?."
+       J. Am. Chem. Soc., 119(27), 6360-6368 (1997)
+
+    """
+    indices, phi = compute_phi(traj)
+
+    if model not in J3_HN_C_coefficients:
+        raise(KeyError("model must be one of %s" % J3_HN_C_coefficients.keys()))
+
+    J = _J3_function(phi, **J3_HN_C_coefficients[model])
+    return indices, J
+
+def compute_J3_HN_CB(traj, model="Bax2007"):
+    """Calculate the scalar coupling between HN and C_beta.
+
+    This function does not take into account periodic boundary conditions (it
+    will give spurious results if the three atoms which make up any angle jump
+    across a PBC (are not "wholed"))
+
+    Parameters
+    ----------
+    traj : mdtraj.Trajectory
+        Trajectory to compute J3_HN_CB for
+    model : string, optional, default="Bax2007"
+        Which scalar coupling model to use.  Must be one of Bax2007
+
+    Returns
+    -------
+    indices : np.ndarray, shape=(n_phi, 4), dtype=int
+        Atom indices (zero-based) of the phi dihedrals
+    J : np.ndarray, shape=(n_phi, n_frames)
+        Scalar couplings (J3_HN_CB, in [Hz]) of this trajectory.
+        `J[k]` corresponds to the phi dihedral associated with
+        atoms `indices[k]`
+
+    Notes
+    -----
+    The coefficients are taken from the references below--please cite them.
+
+    References
+    ----------
+    .. [1] Hu, J. S., & Bax, A.
+       "Determination of ϕ and ξ1 Angles in Proteins from 13C-13C
+       Three-Bond J Couplings Measured by Three-Dimensional Heteronuclear NMR.
+       How Planar Is the Peptide Bond?."
+       J. Am. Chem. Soc., 119(27), 6360-6368 (1997)
+
+    """
+    indices, phi = compute_phi(traj)
+
+    if model not in J3_HN_CB_coefficients:
+        raise(KeyError("model must be one of %s" % J3_HN_CB_coefficients.keys()))
+
+    J = _J3_function(phi, **J3_HN_CB_coefficients[model])
     return indices, J

--- a/mdtraj/tests/test_nmr.py
+++ b/mdtraj/tests/test_nmr.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import numpy as np
 import mdtraj as md
 from mdtraj.testing import get_fn, eq, DocStringFormatTester, skipif
 from mdtraj.nmr.shift_wrappers import find_executable, SPARTA_PLUS, PPM, SHIFTX2
@@ -22,7 +23,7 @@ def test_ppm():
     result = md.chemical_shifts_ppm(t)
 
     print(result)
-    
+
     eq(result.shape[1], 20)  # 2EQQ is NMR structure with 20 frames
     eq(float(result.ix[(2, "CA")][0]), 53.004, decimal=4)
     # taken from first entry in bb_details.dat, which looks like the following:
@@ -35,7 +36,7 @@ def test_shiftx2():
     result = md.chemical_shifts_shiftx2(t)
 
     print(result)
-    
+
     eq(result.shape[1], 20)  # 2EQQ is NMR structure with 20 frames
     eq(float(result.ix[(1, "C")][0]), 175.2570, decimal=4)
     # taken from first entry in trj.pdb.cs, which looks like the following:
@@ -51,7 +52,7 @@ def test_2_scalar_couplings():
         eq(J.shape, (501, 1))
         J = J.mean()
         assert abs(J - 6.06) <= 2.0, "Value is far from experimental value."
-        # 6.06 [Hz] is the value from Baldwin PNAS 2006 Table 1.  
+        # 6.06 [Hz] is the value from Baldwin PNAS 2006 Table 1.
         # We expect the models to give something comparable to this
         # If it doesn't, something is fishy.
         # Typical ranges are between 1 and 9.
@@ -60,5 +61,18 @@ def test_2_scalar_couplings():
 
 def test_3_scalar_couplings():
     t = md.load(get_fn('1bpi.pdb'))
-    for model in ["Ruterjans1999", "Bax2007", "Bax1997"]:
-        indices, J = md.compute_J3_HN_HA(t)
+    for model in ["Bax2007"]:
+        indices_HA, J_HA = md.compute_J3_HN_HA(t)
+        indices_C, J_C = md.compute_J3_HN_C(t)
+        indices_CB, J_CB = md.compute_J3_HN_CB(t)
+
+        eq(indices_HA.shape, (57, 4))
+        eq(indices_C.shape, (57, 4))
+        eq(indices_CB.shape, (57, 4))
+        eq(J_HA.shape, (1, 57))
+        eq(J_C.shape, (1, 57))
+        eq(J_CB.shape, (1, 57))
+
+        np.testing.assert_almost_equal(J_HA[0,0], 0.48885268)
+        np.testing.assert_almost_equal(J_C[0,0], 3.840529)
+        np.testing.assert_almost_equal(J_CB[0,0], 2.5702963)


### PR DESCRIPTION
Added a test to leeping's PR #833, and fixed a bug in the docstring where it listed the shape of the return value incorrectly in the scalar coupling functions.