### PR TITLE
BUGFIX: Fix pytables inadvertently being moved to a required dependency

### DIFF
--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -51,9 +51,8 @@ import numpy as np
 import xml.etree.ElementTree as etree
 from copy import copy
 from mdtraj.formats.pdb.pdbstructure import PdbStructure
-from mdtraj.io import open_maybe_zipped
 from mdtraj.core.topology import Topology
-from mdtraj.utils import ilen, cast_indices, in_units_of
+from mdtraj.utils import ilen, cast_indices, in_units_of, open_maybe_zipped
 from mdtraj.formats.registry import _FormatRegistry
 from mdtraj.core import element as elem
 from mdtraj.utils import six

--- a/mdtraj/formats/xyzfile.py
+++ b/mdtraj/formats/xyzfile.py
@@ -34,8 +34,8 @@ import os
 import numpy as np
 
 from mdtraj.formats.registry import _FormatRegistry
-from mdtraj.io import open_maybe_zipped
-from mdtraj.utils import cast_indices, in_units_of, ensure_type
+from mdtraj.utils import (cast_indices, in_units_of, ensure_type,
+                          open_maybe_zipped)
 from mdtraj.utils.six import string_types
 from mdtraj.utils.six.moves import xrange
 from mdtraj.version import version

--- a/mdtraj/io.py
+++ b/mdtraj/io.py
@@ -75,8 +75,7 @@ Functions
 ---------
 """
 from __future__ import print_function, division, absolute_import
-import bz2
-import gzip
+
 import io
 import os
 import warnings
@@ -292,55 +291,6 @@ def loadh(file, name=Ellipsis, deferred=True):
         return result
 
     return DeferredTable(handle, own_fid)
-
-
-def open_maybe_zipped(filename, mode, force_overwrite=True):
-    """Open a file in text (not binary) mode, transparently handling
-    .gz or .bz2 compresssion, with utf-8 encoding.
-
-    Parameters
-    ----------
-    filename : str
-        Path to file. Compression will be automatically detected if
-        the filename ends in .gz or .bz2.
-    mode : {'r', 'w'}
-        Mode in which to open file
-    force_overwrite: bool, default=True
-        If 'w', should we overwrite the file if something with `filename`
-        already exists?
-
-    Returns
-    -------
-    handle : file
-        Open file handle.
-    """
-    _, extension = os.path.splitext(filename.lower())
-    if mode == 'r':
-        if extension == '.gz':
-            with gzip.GzipFile(filename, 'r') as gz_f:
-                return StringIO(gz_f.read().decode('utf-8'))
-        elif extension == '.bz2':
-            with bz2.BZ2File(filename, 'r') as bz2_f:
-                return StringIO(bz2_f.read().decode('utf-8'))
-        else:
-            return open(filename, 'r')
-    elif mode == 'w':
-        if os.path.exists(filename) and not force_overwrite:
-            raise IOError('"%s" already exists' % filename)
-        if extension == '.gz':
-            if PY2:
-                return gzip.GzipFile(filename, 'w')
-            binary_fh = gzip.GzipFile(filename, 'wb')
-            return io.TextIOWrapper(binary_fh, encoding='utf-8')
-        elif extension == '.bz2':
-            if PY2:
-                return bz2.BZ2File(filename, 'w')
-            binary_fh = bz2.BZ2File(filename, 'wb')
-            return io.TextIOWrapper(binary_fh, encoding='utf-8')
-        else:
-            return open(filename, 'w')
-    else:
-        raise ValueError('Invalid mode "%s"' % mode)
 
 
 class DeferredTable(object):

--- a/mdtraj/io.py
+++ b/mdtraj/io.py
@@ -95,6 +95,25 @@ except Exception:  #type?
     warnings.warn("Missing Zlib; no compression will used.")
     COMPRESSION = tables.Filters()
 
+
+# Note to developers: This module is pseudo-deprecated. It provides (loadh, saveh)
+# which are useful functions (and we want to maintain them), but aren't really
+# within the scope of MDTraj as we now understand it.
+#
+# With that said, many people use these functions and no good would come from getting
+# rid of them. But we shouldn't add any new functions or new features to this file.
+#
+# One potential landmine is that this file _requires_ the `tables` package, which is
+# only an _optional_ dependency in MDTraj. So if you import this file (or anything in
+# it) from another file that is imported at startup (on a user running `import mdtraj`)
+# then tables ceases to be an optional dependency and becomes a strict requirement.
+#
+# So add new features to a different file, and there shouldn't be any reason for
+# any files inside MDTraj to `import mdtraj.io`.
+#
+# See github issue #852.
+
+
 def saveh(file, *args, **kwargs):
     """Save several numpy arrays into a single file in compressed ``.hdf`` format.
 

