### PR TITLE
add segment_id as residue attribute

### DIFF
--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -116,6 +116,7 @@ class SelectionKeyword(object):
         (('residue', 'resSeq'), _chain('residue', 'resSeq')),
         (('resname', 'resn'), _chain('residue', 'name')),
         (('resid', 'resi'), _chain('residue', 'index')),
+        (('segment_id','segname',), _chain('segment_id')),
 
         # Atom.residue.chain.<attribute>
         (('chainid',), _chain('residue', 'chain', 'index')),

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -397,10 +397,10 @@ class Topology(object):
         pd = import_('pandas')
         data = [(atom.serial, atom.name, atom.element.symbol,
                  atom.residue.resSeq, atom.residue.name,
-                 atom.residue.chain.index) for atom in self.atoms]
+                 atom.residue.chain.index,atom.segment_id) for atom in self.atoms]
 
         atoms = pd.DataFrame(data, columns=["serial", "name", "element",
-                                            "resSeq", "resName", "chainID"])
+                                            "resSeq", "resName", "chainID","segmentID"])
 
         bonds = np.array([(a.index, b.index) for (a, b) in self.bonds])
         return atoms, bonds
@@ -434,7 +434,7 @@ class Topology(object):
             bonds = np.zeros((0, 2))
 
         for col in ["name", "element", "resSeq",
-                    "resName", "chainID", "serial"]:
+                    "resName", "chainID", "serial","segmentID"]:
             if col not in atoms.columns:
                 raise ValueError('dataframe must have column %s' % col)
 
@@ -459,10 +459,12 @@ class Topology(object):
                 residue_atoms = chain_atoms[chain_atoms['resSeq'] == ri]
                 rnames = residue_atoms['resName']
                 residue_name = np.array(rnames)[0]
+                segids = residue_atoms['segmentID']
+                segment_id = np.array(segids)[0]
                 if not np.all(rnames == residue_name):
                     raise ValueError('All of the atoms with residue index %d '
                                      'do not share the same residue name' % ri)
-                r = out.add_residue(residue_name, c, ri, residue.segment_id)
+                r = out.add_residue(residue_name, c, ri,segment_id)
 
                 for atom_index, atom in residue_atoms.iterrows():
                     atom_index = int(atom_index)  # Fixes bizarre hashing issue on Py3K.  See #545

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -91,7 +91,7 @@ def _topology_from_subset(topology, atom_indices):
         for residue in chain._residues:
             resSeq = getattr(residue, 'resSeq', None) or residue.index
             newResidue = newTopology.add_residue(residue.name, newChain,
-                                                 resSeq)
+                                                 resSeq, residue.segment_id)
             for atom in residue._atoms:
                 if atom.index in atom_indices:
                     try:  # OpenMM Topology objects don't have serial attributes, so we have to check first.
@@ -219,7 +219,7 @@ class Topology(object):
         for chain in self.chains:
             c = out.add_chain()
             for residue in chain.residues:
-                r = out.add_residue(residue.name, c, residue.resSeq)
+                r = out.add_residue(residue.name, c, residue.resSeq, residue.segment_id)
                 for atom in residue.atoms:
                     out.add_atom(atom.name, atom.element, r,
                                  serial=atom.serial)
@@ -265,7 +265,7 @@ class Topology(object):
         for chain in other.chains:
             c = out.add_chain()
             for residue in chain.residues:
-                r = out.add_residue(residue.name, c, residue.resSeq)
+                r = out.add_residue(residue.name, c, residue.resSeq, residue.segment_id)
                 for atom in residue.atoms:
                     a = out.add_atom(atom.name, atom.element, r,
                                      serial=atom.serial)
@@ -369,7 +369,7 @@ class Topology(object):
         for chain in value.chains():
             c = out.add_chain()
             for residue in chain.residues():
-                r = out.add_residue(residue.name, c)
+                r = out.add_residue(residue.name, c, residue.segment_id)
                 for atom in residue.atoms():
                     if atom.element is None:
                         element = elem.virtual
@@ -462,7 +462,7 @@ class Topology(object):
                 if not np.all(rnames == residue_name):
                     raise ValueError('All of the atoms with residue index %d '
                                      'do not share the same residue name' % ri)
