### PR TITLE
Add new test runner for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ nosetests.xml
 .idea
 mdtraj/tests/.ipynb_checkpoints
 mdtraj/geometry/drid.cpp
+.cache
+build.log

--- a/mdtraj/__init__.py
+++ b/mdtraj/__init__.py
@@ -57,7 +57,7 @@ from mdtraj.core.trajectory import *
 from mdtraj.nmr import *
 import mdtraj.reporters
 
-def test(label='full', verbose=2):
+def test(label='full', verbose=2, extra_argv=None, doctests=False):
     """Run tests for mdtraj using nose.
 
     Parameters

--- a/mdtraj/__init__.py
+++ b/mdtraj/__init__.py
@@ -71,7 +71,7 @@ def test(label='full', verbose=2, extra_argv=None, doctests=False):
     import mdtraj
     from mdtraj.testing.nosetester import MDTrajTester
     tester = MDTrajTester(mdtraj)
-    return tester.test(label=label, verbose=verbose, extra_argv=('--exe',))
+    return tester.test(label=label, verbose=verbose, extra_argv=extra_argv)
 # prevent nose from discovering this function, or otherwise when its run
 # the test suite in an infinite loop
 test.__test__ = False

--- a/mdtraj/testing/nosetester.py
+++ b/mdtraj/testing/nosetester.py
@@ -28,7 +28,6 @@ from numpy.testing import Tester
 
 class MDTrajTester(Tester):
     def _show_system_info(self):
-        super(MDTrajTester, self)._show_system_info()
         print('mdtraj version %s' % mdtraj.version.version)
         print('mdtraj is installed in %s' % os.path.dirname(mdtraj.__file__))
 
@@ -38,12 +37,5 @@ class MDTrajTester(Tester):
             print('tables hdf5 version %s' % tables.hdf5Version)
         except ImportError:
             print('tables is not installed')
-
-        try:
-            import netCDF4
-            print('netCDF4 version %s' % netCDF4.__version__)
-            print('netCDF4 lib version %s' % netCDF4.getlibversion())
-        except ImportError:
-            print('netCDF4 not installed')
 
 

--- a/mdtraj/tests/test_psf.py
+++ b/mdtraj/tests/test_psf.py
@@ -32,6 +32,7 @@ VMD_MSG = 'This test requires the VMD executable: http://www.ks.uiuc.edu/Researc
 
 
 def test_load_psf():
+    print('sddsfsfdsdsdf')
     top = psf.load_psf(get_fn('ala_ala_ala.psf'))
     ref_top = md.load(get_fn('ala_ala_ala.pdb')).topology
     eq(top, ref_top)
@@ -113,7 +114,7 @@ exit
     with enter_temp_directory():
         with open('script.tcl', 'w') as f:
             f.write(TEMPLATE)
-        os.system(' '.join([VMD.replace(' ', '\ '), '-e', 'script.tcl', 
+        os.system(' '.join([VMD.replace(' ', '\ '), '-e', 'script.tcl',
             '-dispdev', 'none']))
         out_pdb = md.load('out.pdb')
         out_psf = md.load_psf('out.psf')

--- a/runtests.py
+++ b/runtests.py
@@ -26,7 +26,7 @@ from __future__ import division, print_function
 
 PROJECT_MODULE = "mdtraj"
 PROJECT_ROOT_FILES = ['mdtraj', 'LICENSE', 'setup.py']
-SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py:test_byteorder_check"
+SAMPLE_TEST = "mdtraj/tests/test_trajectory.py:test_load"
 
 EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',
               '/usr/local/lib/ccache', '/usr/local/lib/f90cache']
@@ -57,8 +57,11 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 
 def main(argv):
     parser = ArgumentParser(usage=__doc__.lstrip())
-    parser.add_argument("--verbose", "-v", action="count", default=1,
+    parser.add_argument("--verbose", "-v", action="count", default=2,
                         help="more verbosity")
+    # parser.add_argument('--nocapture', '-s', help="Don't capture stdout (any "
+    #                     "stdout output will be pr printed immediately",
+    #                     action='store_true')
     parser.add_argument("--no-build", "-n", action="store_true", default=False,
                         help="do not build the project (use system installed version)")
     parser.add_argument("--build-only", "-b", action="store_true", default=False,
@@ -100,6 +103,9 @@ def main(argv):
     extra_argv = args.args[:]
     if extra_argv and extra_argv[0] == '--':
         extra_argv = extra_argv[1:]
+
+    # if args.nocapture:
+    #     extra_argv += ['-s']
 
     if args.python:
         # Debugging issues with warnings is much easier if you can see them
@@ -154,7 +160,7 @@ def main(argv):
             extra_argv = kw.pop('extra_argv', ())
             extra_argv = extra_argv + tests[1:]
             kw['extra_argv'] = extra_argv
-            from numpy.testing import Tester
+            from mdtraj.testing.nosetester import MDTrajTester as Tester
             return Tester(tests[0]).test(*a, **kw)
     else:
         __import__(PROJECT_MODULE)

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+"""
+runtests.py [OPTIONS] [-- ARGS]
+
+Run tests, building the project first.
+
+Examples::
+
+    $ python runtests.py
+    $ python runtests.py -t {SAMPLE_TEST}
+    $ python runtests.py --ipython
+    $ python runtests.py --python somescript.py
+    $ python runtests.py --bench
+
+Run a debugger:
+
+    $ gdb --args python runtests.py [...other args...]
+
+"""
+from __future__ import division, print_function
+
+#
+# This is a generic test runner script for projects using Numpy's test
+# framework. Change the following values to adapt to your project:
+#
+
+PROJECT_MODULE = "mdtraj"
+PROJECT_ROOT_FILES = ['mdtraj', 'LICENSE', 'setup.py']
+SAMPLE_TEST = "numpy/linalg/tests/test_linalg.py:test_byteorder_check"
+
+EXTRA_PATH = ['/usr/lib/ccache', '/usr/lib/f90cache',
+              '/usr/local/lib/ccache', '/usr/local/lib/f90cache']
+
+# ---------------------------------------------------------------------
+
+
+if __doc__ is None:
+    __doc__ = "Run without -OO if you want usage info"
+else:
+    __doc__ = __doc__.format(**globals())
+
+
+import sys
+import os
+
+# In case we are run from the source directory, we don't want to import the
+# project from there:
+sys.path.pop(0)
+
+import shutil
+import subprocess
+import time
+import imp
+from argparse import ArgumentParser, REMAINDER
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
+
+def main(argv):
+    parser = ArgumentParser(usage=__doc__.lstrip())
+    parser.add_argument("--verbose", "-v", action="count", default=1,
+                        help="more verbosity")
+    parser.add_argument("--no-build", "-n", action="store_true", default=False,
+                        help="do not build the project (use system installed version)")
+    parser.add_argument("--build-only", "-b", action="store_true", default=False,
+                        help="just build, do not run any tests")
+    parser.add_argument("--doctests", action="store_true", default=False,
+                        help="Run doctests in module")
+    parser.add_argument("--mode", "-m", default="fast",
+                        help="'fast', 'full', or something that could be "
+                             "passed to nosetests -A [default: fast]")
+    parser.add_argument("--pythonpath", "-p", default=None,
+                        help="Paths to prepend to PYTHONPATH")
+    parser.add_argument("--tests", "-t", action='append',
+                        help="Specify tests to run")
+    parser.add_argument("--python", action="store_true",
+                        help="Start a Python shell with PYTHONPATH set")
+    parser.add_argument("--ipython", "-i", action="store_true",
+                        help="Start IPython shell with PYTHONPATH set")
+    parser.add_argument("--shell", action="store_true",
+                        help="Start Unix shell with PYTHONPATH set")
+    parser.add_argument("--debug", "-g", action="store_true",
+                        help="Debug build")
+    parser.add_argument("--parallel", "-j", type=int, default=0,
+                        help="Number of parallel jobs during build")
+    parser.add_argument("--show-build-log", action="store_true",
+                        help="Show build output rather than using a log file")
+    parser.add_argument("args", metavar="ARGS", default=[], nargs=REMAINDER,
+                        help="Arguments to pass to Nose, Python or shell")
+    args = parser.parse_args(argv)
+
+    if args.pythonpath:
+        for p in reversed(args.pythonpath.split(os.pathsep)):
+            sys.path.insert(0, p)
+
+    if not args.no_build:
+        site_dir = build_project(args)
+        sys.path.insert(0, site_dir)
+        os.environ['PYTHONPATH'] = site_dir
+
+    extra_argv = args.args[:]
+    if extra_argv and extra_argv[0] == '--':
+        extra_argv = extra_argv[1:]
+
+    if args.python:
+        # Debugging issues with warnings is much easier if you can see them
+        print("Enabling display of all warnings")
+        import warnings; warnings.filterwarnings("always")
+        if extra_argv:
+            # Don't use subprocess, since we don't want to include the
+            # current path in PYTHONPATH.
+            sys.argv = extra_argv
+            with open(extra_argv[0], 'r') as f:
+                script = f.read()
+            sys.modules['__main__'] = imp.new_module('__main__')
+            ns = dict(__name__='__main__',
+                      __file__=extra_argv[0])
+            exec_(script, ns)
+            sys.exit(0)
+        else:
+            import code
+            code.interact()
+            sys.exit(0)
+
+    if args.ipython:
+        # Debugging issues with warnings is much easier if you can see them
+        print("Enabling display of all warnings and pre-importing numpy as np")
+        import warnings; warnings.filterwarnings("always")
+        import IPython
+        import numpy as np
+        IPython.embed(user_ns={"np": np})
+        sys.exit(0)
+
+    if args.shell:
+        shell = os.environ.get('SHELL', 'sh')
+        print("Spawning a Unix shell...")
+        os.execv(shell, [shell] + extra_argv)
+        sys.exit(1)
+
+    test_dir = os.path.join(ROOT_DIR, 'build', 'test')
+
+    if args.build_only:
+        sys.exit(0)
+    elif args.tests:
+        def fix_test_path(x):
+            # fix up test path
+            p = x.split(':')
+            p[0] = os.path.relpath(os.path.abspath(p[0]),
+                                   test_dir)
+            return ':'.join(p)
+
+        tests = [fix_test_path(x) for x in args.tests]
+
+        def test(*a, **kw):
+            extra_argv = kw.pop('extra_argv', ())
+            extra_argv = extra_argv + tests[1:]
+            kw['extra_argv'] = extra_argv
+            from numpy.testing import Tester
+            return Tester(tests[0]).test(*a, **kw)
+    else:
+        __import__(PROJECT_MODULE)
+        test = sys.modules[PROJECT_MODULE].test
+
+    # Run the tests under build/test
+    try:
+        shutil.rmtree(test_dir)
+    except OSError:
+        pass
+    try:
+        os.makedirs(test_dir)
+    except OSError:
+        pass
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(test_dir)
+        result = test(args.mode,
+                      verbose=args.verbose,
+                      extra_argv=extra_argv,
+                      doctests=args.doctests)
+    finally:
+        os.chdir(cwd)
+
+    if result.wasSuccessful():
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+def build_project(args):
+    """
+    Build a dev version of the project.
+
+    Returns
+    -------
+    site_dir
+        site-packages directory where it was installed
+
+    """
+
+    root_ok = [os.path.exists(os.path.join(ROOT_DIR, fn))
+               for fn in PROJECT_ROOT_FILES]
+    if not all(root_ok):
+        print("To build the project, run runtests.py in "
+              "git checkout or unpacked source")
+        sys.exit(1)
+
+    dst_dir = os.path.join(ROOT_DIR, 'build', 'testenv')
+
+    env = dict(os.environ)
+    cmd = [sys.executable, 'setup.py']
+
+    # Always use ccache, if installed
+    env['PATH'] = os.pathsep.join(EXTRA_PATH + env.get('PATH', '').split(os.pathsep))
+
+    if args.debug:
+        # assume everyone uses gcc/gfortran
+        env['OPT'] = '-O0 -ggdb'
+        env['FOPT'] = '-O0 -ggdb'
+
+    cmd += ["build"]
+    if args.parallel > 1:
+        cmd += ["-j", str(args.parallel)]
+    cmd += ['install', '--single-version-externally-managed', '--prefix=' + dst_dir,
+            '--record='+os.path.join(dst_dir, 'install.txt')]
+
+    log_filename = os.path.join(ROOT_DIR, 'build.log')
+
+    if args.show_build_log:
+        ret = subprocess.call(cmd, env=env, cwd=ROOT_DIR)
+    else:
+        log_filename = os.path.join(ROOT_DIR, 'build.log')
+        print("Building, see build.log...")
+        with open(log_filename, 'w') as log:
+            p = subprocess.Popen(cmd, env=env, stdout=log, stderr=log,
+                                 cwd=ROOT_DIR)
+
+        # Wait for it to finish, and print something to indicate the
+        # process is alive, but only if the log file has grown (to
+        # allow continuous integration environments kill a hanging
+        # process accurately if it produces no output)
+        last_blip = time.time()
+        last_log_size = os.stat(log_filename).st_size
+        while p.poll() is None:
+            time.sleep(0.5)
+            if time.time() - last_blip > 60:
+                log_size = os.stat(log_filename).st_size
+                if log_size > last_log_size:
+                    print("    ... build in progress")
+                    last_blip = time.time()
+                    last_log_size = log_size
+
+        ret = p.wait()
+
+    if ret == 0:
+        print("Build OK")
+    else:
+        if not args.show_build_log:
+            with open(log_filename, 'r') as f:
+                print(f.read())
+            print("Build failed!")
+        sys.exit(1)
+
+    from distutils.sysconfig import get_python_lib
+    site_dir = get_python_lib(prefix=dst_dir, plat_specific=True)
+
+    return site_dir
+
+
+#
+#
+# Python 3 support
+#
+
+if sys.version_info[0] >= 3:
+    import builtins
+    exec_ = getattr(builtins, "exec")
+else:
+    def exec_(code, globs=None, locs=None):
+        """Execute code in a namespace."""
+        if globs is None:
+            frame = sys._getframe(1)
+            globs = frame.f_globals
+            if locs is None:
+                locs = frame.f_locals
+            del frame
+        elif locs is None:
+            locs = globs
+        exec("""exec code in globs, locs""")
+
+if __name__ == "__main__":
+    main(argv=sys.argv[1:])


### PR DESCRIPTION
@brookehus this may make running the tests a little more straightforward. I was trying to figure out a way to avoid needing to run `python setup.py develop` before running the tests to avoid having the imports not work, but couldn't figure anything out. I copied this from numpy, which uses the same scheme.

The basic workflow should just be
```
# modify your files (python or cython)
$ python runtests.py
```
or to run just a specific test 

```
$ python runtest.py -t mdtraj/tests/test_trajectory.py:test_load
```