### PR TITLE
Remove warnings when NetCDF files do not have time information

### DIFF
--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -570,7 +570,6 @@ class AmberNetCDFRestartFile(object):
         if 'time' in self._handle.variables:
             time = self._handle.variables['time'].getValue()
         else:
-            warnings.warn('No time found in NetCDF file.')
             time = None
 
         # scipy.io.netcdf variables are mem-mapped, and are only backed by valid

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -249,7 +249,6 @@ class NetCDFTrajectoryFile(object):
         if 'time' in self._handle.variables:
             time = self._handle.variables['time'][frame_slice]
         else:
-            warnings.warn('No time information found in the NetCDF file')
             time = None
 
         if 'cell_lengths' in self._handle.variables:


### PR DESCRIPTION
Time is not required to be present in NetCDF trajectories and it's often the
case that it's not. For example, if trajectories are converted from a format
that does not contain the time (e.g., Amber mdcrd).