### PR TITLE
[core.trajectory] add hash implementation

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -225,6 +225,14 @@ class Topology(object):
     def __deepcopy__(self, *args):
         return self.copy()
 
+    def __hash__(self):
+        hash_value = hash(tuple(self._chains))
+        hash_value ^= hash(tuple(self._atoms))
+        hash_value ^= hash(tuple(self._bonds))
+        hash_value ^= hash(tuple(self._residues))
+
+        return hash_value
+
     def join(self, other):
         """Join two topologies together
 

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -846,11 +846,9 @@ class Trajectory(object):
 
     def __hash__(self):
         def _hash_numpy_array(x):
-            x.flags.writeable = False
             hash_value = hash(x.shape)
             hash_value ^= hash(x.strides)
-            hash_value ^= hash(x.data)
-            x.flags.writeable = True
+            hash_value ^= hash(x.data.tobytes())
             return hash_value
 
         hash_value = hash(self.top)

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -28,7 +28,6 @@
 from __future__ import print_function, division
 import os
 import warnings
-import functools
 from copy import deepcopy
 from collections import Iterable
 import numpy as np
@@ -42,7 +41,6 @@ from mdtraj.formats import NetCDFTrajectoryFile
 from mdtraj.formats import LH5TrajectoryFile
 from mdtraj.formats import PDBTrajectoryFile
 from mdtraj.formats import MDCRDTrajectoryFile
-from mdtraj.formats import ArcTrajectoryFile
 from mdtraj.formats import DTRTrajectoryFile
 from mdtraj.formats import LAMMPSTrajectoryFile
 from mdtraj.formats import XYZTrajectoryFile
@@ -111,6 +109,21 @@ def _assert_files_or_dirs_exist(names):
         if not (os.path.exists(fn) and \
                         (os.path.isfile(fn) or os.path.isdir(fn))):
             raise IOError('No such file: %s' % fn)
+
+if PY3:
+    def _hash_numpy_array(x):
+        hash_value = hash(x.shape)
+        hash_value ^= hash(x.strides)
+        hash_value ^= hash(x.data.tobytes())
+        return hash_value
+else:
+    def _hash_numpy_array(x):
+        x.flags.writeable = False
+        hash_value = hash(x.shape)
+        hash_value ^= hash(x.strides)
+        hash_value ^= hash(x.data)
+        x.flags.writeable = True
+        return hash_value
 
 
 def load_topology(filename):
@@ -845,12 +858,6 @@ class Trajectory(object):
         return "<%s at 0x%02x>" % (self._string_summary_basic(), id(self))
 
     def __hash__(self):
-        def _hash_numpy_array(x):
-            hash_value = hash(x.shape)
-            hash_value ^= hash(x.strides)
-            hash_value ^= hash(x.data.tobytes())
-            return hash_value
-
         hash_value = hash(self.top)
         # combine with hashes of arrays
         hash_value ^= _hash_numpy_array(self._xyz)

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -844,6 +844,26 @@ class Trajectory(object):
     def __repr__(self):
         return "<%s at 0x%02x>" % (self._string_summary_basic(), id(self))
 
+    def __hash__(self):
+        def _hash_numpy_array(x):
+            x.flags.writeable = False
+            hash_value = hash(x.shape)
+            hash_value ^= hash(x.strides)
+            hash_value ^= hash(x.data)
+            x.flags.writeable = True
+            return hash_value
+
+        hash_value = hash(self.top)
+        # combine with hashes of arrays
+        hash_value ^= _hash_numpy_array(self._xyz)
+        hash_value ^= _hash_numpy_array(self.time)
+        hash_value ^= _hash_numpy_array(self._unitcell_lengths)
+        hash_value ^= _hash_numpy_array(self._unitcell_angles)
+        return hash_value
+
+    def __eq__(self, other):
+        return self.__hash__() == other.__hash__()
+
     # def describe(self):
     #     """Diagnostic summary statistics on the trajectory"""
     #     # What information do we want to display?

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -569,15 +569,16 @@ def test_chunk0_iterload():
 
 
 def test_hashing():
-    hashes = [hash(frame) for frame in
+    frames = [frame for frame in
               md.iterload(get_fn('frame0.xtc'), chunk=1,
                           top=get_fn('native.pdb'))]
+    hashes = [hash(frame) for frame in frames]
     # check all frames have a unique hash value
     assert len(hashes) == len(set(hashes))
 
     # change topology and ensure hash changes too
-    top = frame.topology
+    top = frames[0].topology
     top.add_bond(top.atom(0), top.atom(1))
 
-    last_frame_hash = hash(frame)
+    last_frame_hash = hash(frames[0])
     assert last_frame_hash != hashes[-1]

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -33,6 +33,7 @@ from mdtraj.utils.six.moves import xrange
 from mdtraj.core import element
 
 import mdtraj.core.trajectory
+from mdtraj.core.topology import Topology
 TestDocstrings = DocStringFormatTester(mdtraj.core.trajectory, error_on_none=True)
 
 fn = get_fn('traj.h5')
@@ -565,3 +566,18 @@ def test_chunk0_iterload():
         pass
 
     eq(trj0.n_frames, trj.n_frames)
+
+
+def test_hashing():
+    hashes = [hash(frame) for frame in
+              md.iterload(get_fn('frame0.xtc'), chunk=1,
+                          top=get_fn('native.pdb'))]
+    # check all frames have a unique hash value
+    assert len(hashes) == len(set(hashes))
+
+    # change topology and ensure hash changes too
+    top = frame.topology
+    top.add_bond(top.atom(0), top.atom(1))
+
+    last_frame_hash = hash(frame)
+    assert last_frame_hash != hashes[-1]


### PR DESCRIPTION
This might be useful for caching purposes of Trajectory objects. One can also efficiently compare two trajectories for equality. If you do not consider this useful, just close the PR.