-                r = out.add_residue(residue_name, c, ri)
+                r = out.add_residue(residue_name, c, ri, residue.segment_id)
 
                 for atom_index, atom in residue_atoms.iterrows():
                     atom_index = int(atom_index)  # Fixes bizarre hashing issue on Py3K.  See #545
@@ -572,7 +572,7 @@ class Topology(object):
         self._chains.append(chain)
         return chain
 
-    def add_residue(self, name, chain, resSeq=None):
+    def add_residue(self, name, chain, resSeq=None, segment_id=""):
         """Create a new Residue and add it to the Topology.
 
         Parameters
@@ -586,6 +586,8 @@ class Topology(object):
             numbers are arbitrary, and do not necessarily start at 0 (or 1).
             If not supplied, the resSeq attribute will be set to the
             residue's sequential (0 based) index.
+        segment_id : str, optional
+            A label for the segment to which this residue belongs
 
         Returns
         -------
@@ -594,7 +596,7 @@ class Topology(object):
         """
         if resSeq is None:
             resSeq = self._numResidues
-        residue = Residue(name, self._numResidues, chain, resSeq)
+        residue = Residue(name, self._numResidues, chain, resSeq, segment_id)
         self._residues.append(residue)
         self._numResidues += 1
         chain._residues.append(residue)
@@ -1169,15 +1171,18 @@ class Residue(object):
         The chain within which this residue belongs
     resSeq : int
         The residue sequence number
+    segment_id : str, optional
+        A label for the segment to which this residue belongs
     """
 
-    def __init__(self, name, index, chain, resSeq):
+    def __init__(self, name, index, chain, resSeq, segment_id=''):
         """Construct a new Residue.  You should call add_residue()
         on the Topology instead of calling this directly."""
         self.name = name
         self.index = index
         self.chain = chain
         self.resSeq = resSeq
+        self.segment_id = segment_id
         self._atoms = []
 
     @property
@@ -1325,6 +1330,11 @@ class Atom(object):
         """Whether the atom is in the sidechain of a protein residue"""
         return (self.name not in set(['C', 'CA', 'N', 'O'])
                 and self.residue.is_protein)
+
+    @property
+    def segment_id(self):
+        """User specified segment_id of the residue to which this atom belongs"""
+        return self.residue.segment_id
 
     def __eq__(self, other):
         """ Check whether two Atom objects are equal. """

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -416,7 +416,8 @@ class Topology(object):
             frame should have columns "serial" (atom index), "name" (atom name),
             "element" (atom's element), "resSeq" (index of the residue)
             "resName" (name of the residue), "chainID" (index of the chain),
-            following the same conventions as wwPDB 3.0 format.
+            and optionally "segmentID", following the same conventions 
+            as wwPDB 3.0 format.
         bonds : np.ndarray, shape=(n_bonds, 2), dtype=int, optional
             The bonds in the topology, represented as an n_bonds x 2 array
             of the indices of the atoms involved in each bond. Specifiying
@@ -434,9 +435,12 @@ class Topology(object):
             bonds = np.zeros((0, 2))
 
         for col in ["name", "element", "resSeq",
-                    "resName", "chainID", "serial","segmentID"]:
+                    "resName", "chainID", "serial"]:
             if col not in atoms.columns:
                 raise ValueError('dataframe must have column %s' % col)
+
+        if "segmentID" not in atoms.columns:
+            atoms["segmentID"] = ""
 
         out = cls()
         if not isinstance(atoms, pd.DataFrame):

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -283,7 +283,12 @@ class HDF5TrajectoryFile(object):
                 except KeyError:
                     resSeq = None
                     warnings.warn('No resSeq information found in HDF file, defaulting to zero-based indices')
-                residue = topology.add_residue(residue_dict['name'], chain, resSeq=resSeq)
+                try:
+                    segment_id = residue_dict["segmentID"]
+                except KeyError:
+                    segment_id = ""
+                    warnings.warn('No segment_id information found in HDF file, setting as blank')
+                residue = topology.add_residue(residue_dict['name'], chain, resSeq=resSeq, segment_id=segment_id)
                 for atom_dict in sorted(residue_dict['atoms'], key=operator.itemgetter('index')):
                     try:
                         element = elem.get_by_symbol(atom_dict['element'])
@@ -330,7 +335,8 @@ class HDF5TrajectoryFile(object):
                         'index': int(residue.index),
                         'name': str(residue.name),
                         'atoms': [],
-                        "resSeq": int(residue.resSeq)
+                        "resSeq": int(residue.resSeq), 
+                        "segmentID": str(residue.segment_id)
                     }
 
                     for atom in residue.atoms:

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -511,7 +511,7 @@ class PDBTrajectoryFile(object):
                 resName = residue.get_name()
                 if resName in PDBTrajectoryFile._residueNameReplacements:
                     resName = PDBTrajectoryFile._residueNameReplacements[resName]
-                r = self._topology.add_residue(resName, c, residue.number)
+                r = self._topology.add_residue(resName, c, residue.number, residue.segment_id)
                 if resName in PDBTrajectoryFile._atomNameReplacements:
                     atomReplacements = PDBTrajectoryFile._atomNameReplacements[resName]
                 else:

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -337,11 +337,11 @@ class PDBTrajectoryFile(object):
                         symbol = atom.element.symbol
                     else:
                         symbol = ' '
-                    line = "ATOM  %5d %-4s %3s %s%4d    %s%s%s  1.00 %s          %2s  " % (
+                    line = "ATOM  %5d %-4s %3s %1s%4d    %s%s%s  1.00 %5s      %-4s%-2s  " % (
                         atomIndex % 100000, atomName, resName, chainName,
                         (res.resSeq) % 10000, _format_83(coords[0]),
                         _format_83(coords[1]), _format_83(coords[2]),
-                        bfactors[posIndex], symbol)
+                        bfactors[posIndex], atom.segment_id[:4], symbol[-2:])
                     assert len(line) == 80, 'Fixed width overflow detected'
                     print(line, file=self._file)
                     posIndex += 1

--- a/mdtraj/formats/pdb/pdbstructure.py
+++ b/mdtraj/formats/pdb/pdbstructure.py
@@ -418,12 +418,12 @@ class Chain(object):
         """
         # Create a residue if none have been created
         if len(self.residues) == 0:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         # Create a residue if the residue information has changed
         elif self._current_residue.number != atom.residue_number:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         elif self._current_residue.insertion_code != atom.insertion_code:
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         elif self._current_residue.name_with_spaces == atom.residue_name_with_spaces:
             # This is a normal case: number, name, and iCode have not changed
             pass
