### PR TITLE
[core/topology] made all topology related classes hashable

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -234,14 +234,6 @@ class Topology(object):
     def __deepcopy__(self, *args):
         return self.copy()
 
-    def __hash__(self):
-        hash_value = hash(tuple(self._chains))
-        hash_value ^= hash(tuple(self._atoms))
-        hash_value ^= hash(tuple(self._bonds))
-        hash_value ^= hash(tuple(self._residues))
-
-        return hash_value
-
     def join(self, other):
         """Join two topologies together
 
@@ -505,6 +497,14 @@ class Topology(object):
         g.add_nodes_from(self.atoms)
         g.add_edges_from(self.bonds)
         return g
+
+    def __hash__(self):
+        hash_value = hash(tuple(self._chains))
+        hash_value ^= hash(tuple(self._residues))
+        hash_value ^= hash(tuple(self._atoms))
+        hash_value ^= hash(tuple(self._bonds))
+
+        return hash_value
 
     def __eq__(self, other):
         """Are two topologies equal?
@@ -1220,6 +1220,13 @@ class Chain(object):
         """Get the number of atoms in this Chain"""
         return sum(r.n_atoms for r in self._residues)
 
+    def __eq__(self, other):
+        return (self.index == other.index and
+                self._residues == other.residues)
+
+    def __hash__(self, *args, **kwargs):
+        hash_value = hash(tuple(self._residues)) ^ hash(self.index)
+        return hash_value
 
 class Residue(object):
     """A Residue object represents a residue within a Topology.
@@ -1343,6 +1350,20 @@ class Residue(object):
     def __repr__(self):
         return str(self)
 
+    def __eq__(self, other):
+        return (self.name == other.name and
+                self.index == other.index and
+                self.resSeq == other.resSeq and
+                self.chain == other.chain and
+                self._atoms == other._atoms)
+
+    def __hash__(self):
+        # we can not hash atoms here, because they are hashed in Chain
+        hash_value = hash(self.name)
+        hash_value ^= hash(self.index)
+        hash_value ^= hash(self.resSeq)
+        return hash_value
+
 
 class Atom(object):
     """An Atom object represents a residue within a Topology.
@@ -1417,7 +1438,8 @@ class Atom(object):
 
     def __hash__(self):
         """A quick comparison. """
-        return self.index
+        hash_value = hash(self.index) ^ hash(self.element) ^ hash(self.residue)
+        return hash_value
 
     def __str__(self):
         return '%s-%s' % (self.residue, self.name)

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1221,12 +1221,17 @@ class Chain(object):
         return sum(r.n_atoms for r in self._residues)
 
     def __eq__(self, other):
+        if not isinstance(other, Chain):
+            return False
+        if self is other:
+            return True
         return (self.index == other.index and
                 self._residues == other.residues)
 
     def __hash__(self, *args, **kwargs):
         hash_value = hash(tuple(self._residues)) ^ hash(self.index)
         return hash_value
+
 
 class Residue(object):
     """A Residue object represents a residue within a Topology.
@@ -1351,6 +1356,10 @@ class Residue(object):
         return str(self)
 
     def __eq__(self, other):
+        if not isinstance(other, Residue):
+            return False
+        if self is other:
+            return True
         return (self.name == other.name and
                 self.index == other.index and
                 self.resSeq == other.resSeq and
@@ -1422,6 +1431,10 @@ class Atom(object):
 
     def __eq__(self, other):
         """ Check whether two Atom objects are equal. """
+        if not isinstance(other, Atom):
+            return False
+        if self is other:
+            return True
         if self.name != other.name:
             return False
         if self.index != other.index:

--- a/mdtraj/tests/test_topology.py
+++ b/mdtraj/tests/test_topology.py
@@ -28,7 +28,6 @@ from mdtraj.utils.six.moves import cPickle
 from mdtraj.utils import import_
 from mdtraj.testing import get_fn, eq, skipif, assert_raises
 
-
 try:
     from simtk.openmm import app
     HAVE_OPENMM = True
@@ -41,6 +40,7 @@ try:
     HAVE_PANDAS = True
 except ImportError:
     HAVE_PANDAS = False
+
 
 @skipif(not HAVE_OPENMM)
 def test_topology_openmm():
@@ -242,10 +242,28 @@ def test_to_fasta():
 
 
 def test_subset():
-     t1 = md.load(get_fn('2EQQ.pdb')).top
-     t2 = t1.subset([1,2,3])
-     assert t2.n_residues == 1
+    t1 = md.load(get_fn('2EQQ.pdb')).top
+    t2 = t1.subset([1,2,3])
+    assert t2.n_residues == 1
 
+
+def test_hashing():
+    top = md.load(get_fn('tip3p_300K_1ATM.pdb')).top
+    top_copy = top.copy()
+
+    # assert all atoms have a unique hash
+    s = set(top.atoms)
+    assert len(s) == top.n_atoms
+
+    s = set(top.residues)
+    assert len(s) == top.n_residues
+
+    s = set(top.bonds)
+    assert len(s) == top.n_bonds
+
+    htop = hash(top)
+    htopcopy = hash(top_copy)
+    assert htop == htopcopy
 
 def test_molecules():
     top = md.load(get_fn('4OH9.pdb')).topology


### PR DESCRIPTION
This was necessary since Python3 requires __eq__ and __hash__ impl.
Added test to assert equal hash values for "equal" objects.