### PR TITLE
Fix setup.py develop with latest version of setuptools

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -261,6 +261,12 @@ class build_ext(_build_ext):
         else:
             _build_ext.build_extension(self, ext)
 
+    def copy_extensions_to_source(self):
+        _extensions = self.extensions
+        self.extensions = [e for e in _extensions if not isinstance(e, StaticLibrary)]
+        super(build_ext, self).copy_extensions_to_source()
+        self.extensions = _extensions
+
     def build_static_extension(self, ext):
         from distutils import log
 


### PR DESCRIPTION
`python setup.py develop` was not compatible with some of the distutils hacks in basesetup. fixed.