@@ -433,7 +433,7 @@ class Chain(object):
         else: # Residue name does not match
             # Only residue name does not match
             warnings.warn("WARNING: two consecutive residues with same number (%s, %s)" % (atom, self._current_residue.atoms[-1]))
-            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator))
+            self._add_residue(Residue(atom.residue_name_with_spaces, atom.residue_number, atom.insertion_code, atom.alternate_location_indicator,atom.segment_id))
         self._current_residue._add_atom(atom)
 
     def _add_residue(self, residue):
@@ -499,9 +499,10 @@ class Chain(object):
 
 
 class Residue(object):
-    def __init__(self, name, number, insertion_code=' ', primary_alternate_location_indicator=' '):
+    def __init__(self, name, number, insertion_code=' ', primary_alternate_location_indicator=' ',segment_id=''):
         alt_loc = primary_alternate_location_indicator
         self.primary_location_id = alt_loc
+        self.segment_id = segment_id
         self.locations = {}
         self.locations[alt_loc] = Residue.Location(alt_loc, name)
         self.name_with_spaces = name

--- a/mdtraj/formats/pdb/tests/test_pdb.py
+++ b/mdtraj/formats/pdb/tests/test_pdb.py
@@ -237,6 +237,21 @@ def test_1vii_url_and_gz():
     eq(t1.n_atoms, t3.n_atoms)
     eq(t1.n_atoms, t4.n_atoms)
 
+def test_segment_id():
+    pdb = load_pdb(get_fn('ala_ala_ala.pdb'))
+    pdb.save_pdb(temp)
+    pdb2 = load_pdb(temp)
+
+    correct_segment_id = 'AAL'
+    # check that all segment ids are set correctly
+    for ridx,r in enumerate(pdb.top.residues):
+        assert r.segment_id == correct_segment_id, "residue %i (0-indexed) does not have segment_id set correctly from ala_ala_ala.pdb"%(ridx)
+
+    # check that all segment ids are set correctly after a new pdb file is written
+    for ridx,(r1,r2) in enumerate(zip(pdb.top.residues,pdb2.top.residues)):
+        assert r1.segment_id == r2.segment_id, "segment_id of residue %i (0-indexed) in ala_ala_ala.pdb does not agree with value in after being written out to a new pdb file"%(ridx)
+    
+
 def test_bfactors():
     pdb = load_pdb(get_fn('native.pdb'))
     bfactors0 = np.arange(pdb.n_atoms) / 2.0 - 4.0 # (Get some decimals..)

