### PR TITLE
redundant matrices don't work in scipy.cluster

### DIFF
--- a/examples/clustering.ipynb
+++ b/examples/clustering.ipynb
@@ -20,7 +20,8 @@
     "import mdtraj as md\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import scipy.cluster.hierarchy"
+    "import scipy.cluster.hierarchy",
+    "from scipy.spatial.distance import squareform"
    ]
   },
   {
@@ -77,7 +78,8 @@
    },
    "outputs": [],
    "source": [
-    "linkage = scipy.cluster.hierarchy.ward(distances)"
+   
+    "linkage = scipy.cluster.hierarchy.ward(squareform(distances))"
    ]
   },
   {


### PR DESCRIPTION
One has to convert a redundant matrix to a condensed form for it to work with scipy.cluster.hierarchy.linkage(). See also: https://github.com/scipy/scipy/issues/5508