### PR TITLE
Small cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ nosetests.xml
 # PyCharm
 .idea
 mdtraj/tests/.ipynb_checkpoints
+mdtraj/geometry/drid.cpp

--- a/basesetup.py
+++ b/basesetup.py
@@ -51,6 +51,7 @@ class CompilerDetection(object):
 
         self.compiler_args_sse2  = ['-msse2'] if not self.msvc else ['/arch:SSE2']
         self.compiler_args_sse3  = ['-mssse3'] if (self.sse3_enabled and not self.msvc) else []
+        self.compiler_args_warn = ['-Wno-unused-function', '-Wno-unreachable-code'] if not self.msvc else []
 
         self.compiler_args_sse41, self.define_macros_sse41 = [], []
         if self.sse41_enabled:
@@ -77,7 +78,7 @@ class CompilerDetection(object):
             self.compiler_args_opt = ['-O3', '-funroll-loops']
         print()
         self._is_initialized = True
-        
+
     def _print_compiler_version(self, cc):
         print("C compiler:")
         try:

--- a/mdtraj/formats/binpos/src/binposplugin.c
+++ b/mdtraj/formats/binpos/src/binposplugin.c
@@ -39,7 +39,7 @@ typedef struct {
   float *xyz;
 } binposhandle;
 
-void *open_binpos_read(const char *path, const char *filetype, 
+void *open_binpos_read(const char *path, const char *filetype,
     int *natoms) {
   binposhandle *binpos;
   FILE *fd;
@@ -49,7 +49,7 @@ void *open_binpos_read(const char *path, const char *filetype,
   char magicchar[5];
 
   fd = fopen(path, "rb");
-  if (!fd) 
+  if (!fd)
    {
     fprintf(stderr, "Could not open file '%s' for reading.\n", path);
     return NULL;
@@ -82,7 +82,7 @@ void *open_binpos_read(const char *path, const char *filetype,
 	if((fseek(fd, point, SEEK_SET))!=0)
       {
 	  fprintf(stderr,"Endian correction failed. er=%d\n",er);
-      return NULL;	
+      return NULL;
      }
 	fseek(fd, point, SEEK_SET);
    }
@@ -105,7 +105,7 @@ int seek_timestep(void* v, long int offset, int origin) {
     int numatoms;
 
     binpos = (binposhandle *)v;
-    if (!binpos->fd) 
+    if (!binpos->fd)
       return MOLFILE_ERROR;
     numatoms = binpos->numatoms;
 
@@ -125,11 +125,11 @@ int seek_timestep(void* v, long int offset, int origin) {
 
 long int tell_timestep(void* v) {
     binposhandle *binpos;
-    int i, numatoms, frame;
+    int numatoms, frame;
     long int offset;
 
     binpos = (binposhandle *)v;
-    if (!binpos->fd) 
+    if (!binpos->fd)
       return MOLFILE_ERROR;
     numatoms = binpos->numatoms;
     offset = ftell(binpos->fd);
@@ -152,7 +152,7 @@ int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
   char tmpc;
 
   binpos = (binposhandle *)v;
-  if (!binpos->fd) 
+  if (!binpos->fd)
     return MOLFILE_ERROR;  /* Done reading frames */
 
   numatoms = binpos->numatoms;
@@ -182,8 +182,8 @@ int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
     }
   }
   /*
-   * Close the file handle and set to NULL so we know we're done reading 
-   * 
+   * Close the file handle and set to NULL so we know we're done reading
+   *
    */
 
   if((fread(&igarb,sizeof(int),1,binpos->fd))!=1)
@@ -193,7 +193,7 @@ int read_next_timestep(void *v, int natoms, molfile_timestep_t *ts) {
    }
   return MOLFILE_SUCCESS;
 }
- 
+
 void close_file_read(void *v) {
   binposhandle *binpos = (binposhandle *)v;
   if (binpos->fd)
@@ -222,11 +222,11 @@ void *open_binpos_write(const char *path, const char *filetype, int natoms) {
 }
 
 int write_timestep(void *v, const molfile_timestep_t *ts) {
-  
+
   int i,numatoms;
 
   binposhandle *binpos = (binposhandle *)v;
-  
+
   if (!binpos->fd)
     return MOLFILE_ERROR;
 
@@ -236,7 +236,7 @@ int write_timestep(void *v, const molfile_timestep_t *ts) {
 
   fwrite(&numatoms, 4, 1, binpos->fd);
 
-  for (i=0; i<3*numatoms; i++) 
+  for (i=0; i<3*numatoms; i++)
    {
     float tmp = ts->coords[i];
     if (fwrite(&tmp, sizeof(float), 1, binpos->fd) != 1) {
@@ -253,7 +253,7 @@ int write_timestep(void *v, const molfile_timestep_t *ts) {
 
   return MOLFILE_SUCCESS;
 }
-       
+
 void close_file_write(void *v) {
   binposhandle *binpos = (binposhandle *)v;
   if (binpos->fd)

--- a/mdtraj/geometry/include/dridkernels.h
+++ b/mdtraj/geometry/include/dridkernels.h
@@ -1,11 +1,17 @@
 #ifndef _MDTRAJ_DRIDKERNELS_H_
 #define _MDTRAJ_DRIDKERNELS_H_
 
+#ifdef _MSC_VER
+typedef __int32 int32_t;
+#else
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-int drid_moments(float* coords, int index, int* partners, int n_partners, double* moments);
+int drid_moments(float* coords, int32_t index, int32_t* partners, int32_t n_partners, double* moments);
 
 #ifdef __cplusplus
 }

--- a/mdtraj/geometry/src/dridkernels.c
+++ b/mdtraj/geometry/src/dridkernels.c
@@ -30,13 +30,13 @@
 #include "cbrt.h"
 
 int
-drid_moments(float* coords, int index, int* partners, int n_partners, double* moments)
+drid_moments(float* coords, int32_t index, int32_t* partners, int32_t n_partners, double* moments)
 {
-    int i;
+    int32_t i;
     float d;
     moments_t onlinemoments;
     __m128 x, y, r, r2, s;
-    
+
     moments_clear(&onlinemoments);
     x = load_float3(&coords[3 * index]);
 

--- a/mdtraj/geometry/src/moments.c
+++ b/mdtraj/geometry/src/moments.c
@@ -58,8 +58,8 @@ void moments_clear(moments_t *self) {
 /* Push a number or a set of numbers onto the RunningMoments */
 void moments_push(moments_t *self, double x) {
     int n1;
-    double delta, term1, delta_n, delta_n2;
-    
+    double delta, term1, delta_n;  //, delta_n2;
+
     n1 = self->_n;
     self->_n += 1;
     delta = x - self->_u;

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -57,6 +57,8 @@ cdef extern from "math.h":
 # External (Public) Functions
 ##############################################################################
 
+
+@cython.boundscheck(False)
 def rmsd(target, reference, int frame=0, atom_indices=None,
          ref_atom_indices=None, bool parallel=True, bool precentered=False):
     """rmsd(target, reference, frame=0, atom_indices=None, parallel=True, precentered=False)

--- a/mdtraj/rmsd/src/Munkres.cpp
+++ b/mdtraj/rmsd/src/Munkres.cpp
@@ -1,15 +1,15 @@
 // This code was downloaded from https://github.com/jfrelinger/cython-munkres-wrapper
 // accessed March 13, 2014.
-// 
+//
 // Copyright (c) 2012, Jacob Frelinger
 // All rights reserved.
 
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-// 
+//
 //    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 //    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
 //////////////////////////////////////////////////////////////////
 
 /*
@@ -25,7 +25,7 @@
 #include <math.h>
 #include <limits>
 #include <vector>
-#include <algorithm> 
+#include <algorithm>
 
 //using namespace std;
 //using std::vector;
@@ -256,19 +256,19 @@ void Munkres::step5(int i, int j) {
 		}
 	}
 	// remove all primes
-	for (unsigned int i = 0; i < rows; i++) {
-		for (unsigned int j = 0; j < cols; j++) {
+	for (int i = 0; i < rows; i++) {
+		for (int j = 0; j < cols; j++) {
 			primed[i][j] = 0;
 		}
 	}
-	for (unsigned int i = 0; i < rows; i++) {
+	for (int i = 0; i < rows; i++) {
 		covered_rows[i] = 0;
 	}
 	// uncover all covered lines
-	for (unsigned int i = 0; i < rows; i++) {
+	for (int i = 0; i < rows; i++) {
 		covered_rows[i] = 0;
 	}
-	for (unsigned int i = 0; i < cols; i++) {
+	for (int i = 0; i < cols; i++) {
 		covered_cols[i] = 0;
 	}
 	step3();

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ Operating System :: MacOS
 
 # Global info about compiler
 compiler = CompilerDetection(disable_openmp)
+compiler.initialize()
 
 extra_cpp_libraries = []
 if sys.platform == 'darwin':
@@ -91,31 +92,37 @@ if sys.platform == 'win32':
 ################################################################################
 
 def format_extensions():
+    compiler_args = compiler.compiler_args_warn
+
     xtc = Extension('mdtraj.formats.xtc',
                     sources=['mdtraj/formats/xtc/src/xdrfile.c',
                              'mdtraj/formats/xtc/src/xdrfile_xtc.c',
                              'mdtraj/formats/xtc/xtc.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
-                                  'mdtraj/formats/xtc/'])
+                                  'mdtraj/formats/xtc/'],
+                    extra_compile_args=compiler_args)
 
     trr = Extension('mdtraj.formats.trr',
                     sources=['mdtraj/formats/xtc/src/xdrfile.c',
                              'mdtraj/formats/xtc/src/xdrfile_trr.c',
                              'mdtraj/formats/xtc/trr.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
-                                  'mdtraj/formats/xtc/'])
+                                  'mdtraj/formats/xtc/'],
+                    extra_compile_args=compiler_args)
 
     dcd = Extension('mdtraj.formats.dcd',
                     sources=['mdtraj/formats/dcd/src/dcdplugin.c',
                              'mdtraj/formats/dcd/dcd.pyx'],
                     include_dirs=["mdtraj/formats/dcd/include/",
-                                  'mdtraj/formats/dcd/'])
+                                  'mdtraj/formats/dcd/'],
+                    extra_compile_args=compiler_args)
 
     binpos = Extension('mdtraj.formats.binpos',
                        sources=['mdtraj/formats/binpos/src/binposplugin.c',
                                 'mdtraj/formats/binpos/binpos.pyx'],
                        include_dirs=['mdtraj/formats/binpos/include/',
-                                     'mdtraj/formats/binpos/'])
+                                     'mdtraj/formats/binpos/'],
+                       extra_compile_args=compiler_args)
 
     dtr = Extension('mdtraj.formats.dtr',
                     sources=['mdtraj/formats/dtr/src/dtrplugin.cxx',
@@ -124,15 +131,16 @@ def format_extensions():
                                   'mdtraj/formats/dtr/'],
                     define_macros=[('DESRES_READ_TIMESTEP2', 1)],
                     language='c++',
+                    extra_compile_args=compiler_args,
                     libraries=extra_cpp_libraries)
 
     return [xtc, trr, dcd, binpos, dtr]
 
 
 def rmsd_extensions():
-    compiler.initialize()
     compiler_args = (compiler.compiler_args_openmp + compiler.compiler_args_sse2 +
-                     compiler.compiler_args_sse3 + compiler.compiler_args_opt)
+                     compiler.compiler_args_sse3 + compiler.compiler_args_opt +
+                     compiler.compiler_args_warn)
     compiler_libraries = compiler.compiler_libraries_openmp
 
     libtheobald = StaticLibrary(
@@ -178,7 +186,7 @@ def rmsd_extensions():
 def geometry_extensions():
     compiler.initialize()
     compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
-                     compiler.compiler_args_opt)
+                     compiler.compiler_args_opt + compiler.compiler_args_warn)
     define_macros = None
 
     return [
@@ -202,7 +210,8 @@ def geometry_extensions():
             include_dirs=["mdtraj/geometry/include",
                           "mdtraj/geometry/include/cephes"],
             define_macros=define_macros,
-            extra_compile_args=compiler_args),
+            extra_compile_args=compiler_args,
+            language='c++'),
         Extension('mdtraj.geometry.neighbors',
             sources=["mdtraj/geometry/neighbors.pyx",
                      "mdtraj/geometry/src/neighbors.cpp"],


### PR DESCRIPTION
- [x] Remove some useless noise warnings produced by gcc/clang on the cython-generated C code (unused functions and dead code)
- [x] Remove a couple unused variables in C
- [x] Change some cython to use more modern typed memoryviews. 