--- a/mdtraj/formats/psf.py
+++ b/mdtraj/formats/psf.py
@@ -237,7 +237,7 @@ def load_psf(fname):
                 rname = pdb.PDBTrajectoryFile._residueNameReplacements[rname]
             except KeyError:
                 pass
-            r = top.add_residue(rname, c, resid)
+            r = top.add_residue(rname, c, resid, segid)
 
         try:
             name = pdb.PDBTrajectoryFile._atomNameReplacements[rname][name]

--- a/mdtraj/tests/test_psf.py
+++ b/mdtraj/tests/test_psf.py
@@ -38,6 +38,9 @@ def test_load_psf():
     # Test the XPLOR psf format parsing
     top2 = psf.load_psf(get_fn('ala_ala_ala.xpsf'))
     eq(top2, ref_top)
+    # Test segment_names are loaded properly
+    assert top.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
+    assert top2.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.xpsf"
 
 def test_multichain_psf():
     top = psf.load_psf(get_fn('3pqr_memb.psf'))

--- a/mdtraj/tests/test_psf.py
+++ b/mdtraj/tests/test_psf.py
@@ -39,8 +39,8 @@ def test_load_psf():
     top2 = psf.load_psf(get_fn('ala_ala_ala.xpsf'))
     eq(top2, ref_top)
     # Test segment_names are loaded properly
-    assert top.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
-    assert top2.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.xpsf"
+    assert next(top.residues).segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
+    assert next(top2.residues).segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.xpsf"
 
 def test_multichain_psf():
     top = psf.load_psf(get_fn('3pqr_memb.psf'))

--- a/mdtraj/tests/test_topology.py
+++ b/mdtraj/tests/test_topology.py
@@ -121,7 +121,7 @@ def test_residue():
 
 def test_segment_id():
     top = md.load(get_fn('ala_ala_ala.pdb')).topology
-    assert top.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
+    assert next(top.residues).segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
     df = top.to_dataframe()[0]
     assert len(df["segmentID"] == "AAL")==len(df), "Segment id is not being assigned correctly to topology data frame ala_ala_ala.psf"
 

--- a/mdtraj/tests/test_topology.py
+++ b/mdtraj/tests/test_topology.py
@@ -42,7 +42,6 @@ try:
 except ImportError:
     HAVE_PANDAS = False
 
-
 @skipif(not HAVE_OPENMM)
 def test_topology_openmm():
     topology = md.load(get_fn('1bpi.pdb')).topology
@@ -120,6 +119,11 @@ def test_residue():
     for i in range(residue.n_atoms):
         assert residue.atom(i) == atoms[i]
 
+def test_segment_id():
+    top = md.load(get_fn('ala_ala_ala.pdb')).topology
+    assert top.residues.next().segment_id == "AAL", "Segment id is not being assigned correctly for ala_ala_ala.psf"
+    df = top.to_dataframe()[0]
+    assert len(df["segmentID"] == "AAL")==len(df), "Segment id is not being assigned correctly to topology data frame ala_ala_ala.psf"
 
 def test_nonconsective_resSeq():
     t = md.load(get_fn('nonconsecutive_resSeq.pdb'))


### PR DESCRIPTION
Both psf and pdb topology readers get a segment_id from files, but this is not stored anywhere. This is an extremely useful way to do selections for systems with complex topology (vs chains, which are numbered).

Segment_id is now elevated to a main, although not required, property of the residue class. 
Segment_id is read from psf and pdb file readers and stored in this attribute. It has also been added to the data frame object list of columns (which could be a problem if anyone is storing topologies as data frames for future use). 
Segment_id or segname (vmd style) can be used in atom selections.

save_pdb has been adjusted to write out segment_id in the proper style. 
I believe I have also successfully added segment_id to the topology information in hdf5 writing without breaking backwards compatibility to previously saved hdf5 files (a warning is raised that there is no segment_id information). 

Tests have been added to make sure these features are working based on the tri-alanene pdb and psf files, which is not ideal since there is only a single segment name for the entire structure. 