--- a/mdtraj/tests/test_io.py
+++ b/mdtraj/tests/test_io.py
@@ -35,10 +35,11 @@ from mdtraj import io
 import numpy as np
 
 fd, temp = tempfile.mkstemp(suffix='.h5')
+os.close(fd)
+
 def teardown_module(module):
     """remove the temporary file created by tests in this file
     this gets automatically called by nose"""
-    os.close(fd)
     os.unlink(temp)
 
 
@@ -74,41 +75,6 @@ def test_overwrite_2():
             os.close(fid)
             os.unlink(fn)
 
-
-class test_open_maybe_zipped(unittest.TestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-
-    def teardown(self):
-        for fn in glob.glob(os.path.join(self.tmpdir, '*')):
-            os.remove(fn)
-        os.rmdir(self.tmpdir)
-
-    def test_read_gz(self):
-        fn = os.path.join(self.tmpdir, 'read.gz')
-        with gzip.GzipFile(fn, 'w') as f:
-            f.write('COOKIE'.encode('utf-8'))
-        eq(io.open_maybe_zipped(fn, 'r').read(), u'COOKIE')
-
-    def test_write_gz(self):
-        fn = os.path.join(self.tmpdir, 'write.gz')
-        with io.open_maybe_zipped(fn, 'w') as f:
-            f.write(u'COOKIE')
-        with gzip.GzipFile(fn, 'r') as f:
-            eq(f.read().decode('utf-8'), u'COOKIE')
-
-    def test_read_bz2(self):
-        fn = os.path.join(self.tmpdir, 'read.bz2')
-        with bz2.BZ2File(fn, 'w') as f:
-            f.write('COOKIE'.encode('utf-8'))
-        eq(io.open_maybe_zipped(fn, 'r').read(), u'COOKIE')
-
-    def test_write_bz2(self):
-        fn = os.path.join(self.tmpdir, 'write.bz2')
-        with io.open_maybe_zipped(fn, 'w') as f:
-            f.write(u'COOKIE')
-        with bz2.BZ2File(fn, 'r') as f:
-            eq(f.read().decode('utf-8'), u'COOKIE')
 
 
 class test_io(unittest.TestCase):

--- a/mdtraj/tests/test_zipped.py
+++ b/mdtraj/tests/test_zipped.py
@@ -1,0 +1,45 @@
+from __future__ import print_function, absolute_import, division
+
+import os
+import gzip
+import bz2
+import tempfile
+import unittest
+from mdtraj.testing import eq
+from mdtraj.utils import open_maybe_zipped
+
+
+class test_open_maybe_zipped(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def teardown(self):
+        for fn in glob.glob(os.path.join(self.tmpdir, '*')):
+            os.remove(fn)
+        os.rmdir(self.tmpdir)
+
+    def test_read_gz(self):
+        fn = os.path.join(self.tmpdir, 'read.gz')
+        with gzip.GzipFile(fn, 'w') as f:
+            f.write('COOKIE'.encode('utf-8'))
+        eq(open_maybe_zipped(fn, 'r').read(), u'COOKIE')
+
+    def test_write_gz(self):
+        fn = os.path.join(self.tmpdir, 'write.gz')
+        with open_maybe_zipped(fn, 'w') as f:
+            f.write(u'COOKIE')
+        with gzip.GzipFile(fn, 'r') as f:
+            eq(f.read().decode('utf-8'), u'COOKIE')
+
+    def test_read_bz2(self):
+        fn = os.path.join(self.tmpdir, 'read.bz2')
+        with bz2.BZ2File(fn, 'w') as f:
+            f.write('COOKIE'.encode('utf-8'))
+        eq(open_maybe_zipped(fn, 'r').read(), u'COOKIE')
+
+    def test_write_bz2(self):
+        fn = os.path.join(self.tmpdir, 'write.bz2')
+        with open_maybe_zipped(fn, 'w') as f:
+            f.write(u'COOKIE')
+        with bz2.BZ2File(fn, 'r') as f:
+            eq(f.read().decode('utf-8'), u'COOKIE')

--- a/mdtraj/utils/__init__.py
+++ b/mdtraj/utils/__init__.py
@@ -8,6 +8,7 @@ from mdtraj.utils.rotation import rotation_matrix_from_quaternion, uniform_quate
 from mdtraj.utils.unitcell import (lengths_and_angles_to_box_vectors,
                        box_vectors_to_lengths_and_angles)
 from mdtraj.utils.contextmanagers import timing, enter_temp_directory
+from mdtraj.utils.zipped import open_maybe_zipped
 
 __all__ = ["ensure_type", "import_", "in_units_of",
            "lengths_and_angles_to_box_vectors",

--- a/mdtraj/utils/zipped.py
+++ b/mdtraj/utils/zipped.py
@@ -1,0 +1,56 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+import io
+import bz2
+import gzip
+from mdtraj.utils.six import PY2, StringIO
+
+
+def open_maybe_zipped(filename, mode, force_overwrite=True):
+    """Open a file in text (not binary) mode, transparently handling
+    .gz or .bz2 compresssion, with utf-8 encoding.
+
+    Parameters
+    ----------
+    filename : str
+        Path to file. Compression will be automatically detected if
+        the filename ends in .gz or .bz2.
+    mode : {'r', 'w'}
+        Mode in which to open file
+    force_overwrite: bool, default=True
+        If 'w', should we overwrite the file if something with `filename`
+        already exists?
+
+    Returns
+    -------
+    handle : file
+        Open file handle.
+    """
+    _, extension = os.path.splitext(filename.lower())
+    if mode == 'r':
+        if extension == '.gz':
+            with gzip.GzipFile(filename, 'r') as gz_f:
+                return StringIO(gz_f.read().decode('utf-8'))
+        elif extension == '.bz2':
+            with bz2.BZ2File(filename, 'r') as bz2_f:
+                return StringIO(bz2_f.read().decode('utf-8'))
+        else:
+            return open(filename, 'r')
+    elif mode == 'w':
+        if os.path.exists(filename) and not force_overwrite:
+            raise IOError('"%s" already exists' % filename)
+        if extension == '.gz':
+            if PY2:
+                return gzip.GzipFile(filename, 'w')
+            binary_fh = gzip.GzipFile(filename, 'wb')
+            return io.TextIOWrapper(binary_fh, encoding='utf-8')
+        elif extension == '.bz2':
+            if PY2:
+                return bz2.BZ2File(filename, 'w')
+            binary_fh = bz2.BZ2File(filename, 'wb')
+            return io.TextIOWrapper(binary_fh, encoding='utf-8')
+        else:
+            return open(filename, 'w')
+    else:
+        raise ValueError('Invalid mode "%s"' % mode)


### PR DESCRIPTION
Pytables (`import tables`) has been an optional dependency of MDTraj for a while. It's used by HDF5TrajectoryFile, and by `mdtraj.io`. We accidentally made it a required dependency by adding the function `open_maybe_zipped` to `mdtraj.io`, and then importing `open_maybe_zipped` from inside the PDB code which is imported at startup, causing a user's `import mdtraj` to fail if they don't have pytables.

This is issue #852.

PR fixes the issue by moving `open_maybe_zipped` to a new file inside `utils`, and adding a comment to `io.py` that explains what's going on.

This looks like a kind of annoying bug for packages that depend on MDTraj and use Travis-CI (like https://github.com/markovmodel/PyEMMA/pull/349 and https://github.com/choderalab/openmoltools/pull/123), so I think we should do a quick bugfix release.