### PR TITLE
Improve speed/efficiency of 1 case of top.select_pairs

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - matplotlib
     - pandas
     # Hack to install shiftx2 on travis
-    {{ '- shiftx2' if environ.get('TRAVIS', False) == 'true' }}
+    {{ '- shiftx2' if environ.get('TRAVIS', False) == 'true' else "" }}
 
   commands:
     - nosetests mdtraj -v -s

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1018,21 +1018,33 @@ class Topology(object):
         # approach by removing the intermediate set creation required in
         # the general case.
         if np.array_equal(a_indices, b_indices):
-            pairs = np.fromiter(itertools.chain.from_iterable(
-                itertools.combinations(a_indices, 2)),
-                dtype=np.int32, count=len(a_indices) * (len(a_indices) - 1))
-            pairs = np.vstack((pairs[::2], pairs[1::2])).T
+            pairs = self._unique_pairs_equal(a_indices)
         elif len(np.intersect1d(a_indices, b_indices)) == 0:
-            pairs = np.fromiter(itertools.chain.from_iterable(
-                itertools.product(a_indices, b_indices)),
-                dtype=np.int32, count=len(a_indices) * len(b_indices) * 2)
-            pairs = np.vstack((pairs[::2], pairs[1::2])).T
+            pairs = self._unique_pairs_mutually_exclusive(a_indices, b_indices)
         else:
-            pairs = np.array(list(set(
-                (a, b) if a > b else (b, a)
-                for a, b in itertools.product(a_indices, b_indices)
-                if a != b)), dtype=np.int32)
+            pairs = self._unique_pairs(a_indices, b_indices)
         return pairs
+
+    @classmethod
+    def _unique_pairs(cls, a_indices, b_indices):
+        return np.array(list(set(
+            (a, b) if a > b else (b, a)
+            for a, b in itertools.product(a_indices, b_indices)
+            if a != b)), dtype=np.int32)
+
+    @classmethod
+    def _unique_pairs_mutually_exclusive(cls, a_indices, b_indices):
+        pairs = np.fromiter(itertools.chain.from_iterable(
+            itertools.product(a_indices, b_indices)),
+            dtype=np.int32, count=len(a_indices) * len(b_indices) * 2)
+        return np.vstack((pairs[::2], pairs[1::2])).T
+
+    @classmethod
+    def _unique_pairs_equal(cls, a_indices):
+        pairs = np.fromiter(itertools.chain.from_iterable(
+            itertools.combinations(a_indices, 2)),
+            dtype=np.int32, count=len(a_indices) * (len(a_indices) - 1))
+        return np.vstack((pairs[::2], pairs[1::2])).T
 
 
 class Chain(object):

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1013,12 +1013,19 @@ class Topology(object):
         b_indices.sort()
 
         # Create unique pairs from the indices.
+        # In the cases where a_indices and b_indices are identical or mutually
+        # exclusive, we can utilize a more efficient and memory friendly
+        # approach by removing the intermediate set creation required in
+        # the general case.
         if np.array_equal(a_indices, b_indices):
-            # This is more efficient and memory friendly by removing the
-            # intermediate set creation required in the case below.
             pairs = np.fromiter(itertools.chain.from_iterable(
                 itertools.combinations(a_indices, 2)),
                 dtype=np.int32, count=len(a_indices) * (len(a_indices) - 1))
+            pairs = np.vstack((pairs[::2], pairs[1::2])).T
+        elif len(np.intersect1d(a_indices, b_indices)) == 0:
+            pairs = np.fromiter(itertools.chain.from_iterable(
+                itertools.product(a_indices, b_indices)),
+                dtype=np.int32, count=len(a_indices) * len(b_indices) * 2)
             pairs = np.vstack((pairs[::2], pairs[1::2])).T
         else:
             pairs = np.array(list(set(

--- a/mdtraj/tests/test_topology.py
+++ b/mdtraj/tests/test_topology.py
@@ -197,15 +197,30 @@ def test_load_unknown_topology():
         assert False  # fail
 
 
-def test_select_pairs_args():
+def test_select_pairs():
     traj = md.load(get_fn('tip3p_300K_1ATM.pdb'))
-    assert len(traj.top.select_pairs(selection1='name O', selection2='name O')) == 258 * (258 - 1) // 2
-    assert (eq(traj.top.select_pairs(selection1="(name O) or (name =~ 'H.*')", selection2="(name O) or (name =~ 'H.*')").sort(),
-               traj.top.select_pairs(selection1='all', selection2='all').sort()))
-    assert (eq(traj.top.select_pairs(selection1="name O", selection2="name H1").sort(),
-               traj.top.select_pairs(selection1="name H1", selection2="name O").sort()))
-    assert (eq(traj.top.select_pairs(selection1=range(traj.n_atoms), selection2="(name O) or (name =~ 'H.*')").sort(),
-               traj.top.select_pairs(selection1='all', selection2='all').sort()))
+    select_pairs = traj.top.select_pairs
+
+    assert len(select_pairs(selection1='name O', selection2='name O')) == 258 * (258 - 1) // 2
+    assert len(select_pairs(selection1='name H1', selection2='name O')) == 258 * 258
+
+    selections = iter([
+        # Equal
+        ("(name O) or (name =~ 'H.*')", "(name O) or (name =~ 'H.*')"),
+        ('all', 'all'),
+
+        # Exclusive
+        ('name O', 'name H1'),
+        ('name H1', 'name O'),
+
+        # Overlap
+        (range(traj.n_atoms), 'name O'),
+        ('all', 'name O')])
+
+    for select1, select2 in selections:
+        select3, select4 = next(selections)
+        assert eq(select_pairs(selection1=select1, selection2=select2).sort(),
+                  select_pairs(selection1=select3, selection2=select4).sort())
 
 
 def test_to_fasta():

--- a/mdtraj/tests/test_topology.py
+++ b/mdtraj/tests/test_topology.py
@@ -197,6 +197,15 @@ def test_load_unknown_topology():
         assert False  # fail
 
 
+def test_unique_pairs():
+    n = 10
+    a = np.arange(n)
+    b = np.arange(n, n+n)
+
+    eq(md.Topology._unique_pairs(a, a).sort(), md.Topology._unique_pairs_equal(a).sort())
+    eq(md.Topology._unique_pairs(a, b).sort(), md.Topology._unique_pairs_mutually_exclusive(a, b).sort())
+
+
 def test_select_pairs():
     traj = md.load(get_fn('tip3p_300K_1ATM.pdb'))
     select_pairs = traj.top.select_pairs


### PR DESCRIPTION
This adds a more efficient pathway to unique pair generation when `a_indices` and `b_indices` are mutually exclusive. It might be time to role some cython code at this point though...

Also anyone have any better naming suggestions for the 3 methods?

