### PR TITLE
[setup] require at least setuptools>=18 before doing anything.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ binpos, AMBER NetCDF, AMBER mdcrd, TINKER arc and MDTraj HDF5.
 """
 
 from __future__ import print_function, absolute_import
+__requires__=['setuptools>=18']
 
 DOCLINES = __doc__.split("\n")
 
@@ -194,8 +195,7 @@ extensions.extend(geometry_extensions())
 
 write_version_py(VERSION, ISRELEASED)
 
-try:
-    setup(name='mdtraj',
+setup(name='mdtraj',
       author='Robert McGibbon',
       author_email='rmcgibbo@gmail.com',
       description=DOCLINES[0],
@@ -227,11 +227,4 @@ try:
           ['mdconvert = mdtraj.scripts.mdconvert:entry_point',
            'mdinspect = mdtraj.scripts.mdinspect:entry_point']},
 )
-except pkg_resources.VersionConflict as vc:
-    if len(vc.args) == 2 and hasattr(vc.args[0], 'key') and vc.args[0].key == 'setuptools':
-        print('Your setuptools version %s is too old, please upgrade it.'
-              ' Eg. via "pip install setuptools -U"'
-              ' Detailed instructions can be found here: https://pypi.python.org/pypi/setuptools' %
-              vc.args[0].version)
-        sys.exit(1)
-    raise
+


### PR DESCRIPTION
This leads to the following error message (eg. with setuptools==17 installed):

``` python
$ python setup.py build_ext
Traceback (most recent call last):
  File "setup.py", line 17, in <module>
    import pkg_resources
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 3074, in <module>
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 3060, in _call_aside
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 3087, in _initialize_master_working_set
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 647, in _build_master
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 660, in _build_from_requirements
  File "/home/marscher/miniconda/lib/python2.7/site-packages/setuptools-17.0-py2.7.egg/pkg_resources/__init__.py", line 833, in resolve
pkg_resources.DistributionNotFound: The 'setuptools>=18' distribution was not found and is required by the application
```