### PR TITLE
Follow the Amber NetCDF Trajectory Spec (for compatibility with cpptraj)

### DIFF
--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -450,17 +450,17 @@ class NetCDFTrajectoryFile(object):
             self._handle.createDimension('label', 5)
 
             # Define variables to store unit cell data
-            self._handle.createVariable('cell_spatial', 'c', ('cell_spatial',))
-            cell_angles = self._handle.createVariable('cell_angular', 'c', ('cell_spatial', 'label'))
             cell_lengths = self._handle.createVariable('cell_lengths', 'd', ('frame', 'cell_spatial'))
             setattr(cell_lengths, 'units', 'angstrom')
             cell_angles = self._handle.createVariable('cell_angles', 'd', ('frame', 'cell_angular'))
             setattr(cell_angles, 'units', 'degree')
 
-            self._handle.variables['cell_spatial'][0] = 'x'
-            self._handle.variables['cell_spatial'][1] = 'y'
-            self._handle.variables['cell_spatial'][2] = 'z'
+            self._handle.createVariable('cell_spatial', 'c', ('cell_spatial',))
+            self._handle.variables['cell_spatial'][0] = 'a'
+            self._handle.variables['cell_spatial'][1] = 'b'
+            self._handle.variables['cell_spatial'][2] = 'c'
 
+            self._handle.createVariable('cell_angular', 'c', ('cell_spatial', 'label'))
             self._handle.variables['cell_angular'][0] = 'alpha'
             self._handle.variables['cell_angular'][1] = 'beta '
             self._handle.variables['cell_angular'][2] = 'gamma'
@@ -473,6 +473,11 @@ class NetCDFTrajectoryFile(object):
         if set_coordinates:
             frame_coordinates = self._handle.createVariable('coordinates', 'f', ('frame', 'atom', 'spatial'))
             setattr(frame_coordinates, 'units', 'angstrom')
+
+            self._handle.createVariable('spatial', 'c', ('spatial',))
+            self._handle.variables['spatial'][0] = 'x'
+            self._handle.variables['spatial'][1] = 'y'
+            self._handle.variables['spatial'][2] = 'z'
 
     def seek(self, offset, whence=0):
         """Move to a new file position

--- a/mdtraj/tests/test_netcdf.py
+++ b/mdtraj/tests/test_netcdf.py
@@ -30,15 +30,19 @@ import os, tempfile
 from nose.tools import assert_raises
 import numpy as np
 import mdtraj as md
+import subprocess
 from mdtraj.testing import get_fn, eq, raises
 
 
 fd, temp = tempfile.mkstemp(suffix='.nc')
+fd2, temp2 = tempfile.mkstemp(suffix='.nc')
 def teardown_module(module):
     """remove the temporary file created by tests in this file
     this gets automatically called by nose"""
     os.close(fd)
+    os.close(fd2)
     os.unlink(temp)
+    os.unlink(temp2)
 
 
 def test_read_after_close():
@@ -228,3 +232,31 @@ def test_trajectory_save_load():
 
     eq(t.xyz, t2.xyz)
     eq(t.unitcell_lengths, t2.unitcell_lengths)
+
+
+def test_cpptraj():
+    trj0 = md.load(get_fn('frame0.dcd'), top=get_fn('frame0.pdb'))
+    trj0.save(temp)
+
+    top = get_fn("frame0.pdb")
+    subprocess.check_call([
+        'cpptraj',
+        '-p', top,
+        '-y', temp,
+        '-x', temp2
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    trj1 = md.load(temp, top=top)
+    trj2 = md.load(temp2, top=top)
+
+    np.testing.assert_array_almost_equal(trj0.xyz, trj2.xyz)
+    np.testing.assert_array_almost_equal(trj1.xyz, trj2.xyz)
+    np.testing.assert_array_almost_equal(trj0.unitcell_vectors,
+                                         trj2.unitcell_vectors)
+    np.testing.assert_array_almost_equal(trj1.unitcell_vectors,
+                                         trj2.unitcell_vectors)
+
+    # cpptraj doesn't preserve time information (?)
+    np.testing.assert_array_almost_equal(trj0.time, trj1.time)
+    # np.testing.assert_array_almost_equal(trj0.time, trj2.time)
+    # np.testing.assert_array_almost_equal(trj1.time, trj2.time)

--- a/mdtraj/tests/test_netcdf.py
+++ b/mdtraj/tests/test_netcdf.py
@@ -25,13 +25,20 @@
 Tests for the AMBER netcdf reader/writer code
 """
 
-from mdtraj.formats import netcdf, NetCDFTrajectoryFile
+from mdtraj.formats import NetCDFTrajectoryFile
 import os, tempfile
 from nose.tools import assert_raises
 import numpy as np
 import mdtraj as md
 import subprocess
-from mdtraj.testing import get_fn, eq, raises
+from mdtraj.testing import get_fn, eq, raises, skipif
+
+from distutils.spawn import find_executable
+
+HAVE_CPPTRAJ = find_executable('cpptraj')
+CPPTRAJ_MSG = ("This test requires cpptraj from AmberTools to be installed "
+               "(http://ambermd.org)")
+
 
 
 fd, temp = tempfile.mkstemp(suffix='.nc')
@@ -233,7 +240,7 @@ def test_trajectory_save_load():
     eq(t.xyz, t2.xyz)
     eq(t.unitcell_lengths, t2.unitcell_lengths)
 
-
+@skipif(not HAVE_CPPTRAJ, CPPTRAJ_MSG)
 def test_cpptraj():
     trj0 = md.load(get_fn('frame0.dcd'), top=get_fn('frame0.pdb'))
     trj0.save(temp)


### PR DESCRIPTION
`cpptraj` was refusing to read mdtraj-generated `.nc` files because we weren't following the spec to a T (or an "xyz")

This fixes it and adds a test. The test requires cpptraj. Should we skip on travis and how?