### PR TITLE
changed _topology_from_subset to create topology with correct number of residues

### DIFF
--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -111,6 +111,7 @@ class SelectionKeyword(object):
         # (('nucleic', 'is_nucleic'), _chain('residue', 'is_nucleic')),
         (('water', 'waters', 'is_water'), _chain('residue', 'is_water')),
         (('name',), _chain('name')),
+        (('segment_id','segname',), _chain('segment_id')),
         (('index',), _chain('index')),
         (('n_bonds',), _chain('n_bonds')),
         (('residue', 'resSeq'), _chain('residue', 'resSeq')),

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1144,6 +1144,8 @@ class Residue(object):
         The chain within which this residue belongs
     resSeq : int
         The residue sequence number
+    segment_id : str
+        An optional label for the segment to which this residue belongs
     """
 
     def __init__(self, name, index, chain, resSeq):
@@ -1153,6 +1155,7 @@ class Residue(object):
         self.index = index
         self.chain = chain
         self.resSeq = resSeq
+        self.segment_id = ""
         self._atoms = []
 
     @property

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -88,12 +88,16 @@ def _topology_from_subset(topology, atom_indices):
 
     for chain in topology._chains:
         newChain = newTopology.add_chain()
+        previous_residue = None
         for residue in chain._residues:
             resSeq = getattr(residue, 'resSeq', None) or residue.index
-            newResidue = newTopology.add_residue(residue.name, newChain,
-                                                 resSeq)
             for atom in residue._atoms:
                 if atom.index in atom_indices:
+                    if not residue == previous_residue:
+                        newResidue = newTopology.add_residue(residue.name, newChain,
+                                                             resSeq)
+                        previous_residue = residue
+                    
                     try:  # OpenMM Topology objects don't have serial attributes, so we have to check first.
                         serial = atom.serial
                     except AttributeError:
@@ -101,6 +105,7 @@ def _topology_from_subset(topology, atom_indices):
                     newAtom = newTopology.add_atom(atom.name, atom.element,
                                                    newResidue, serial=serial)
                     old_atom_to_new_atom[atom] = newAtom
+
 
     bondsiter = topology.bonds
     if not hasattr(bondsiter, '__iter__'):

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1304,6 +1304,11 @@ class Atom(object):
         return (self.name not in set(['C', 'CA', 'N', 'O'])
                 and self.residue.is_protein)
 
+    @property
+    def segment_id(self):
+        """User specified segment_id of the residue to which this atom belongs"""
+        return self.residue.segment_id
+
     def __eq__(self, other):
         """ Check whether two Atom objects are equal. """
         if self.name != other.name:

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -482,6 +482,7 @@ class PDBTrajectoryFile(object):
                 if resName in PDBTrajectoryFile._residueNameReplacements:
                     resName = PDBTrajectoryFile._residueNameReplacements[resName]
                 r = self._topology.add_residue(resName, c, residue.number)
+                r.segment_id = residue.segment_id
                 if resName in PDBTrajectoryFile._atomNameReplacements:
                     atomReplacements = PDBTrajectoryFile._atomNameReplacements[resName]
                 else:

--- a/mdtraj/formats/pdb/pdbstructure.py
+++ b/mdtraj/formats/pdb/pdbstructure.py
@@ -418,12 +418,12 @@ class Chain(object):
         """
         # Create a residue if none have been created
         if len(self.residues) == 0:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         # Create a residue if the residue information has changed
         elif self._current_residue.number != atom.residue_number:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         elif self._current_residue.insertion_code != atom.insertion_code:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         elif self._current_residue.name_with_spaces == atom.residue_name_with_spaces:
             # This is a normal case: number, name, and iCode have not changed
             pass
@@ -433,7 +433,7 @@ class Chain(object):
         else: # Residue name does not match
             # Only residue name does not match
             warnings.warn("WARNING: two consecutive residues with same number (%s, %s)" % (atom, self._current_residue.atoms[-1]))
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         self._current_residue._add_atom(atom)
 
     def _add_residue(self, residue):
@@ -499,7 +499,7 @@ class Chain(object):
 
 
 class Residue(object):
-    def __init__(self, name, number, insertion_code=' ', primary_alternate_location_indicator=' '):
+    def __init__(self, name, number, insertion_code=' ', primary_alternate_location_indicator=' ',segment_id=''):
         alt_loc = primary_alternate_location_indicator
         self.primary_location_id = alt_loc
         self.locations = {}
@@ -512,6 +512,7 @@ class Residue(object):
         self.is_first_in_chain = False
         self.is_final_in_chain = False
         self._current_atom = None
+        self.segment_id = segment_id
 
     def _add_atom(self, atom):
         """

--- a/mdtraj/formats/psf.py
+++ b/mdtraj/formats/psf.py
@@ -238,6 +238,7 @@ def load_psf(fname):
             except KeyError:
                 pass
             r = top.add_residue(rname, c, resid)
+            r.segment_id = segid
 
         try:
             name = pdb.PDBTrajectoryFile._atomNameReplacements[rname][name]


### PR DESCRIPTION
When using trajectory.atom_slice, new trajectory file has the correct number of residues, but trajectory.top still had the original number of resides. This is because previously, there was an iteration over residues in the original topology, and a newResidue created for each one. 

In this modified version, only newResidues are created if there is an atom from that residue in the subset of atoms specified.

There is a point on the lines below where empty residues are deleted, but this still resulted in residues which internally contained an index which did not go from [0,new_n_residues]. 

That line may no longer be necessary with this change, but I did not remove it.
Additionally, I would expect a similar problem for chains, but it did not arise for my test PDB file, and so I did not make that additional modification.