### PR TITLE
[setup] do not call parent function via super, because Extension is an old-style class.

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -5,8 +5,8 @@ import json
 import shutil
 import subprocess
 import tempfile
+from setuptools import Extension
 from distutils.dep_util import newer_group
-from distutils.core import Extension
 from distutils.errors import DistutilsExecError, DistutilsSetupError
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_vars
@@ -264,7 +264,7 @@ class build_ext(_build_ext):
     def copy_extensions_to_source(self):
         _extensions = self.extensions
         self.extensions = [e for e in _extensions if not isinstance(e, StaticLibrary)]
-        super(build_ext, self).copy_extensions_to_source()
+        _build_ext.copy_extensions_to_source(self)
         self.extensions = _extensions
 
     def build_static_extension(self, ext):


### PR DESCRIPTION
Without this change, one can not use python setup.py develop:
``` python
Traceback (most recent call last):
  File "setup.py", line 228, in <module>
    'mdinspect = mdtraj.scripts.mdinspect:entry_point']},
  File "/home/marscher/anaconda/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/home/marscher/anaconda/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/home/marscher/anaconda/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/marscher/anaconda/lib/python2.7/site-packages/setuptools/command/develop.py", line 32, in run
    self.install_for_development()
  File "/home/marscher/anaconda/lib/python2.7/site-packages/setuptools/command/develop.py", line 117, in install_for_development
    self.run_command('build_ext')
  File "/home/marscher/anaconda/lib/python2.7/distutils/cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "/home/marscher/anaconda/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/marscher/anaconda/lib/python2.7/site-packages/setuptools/command/build_ext.py", line 52, in run
    self.copy_extensions_to_source()
  File "./basesetup.py", line 267, in copy_extensions_to_source
    super(build_ext, self).copy_extensions_to_source()
TypeError: must be type, not classobj
```