### PR TITLE
Revert setup.py clever handling of numpy and cython

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -29,13 +29,20 @@ class CompilerDetection(object):
     _DONT_REMOVE_ME = get_config_vars()
 
     def __init__(self, disable_openmp):
+        self.disable_openmp = disable_openmp
+        self._is_initialized = False
+
+    def initialize(self):
+        if self._is_initialized:
+            return
+
         cc = new_compiler()
         customize_compiler(cc)
 
         self.msvc = cc.compiler_type == 'msvc'
         self._print_compiler_version(cc)
 
-        if disable_openmp:
+        if self.disable_openmp:
             self.openmp_enabled = False
         else:
             self.openmp_enabled, openmp_needs_gomp = self._detect_openmp()
@@ -69,7 +76,8 @@ class CompilerDetection(object):
         else:
             self.compiler_args_opt = ['-O3', '-funroll-loops']
         print()
-
+        self._is_initialized = True
+        
     def _print_compiler_version(self, cc):
         print("C compiler:")
         try:


### PR DESCRIPTION
Fixes #984. I really wish there were a way to have this feature work robustly, but unfortunately I don't think we're quite there yet.

Without numpy/cython installed, you will now get the following error message on installation.

```
$ pip install .               
Processing /home/rmcgibbo/projects/mdtraj
    Complete output from command python setup.py egg_info:
    --------------------------------------------------------------------------------
    Error: building mdtraj requires numpy and cython>=0.19
    
    Try running the command ``pip install numpy cython`` or
    ``conda install numpy cython``.
    
    or see http://docs.scipy.org/doc/numpy/user/install.html and
    http://cython.org/ for more information.
    
    If you're feeling lost, we recommend downloading the (free) Anaconda python
    distribution https://www.continuum.io/downloads, because it comes with
    these components included.
    --------------------------------------------------------------------------------
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-wkt17rok-build
```

or 


```
$ python setup.py install
--------------------------------------------------------------------------------
Error: building mdtraj requires numpy and cython>=0.19

Try running the command ``pip install numpy cython`` or
``conda install numpy cython``.

or see http://docs.scipy.org/doc/numpy/user/install.html and
http://cython.org/ for more information.

If you're feeling lost, we recommend downloading the (free) Anaconda python
distribution https://www.continuum.io/downloads, because it comes with
these components included.
--------------------------------------------------------------------------------
```