### PR TITLE
Automized setup (pip) to drag-in build time dependencies (numpy, cython)

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -2,32 +2,15 @@ from __future__ import print_function, absolute_import
 import os
 import sys
 import json
-import string
 import shutil
 import subprocess
 import tempfile
 from distutils.dep_util import newer_group
 from distutils.core import Extension
-from distutils.errors import DistutilsExecError
+from distutils.errors import DistutilsExecError, DistutilsSetupError
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_vars
-from distutils.command.build_ext import build_ext as _build_ext
-
-
-def find_packages():
-    """Find all of mdtraj's python packages.
-    Adapted from IPython's setupbase.py. Copyright IPython
-    contributors, licensed under the BSD license.
-    """
-    packages = ['mdtraj.scripts']
-    for dir,subdirs,files in os.walk('mdtraj'):
-        package = dir.replace(os.path.sep, '.')
-        if '__init__.py' not in files:
-            # not a package
-            continue
-        packages.append(package)
-    return packages
-
+from setuptools.command.build_ext import build_ext as _build_ext
 
 
 ################################################################################

--- a/basesetup.py
+++ b/basesetup.py
@@ -249,6 +249,12 @@ class StaticLibrary(Extension):
 
 class build_ext(_build_ext):
 
+    def initialize_options(self):
+        _build_ext.initialize_options(self)
+        import pkg_resources
+        dir = pkg_resources.resource_filename('numpy', 'core/include')
+        self.include_dirs = [dir]
+
     def build_extension(self, ext):
         if isinstance(ext, StaticLibrary):
             self.build_static_extension(ext)

--- a/setup.py
+++ b/setup.py
@@ -131,8 +131,7 @@ def rmsd_extensions():
                          'mdtraj/rmsd/src/rotation.c',
                          'mdtraj/rmsd/src/center.c',
                          'mdtraj/rmsd/_rmsd.pyx'],
-                     include_dirs=['mdtraj/rmsd/include',
-                                  ],
+                     include_dirs=['mdtraj/rmsd/include'],
                      extra_compile_args=compiler_args,
                      libraries=compiler_libraries)
 
@@ -146,9 +145,7 @@ def rmsd_extensions():
                            'mdtraj/rmsd/src/euclidean_permutation.cpp',
                            'mdtraj/rmsd/_lprmsd.pyx'],
                        language='c++',
-                       include_dirs=[
-                           'mdtraj/rmsd/include',
-                                    ],
+                       include_dirs=['mdtraj/rmsd/include'],
                        extra_compile_args=compiler_args,
                        libraries=compiler_libraries + extra_cpp_libraries)
     return rmsd, lprmsd, libtheobald
@@ -166,8 +163,7 @@ def geometry_extensions():
                      'mdtraj/geometry/src/dssp.cpp',
                      'mdtraj/geometry/src/_geometry.pyx'],
             include_dirs=['mdtraj/geometry/include',
-                          'mdtraj/geometry/src/kernels',
-                         ],
+                          'mdtraj/geometry/src/kernels'],
             define_macros=define_macros,
             extra_compile_args=compiler_args,
             libraries=extra_cpp_libraries,
@@ -179,8 +175,7 @@ def geometry_extensions():
                      "mdtraj/geometry/src/cephes/isnan.c",
                      "mdtraj/geometry/src/moments.c"],
             include_dirs=["mdtraj/geometry/include",
-                          "mdtraj/geometry/include/cephes",
-                         ],
+                          "mdtraj/geometry/include/cephes"],
             define_macros=define_macros,
             extra_compile_args=compiler_args),
         Extension('mdtraj.geometry.neighbors',


### PR DESCRIPTION
* NumPy includes and Cython extensions are handled transparently.
* Requires setuptools >= 18

closes #933 