### PR TITLE
[xtc|trr] added xdrlib2 (seek support).

### DIFF
--- a/mdtraj/formats/xtc/include/ms_stdint.h
+++ b/mdtraj/formats/xtc/include/ms_stdint.h
@@ -1,0 +1,259 @@
+// ISO C9x  compliant stdint.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124
+//
+//  Copyright (c) 2006-2013 Alexander Chemeris
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the product nor the names of its contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _MSC_VER // [
+#error "Use this header only with Microsoft Visual C++ compilers!"
+#endif // _MSC_VER ]
+
+#ifndef _MSC_STDINT_H_ // [
+#define _MSC_STDINT_H_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#if _MSC_VER >= 1600 // [
+#include <stdint.h>
+#else // ] _MSC_VER >= 1600 [
+
+#include <limits.h>
+
+// For Visual Studio 6 in C++ mode and for many Visual Studio versions when
+// compiling for ARM we should wrap <wchar.h> include with 'extern "C++" {}'
+// or compiler give many errors like this:
+//   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
+#ifdef __cplusplus
+extern "C" {
+#endif
+#  include <wchar.h>
+#ifdef __cplusplus
+}
+#endif
+
+// Define _W64 macros to mark types changing their size, like intptr_t.
+#ifndef _W64
+#  if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300
+#     define _W64 __w64
+#  else
+#     define _W64
+#  endif
+#endif
+
+
+// 7.18.1 Integer types
+
+// 7.18.1.1 Exact-width integer types
+
+// Visual Studio 6 and Embedded Visual C++ 4 doesn't
+// realize that, e.g. char has the same size as __int8
+// so we give up on __intX for them.
+#if (_MSC_VER < 1300)
+   typedef signed char       int8_t;
+   typedef signed short      int16_t;
+   typedef signed int        int32_t;
+   typedef unsigned char     uint8_t;
+   typedef unsigned short    uint16_t;
+   typedef unsigned int      uint32_t;
+#else
+   typedef signed __int8     int8_t;
+   typedef signed __int16    int16_t;
+   typedef signed __int32    int32_t;
+   typedef unsigned __int8   uint8_t;
+   typedef unsigned __int16  uint16_t;
+   typedef unsigned __int32  uint32_t;
+#endif
+typedef signed __int64       int64_t;
+typedef unsigned __int64     uint64_t;
+
+
+// 7.18.1.2 Minimum-width integer types
+typedef int8_t    int_least8_t;
+typedef int16_t   int_least16_t;
+typedef int32_t   int_least32_t;
+typedef int64_t   int_least64_t;
+typedef uint8_t   uint_least8_t;
+typedef uint16_t  uint_least16_t;
+typedef uint32_t  uint_least32_t;
+typedef uint64_t  uint_least64_t;
+
+// 7.18.1.3 Fastest minimum-width integer types
+typedef int8_t    int_fast8_t;
+typedef int16_t   int_fast16_t;
+typedef int32_t   int_fast32_t;
+typedef int64_t   int_fast64_t;
+typedef uint8_t   uint_fast8_t;
+typedef uint16_t  uint_fast16_t;
+typedef uint32_t  uint_fast32_t;
+typedef uint64_t  uint_fast64_t;
+
+// 7.18.1.4 Integer types capable of holding object pointers
+#ifdef _WIN64 // [
+   typedef signed __int64    intptr_t;
+   typedef unsigned __int64  uintptr_t;
+#else // _WIN64 ][
+   typedef _W64 signed int   intptr_t;
+   typedef _W64 unsigned int uintptr_t;
+#endif // _WIN64 ]
+
+// 7.18.1.5 Greatest-width integer types
+typedef int64_t   intmax_t;
+typedef uint64_t  uintmax_t;
+
+
+// 7.18.2 Limits of specified-width integer types
+
+#if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
+
+// 7.18.2.1 Limits of exact-width integer types
+#define INT8_MIN     ((int8_t)_I8_MIN)
+#define INT8_MAX     _I8_MAX
+#define INT16_MIN    ((int16_t)_I16_MIN)
+#define INT16_MAX    _I16_MAX
+#define INT32_MIN    ((int32_t)_I32_MIN)
+#define INT32_MAX    _I32_MAX
+#define INT64_MIN    ((int64_t)_I64_MIN)
+#define INT64_MAX    _I64_MAX
+#define UINT8_MAX    _UI8_MAX
+#define UINT16_MAX   _UI16_MAX
+#define UINT32_MAX   _UI32_MAX
+#define UINT64_MAX   _UI64_MAX
+
+// 7.18.2.2 Limits of minimum-width integer types
+#define INT_LEAST8_MIN    INT8_MIN
+#define INT_LEAST8_MAX    INT8_MAX
+#define INT_LEAST16_MIN   INT16_MIN
+#define INT_LEAST16_MAX   INT16_MAX
+#define INT_LEAST32_MIN   INT32_MIN
+#define INT_LEAST32_MAX   INT32_MAX
+#define INT_LEAST64_MIN   INT64_MIN
+#define INT_LEAST64_MAX   INT64_MAX
+#define UINT_LEAST8_MAX   UINT8_MAX
+#define UINT_LEAST16_MAX  UINT16_MAX
+#define UINT_LEAST32_MAX  UINT32_MAX
+#define UINT_LEAST64_MAX  UINT64_MAX
+
+// 7.18.2.3 Limits of fastest minimum-width integer types
+#define INT_FAST8_MIN    INT8_MIN
+#define INT_FAST8_MAX    INT8_MAX
+#define INT_FAST16_MIN   INT16_MIN
+#define INT_FAST16_MAX   INT16_MAX
+#define INT_FAST32_MIN   INT32_MIN
+#define INT_FAST32_MAX   INT32_MAX
+#define INT_FAST64_MIN   INT64_MIN
+#define INT_FAST64_MAX   INT64_MAX
+#define UINT_FAST8_MAX   UINT8_MAX
+#define UINT_FAST16_MAX  UINT16_MAX
+#define UINT_FAST32_MAX  UINT32_MAX
+#define UINT_FAST64_MAX  UINT64_MAX
+
+// 7.18.2.4 Limits of integer types capable of holding object pointers
+#ifdef _WIN64 // [
+#  define INTPTR_MIN   INT64_MIN
+#  define INTPTR_MAX   INT64_MAX
+#  define UINTPTR_MAX  UINT64_MAX
+#else // _WIN64 ][
+#  define INTPTR_MIN   INT32_MIN
+#  define INTPTR_MAX   INT32_MAX
+#  define UINTPTR_MAX  UINT32_MAX
+#endif // _WIN64 ]
+
+// 7.18.2.5 Limits of greatest-width integer types
+#define INTMAX_MIN   INT64_MIN
+#define INTMAX_MAX   INT64_MAX
+#define UINTMAX_MAX  UINT64_MAX
+
+// 7.18.3 Limits of other integer types
+
+#ifdef _WIN64 // [
+#  define PTRDIFF_MIN  _I64_MIN
+#  define PTRDIFF_MAX  _I64_MAX
+#else  // _WIN64 ][
+#  define PTRDIFF_MIN  _I32_MIN
+#  define PTRDIFF_MAX  _I32_MAX
+#endif  // _WIN64 ]
+
+#define SIG_ATOMIC_MIN  INT_MIN
+#define SIG_ATOMIC_MAX  INT_MAX
+
+#ifndef SIZE_MAX // [
+#  ifdef _WIN64 // [
+#     define SIZE_MAX  _UI64_MAX
+#  else // _WIN64 ][
+#     define SIZE_MAX  _UI32_MAX
+#  endif // _WIN64 ]
+#endif // SIZE_MAX ]
+
+// WCHAR_MIN and WCHAR_MAX are also defined in <wchar.h>
+#ifndef WCHAR_MIN // [
+#  define WCHAR_MIN  0
+#endif  // WCHAR_MIN ]
+#ifndef WCHAR_MAX // [
+#  define WCHAR_MAX  _UI16_MAX
+#endif  // WCHAR_MAX ]
+
+#define WINT_MIN  0
+#define WINT_MAX  _UI16_MAX
+
+#endif // __STDC_LIMIT_MACROS ]
+
+
+// 7.18.4 Limits of other integer types
+
+#if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) // [   See footnote 224 at page 260
+
+// 7.18.4.1 Macros for minimum-width integer constants
+
+#define INT8_C(val)  val##i8
+#define INT16_C(val) val##i16
+#define INT32_C(val) val##i32
+#define INT64_C(val) val##i64
+
+#define UINT8_C(val)  val##ui8
+#define UINT16_C(val) val##ui16
+#define UINT32_C(val) val##ui32
+#define UINT64_C(val) val##ui64
+
+// 7.18.4.2 Macros for greatest-width integer constants
+// These #ifndef's are needed to prevent collisions with <boost/cstdint.hpp>.
+// Check out Issue 9 for the details.
+#ifndef INTMAX_C //   [
+#  define INTMAX_C   INT64_C
+#endif // INTMAX_C    ]
+#ifndef UINTMAX_C //  [
+#  define UINTMAX_C  UINT64_C
+#endif // UINTMAX_C   ]
+
+#endif // __STDC_CONSTANT_MACROS ]
+
+#endif // _MSC_VER >= 1600 ]
+
+#endif // _MSC_STDINT_H_ ]

--- a/mdtraj/formats/xtc/include/util.h
+++ b/mdtraj/formats/xtc/include/util.h
@@ -1,0 +1,5 @@
+#ifndef __xtc_util_h
+#define __xtc_util_h
+#include "numpy/arrayobject.h"
+void PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags);
+#endif

--- a/mdtraj/formats/xtc/include/util.h
+++ b/mdtraj/formats/xtc/include/util.h
@@ -1,5 +1,9 @@
 #ifndef __xtc_util_h
 #define __xtc_util_h
-#include "numpy/arrayobject.h"
+
+#include "Python.h"
+#include "numpy/ndarrayobject.h"
+
 void PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags);
+
 #endif

--- a/mdtraj/formats/xtc/include/xdrfile.h
+++ b/mdtraj/formats/xtc/include/xdrfile.h
@@ -70,9 +70,15 @@
  * documentation on the FORTRAN interface!
  */
 
-
 #ifndef _XDRFILE_H_
 #define _XDRFILE_H_
+
+// for int64_t on older M$ Visual Studio
+#if _MSC_VER && _MSVC_VER < 1800 && !__INTEL_COMPILER
+	#include "ms_stdint.h"
+#else
+	#include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" 

--- a/mdtraj/formats/xtc/include/xdrfile.h
+++ b/mdtraj/formats/xtc/include/xdrfile.h
@@ -622,7 +622,9 @@ extern "C"
 									double *     precision,
 									XDRFILE *    xfp);
 
-
+	// taken from xdrlib2
+	int64_t xdr_tell(XDRFILE *xd);
+	int xdr_seek(XDRFILE *xd, int64_t pos, int whence);
 
 #ifdef __cplusplus
 }

--- a/mdtraj/formats/xtc/include/xdrfile.h
+++ b/mdtraj/formats/xtc/include/xdrfile.h
@@ -74,7 +74,7 @@
 #define _XDRFILE_H_
 
 // for int64_t on older M$ Visual Studio
-#if _MSC_VER && _MSVC_VER < 1800 && !__INTEL_COMPILER
+#if _MSC_VER && _MSVC_VER < 1600 && !__INTEL_COMPILER
 	#include "ms_stdint.h"
 #else
 	#include <stdint.h>

--- a/mdtraj/formats/xtc/include/xdrfile_trr.h
+++ b/mdtraj/formats/xtc/include/xdrfile_trr.h
@@ -42,7 +42,7 @@ extern "C" {
    
   /* This function returns the number of atoms in the xtc file in *natoms */
   extern int read_trr_natoms(char *fn,int *natoms);
-  extern int read_trr_nframes(char* fn, unsigned long *nframes);
+  extern int read_trr_nframes(char* fn, unsigned long *nframes, unsigned long *est_nframes, int64_t** offsets);
   
   /* Read one frame of an open xtc file. If either of x,v,f,box are
      NULL the arrays will be read from the file but not used.  */
@@ -52,6 +52,12 @@ extern "C" {
   /* Write a frame to xtc file */
   extern int write_trr(XDRFILE *xd,int natoms,int step,float t,float lambda,
 		       matrix box,rvec *x,rvec *v,rvec *f);
+
+  /* Minimum TRR header size. It can have 8 bytes more if we have double time and
+   * lambda. */
+  #define TRR_MIN_HEADER_SIZE 54
+  #define TRR_DOUBLE_XTRA_HEADER 8
+
 
   
 #ifdef __cplusplus

--- a/mdtraj/formats/xtc/include/xdrfile_xtc.h
+++ b/mdtraj/formats/xtc/include/xdrfile_xtc.h
@@ -41,18 +41,30 @@ extern "C" {
    */  
    
   /* This function returns the number of atoms in the xtc file in *natoms */
-  extern int read_xtc_natoms(char *fn,int *natoms);
+  extern int read_xtc_natoms(char *fn, int *natoms);
   
-  int read_xtc_nframes(char* fn, unsigned long *nframes);
+  int read_xtc_nframes(char* fn, unsigned long *nframes, unsigned long *est_nframes, int64_t **offsets);
 
   /* Read one frame of an open xtc file */
   extern int read_xtc(XDRFILE *xd,int natoms,int *step,float *time,
 		      matrix box,rvec *x,float *prec);
   
   /* Write a frame to xtc file */
-  extern int write_xtc(XDRFILE *xd,
-		       int natoms,int step,float time,
-		       matrix box,rvec *x,float prec);
+  extern int write_xtc(XDRFILE *xd, int natoms,int step,float time, matrix box,rvec *x,float prec);
+
+  // taken from xdrlib2
+  /* XTC header fields until coord floats: *** only for trajectories of less than
+   * 10 atoms! ***  */
+  /* magic natoms step time DIM*DIM_box_vecs natoms */
+  #define XTC_SHORTHEADER_SIZE (20 + DIM * DIM * 4)
+  /* Short XTCs store each coordinate as a 32-bit float. */
+  #define XTC_SHORT_BYTESPERATOM 12
+  /* XTC header fields until frame bytes: *** only for trajectories of more than 9
+   * atoms! ***  */
+  /* magic natoms step time DIM*DIM_box_vecs natoms prec DIM_min_xyz DIM_max_xyz
+   * smallidx */
+  #define XTC_HEADER_SIZE (DIM * DIM * 4 + DIM * 2 + 46)
+
   
 #ifdef __cplusplus
 }

--- a/mdtraj/formats/xtc/src/README
+++ b/mdtraj/formats/xtc/src/README
@@ -14,3 +14,4 @@ Changes from upsteam's xdrfile-1.1.4 include:
  - Addition of read_trr_nframes function in xdrfile_trr.c
  - Bugfix in do_trnheader to return the appropriate error code when reading magic, and properly check the value of the magic in xdrfile_trr.c
  - Bugfix of float exception (divide by zero) in xdrfile.c, see https://github.com/SimTk/mdtraj/issues/616
+ - Adapted efficient seeking pattern from xdrlib2 (part of MDAnalysis)

--- a/mdtraj/formats/xtc/src/util.c
+++ b/mdtraj/formats/xtc/src/util.c
@@ -1,0 +1,5 @@
+#include "util.h"
+void PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags)
+{
+    ((PyArrayObject_fields *)arr)->flags |= flags;
+}

--- a/mdtraj/formats/xtc/src/util.c
+++ b/mdtraj/formats/xtc/src/util.c
@@ -1,5 +1,14 @@
 #include "util.h"
+
+// defines PyArray_ENABLEFLAGS
+#include "numpy/ndarraytypes.h"
+
+// only if not defined (prior NumPy 1.7), provide impl
+#if NPY_API_VERSION <= 0x00000006
+#warning "numpy override enableflags"
 void PyArray_ENABLEFLAGS(PyArrayObject *arr, int flags)
 {
-    ((PyArrayObject_fields *)arr)->flags |= flags;
+	arr->flags |= flags;
 }
+
+#endif

--- a/mdtraj/formats/xtc/src/xdrfile.c
+++ b/mdtraj/formats/xtc/src/xdrfile.c
@@ -2534,8 +2534,8 @@ static int xdrstdio_getlong (XDR *, int32_t *);
 static int xdrstdio_putlong (XDR *, int32_t *);
 static int xdrstdio_getbytes (XDR *, char *, unsigned int);
 static int xdrstdio_putbytes (XDR *, char *, unsigned int);
-static unsigned int xdrstdio_getpos (XDR *);
-static int xdrstdio_setpos (XDR *, unsigned int, int);
+static int64_t xdrstdio_getpos (XDR *);
+static int64_t xdrstdio_setpos (XDR *, int64_t, int);
 static void xdrstdio_destroy (XDR *);
 
 /*
@@ -2616,32 +2616,45 @@ xdrstdio_putbytes (XDR *xdrs, char *addr, unsigned int len)
 	return 1;
 }
 
-/* 32/64 bit fileseek operations */
-static unsigned int
+/* 64 bit fileseek operations */
+static int64_t
 xdrstdio_getpos (XDR *xdrs)
 {
-	return (unsigned int) ftello ((FILE *) xdrs->x_private);
+#ifndef _WIN32
+	// use posix 64 bit ftell version
+	return ftello ((FILE *) xdrs->x_private);
+#elif defined(_MSVC_VER) && !__INTEL_COMPILER
+	return _ftelli64((FILE *) xdrs->x_private);
+#endif
+// fallback to 32bit
+	return ftell((FILE *) xdrs->x_private);
 }
 
-static int
-xdrstdio_setpos (XDR *xdrs, unsigned int pos, int whence)
+static int64_t
+xdrstdio_setpos (XDR *xdrs, int64_t pos, int whence)
 {
+#ifndef _WIN32
+	// use posix 64 bit ftell version
 	return fseeko((FILE *) xdrs->x_private, pos, whence) < 0 ? exdrNR : exdrOK;
+#elif _MSVC_VER && !__INTEL_COMPILER
+	return _fseeki64((FILE *) xdrs->x_private, pos, whence) < 0 ? exdrNR : exdrOK;
+#endif
+	return fseek((FILE *) xdrs->x_private, pos, whence) < 0 ? exdrNR : exdrOK;
 }
 
-// taken from xdrlib2
+// adopted from xdrlib2
 int64_t xdr_tell(XDRFILE *xd)
 /* Reads position in file */
 {
-    return (int64_t)xdrstdio_getpos(xd->xdr);
+    return xdrstdio_getpos(xd->xdr);
 }
 
-// taken from xdrlib2
+// adopted from xdrlib2
 int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
 /* Seeks to position in file */
 {
     int result;
-    if ((result = xdrstdio_setpos(xd->xdr, (off_t) pos, whence)) != exdrOK)
+    if ((result = xdrstdio_setpos(xd->xdr, pos, whence)) != exdrOK)
         return result;
 
     return exdrOK;

--- a/mdtraj/formats/xtc/src/xdrfile_trr.c
+++ b/mdtraj/formats/xtc/src/xdrfile_trr.c
@@ -26,9 +26,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "fastio.h"
 
 #include <stdlib.h>
 #include <string.h>
+
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -488,33 +490,77 @@ int read_trr_natoms(char *fn,int *natoms)
 	return exdrOK;
 }
 
-int read_trr_nframes(char *fn, unsigned long *nframes) {
-    XDRFILE *xd;
-    int result, step;
-    float time, lambda;
-	int natoms;
-	matrix box;
-	rvec *x;
-	*nframes = 0;
+int read_trr_nframes(char *fn, unsigned long *n_frames, unsigned long *est_nframes,
+                      int64_t **offsets) {
+	XDRFILE *xd;
+	t_trnheader sh;
+	float time, lambda;
+	int result, framebytes, totalframebytes;
+	int64_t filesize, frame_offset;
 
-	read_trr_natoms(fn, &natoms);
-	x = malloc(natoms * sizeof(*x));
+	if ((xd = xdrfile_open(fn, "r")) == NULL)
+		return exdrFILENOTFOUND;
+	if (xdr_seek(xd, 0L, SEEK_END) != exdrOK) {
+		xdrfile_close(xd);
+		return exdrNR;
+	}
+	filesize = xdr_tell(xd);
+	if (xdr_seek(xd, 0L, SEEK_SET) != exdrOK) {
+		xdrfile_close(xd);
+		return exdrNR;
+	}
 
-    xd = xdrfile_open(fn, "r");
-    if (NULL == xd)
-        return exdrFILENOTFOUND;
+	if ((result = do_trnheader(xd, 1, &sh)) != exdrOK) {
+		xdrfile_close(xd);
+		return result;
+	}
 
-	do {
-		result = read_trr(xd, natoms, &step, &time, &lambda,
-						  box, x, NULL, NULL);
-		if (exdrENDOFFILE != result) {
-			(*nframes)++;
+	framebytes = sh.ir_size + sh.e_size + sh.box_size + sh.vir_size +
+			sh.pres_size + sh.top_size + sh.sym_size + sh.x_size +
+			sh.v_size + sh.f_size;
+
+	*est_nframes =
+			(int)(filesize / ((int64_t)(framebytes + TRR_MIN_HEADER_SIZE)) +
+					1); // add one because it'd be easy to underestimate low
+	// frame numbers.
+	*est_nframes += *est_nframes / 5;
+
+	/* Allocate memory for the frame index array */
+	if ((*offsets = malloc(sizeof(int64_t) * *est_nframes)) == NULL) {
+		xdrfile_close(xd);
+		return exdrNOMEM;
+	}
+
+	(*offsets)[0] = 0L;
+	*n_frames = 1;
+	while (1) {
+		if (xdr_seek(xd, (int64_t)(framebytes), SEEK_CUR) != exdrOK) {
+			free(*offsets);
+			xdrfile_close(xd);
+			return exdrNR;
 		}
-	} while (result == exdrOK);
-
+		frame_offset = xdr_tell(xd); /* Store it now, before we read the header */
+		if ((result = do_trnheader(xd, 1, &sh)) != exdrOK) /* Interpreting as EOF */
+			break;
+		/* Read was successful; this is another frame */
+		/* Check if we need to enlarge array */
+		if (*n_frames == *est_nframes) {
+			*est_nframes += *est_nframes / 5 + 1; // Increase in 20% stretches
+			if ((*offsets = realloc(*offsets, sizeof(int64_t) * *est_nframes)) ==
+					NULL) {
+				xdrfile_close(xd);
+				return exdrNOMEM;
+			}
+		}
+		(*offsets)[*n_frames] = frame_offset;
+		(*n_frames)++;
+		/* Calculate how much to skip this time */
+		framebytes = sh.ir_size + sh.e_size + sh.box_size + sh.vir_size +
+				sh.pres_size + sh.top_size + sh.sym_size + sh.x_size +
+				sh.v_size + sh.f_size;
+	}
 	xdrfile_close(xd);
-	free(x);
-    return exdrOK;
+	return exdrOK;
 }
 
 int write_trr(XDRFILE *xd,int natoms,int step,float t,float lambda,

--- a/mdtraj/formats/xtc/src/xdrfile_xtc.c
+++ b/mdtraj/formats/xtc/src/xdrfile_xtc.c
@@ -26,15 +26,16 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "fastio.h"
+// stdlib needs to be included after fastio.h (fuck it)
 #include <stdlib.h>
 #include "xdrfile.h"
 #include "xdrfile_xtc.h"
 	
 #define MAGIC 1995
 
-enum { FALSE, TRUE };
+enum { _FALSE, _TRUE };
 
 static int xtc_header(XDRFILE *xd,int *natoms,int *step,float *time,mybool bRead)
 {
@@ -97,7 +98,7 @@ int read_xtc_natoms(char *fn,int *natoms)
 	xd = xdrfile_open(fn,"r");
 	if (NULL == xd)
 		return exdrFILENOTFOUND;
-	result = xtc_header(xd,natoms,&step,&time,TRUE);
+	result = xtc_header(xd,natoms,&step,&time,_TRUE);
 	xdrfile_close(xd);
 	
 	return result;
@@ -113,7 +114,7 @@ int read_xtc_nframes(char *fn, unsigned long *n_frames, unsigned long *est_nfram
 	if ((xd = xdrfile_open(fn, "r"))==NULL)
 		return exdrFILENOTFOUND;
 
-	if (xtc_header(xd, &natoms, &step, &time, TRUE) != exdrOK)
+	if (xtc_header(xd, &natoms, &step, &time, _TRUE) != exdrOK)
 	{
 		xdrfile_close(xd);
 		return exdrHEADER;
@@ -206,7 +207,7 @@ int read_xtc(XDRFILE *xd,
 {
 	int result;
   
-	if ((result = xtc_header(xd,&natoms,step,time,TRUE)) != exdrOK)
+	if ((result = xtc_header(xd,&natoms,step,time,_TRUE)) != exdrOK)
 		return result;
 	  
 	if ((result = xtc_coord(xd,&natoms,box,x,prec,1)) != exdrOK)
@@ -222,7 +223,7 @@ int write_xtc(XDRFILE *xd,
 {
 	int result;
   
-	if ((result = xtc_header(xd,&natoms,&step,&time,FALSE)) != exdrOK)
+	if ((result = xtc_header(xd,&natoms,&step,&time,_FALSE)) != exdrOK)
 		return result;
 
 	if ((result = xtc_coord(xd,&natoms,box,x,&prec,0)) != exdrOK)

--- a/mdtraj/formats/xtc/src/xdrfile_xtc.c
+++ b/mdtraj/formats/xtc/src/xdrfile_xtc.c
@@ -156,8 +156,8 @@ int read_xtc_nframes(char *fn, unsigned long *n_frames, unsigned long *est_nfram
 			xdrfile_close(xd);
 			return exdrENDOFFILE;
 		}
-		//Rounding to the next 32-bit boundary
-		framebytes = (framebytes + 3) & ~0x03;
+		//Rounding to the next 64-bit boundary
+		framebytes = (framebytes + 3) & ~(sizeof(int64_t) - 1);
 		// add one because it'd be easy to underestimate low frame numbers.
 		*est_nframes = /*(int)*/ (filesize/((int64_t) (framebytes+XTC_HEADER_SIZE)) + 1);
 		*est_nframes += *est_nframes/5;
@@ -193,7 +193,8 @@ int read_xtc_nframes(char *fn, unsigned long *n_frames, unsigned long *est_nfram
 			/*Account for the header and the nbytes bytes we read.*/
 			(*offsets)[*n_frames] = xdr_tell(xd) - 4L - (int64_t) (XTC_HEADER_SIZE);
 			(*n_frames)++;
-			framebytes = (framebytes + 3) & ~0x03; //Rounding to the next 32-bit boundary
+			//Rounding to the next 64-bit boundary
+			framebytes = (framebytes + 3) & ~(sizeof(int64_t) - 1);
 		}
 		xdrfile_close(xd);
 		return exdrOK;

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -37,20 +37,11 @@ from mdtraj.utils import ensure_type, cast_indices, in_units_of
 from mdtraj.utils.six import string_types
 from mdtraj.formats.registry import _FormatRegistry
 cimport trrlib
+from xdrlib cimport _int64_ptr_to_numpy_array
 from libc.stdio cimport SEEK_SET
 from libc.stdint cimport int64_t
 
 __all__ = ['load_trr', 'TRRTrajectoryFile']
-
-# utility func to take over memory of a pointer in a ndarray.
-
-cdef extern from "numpy/arrayobject.h":
-    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
-cdef _int64_ptr_to_numpy_array(void * ptr, np.npy_intp N, int t):
-    cdef np.ndarray[np.int64_t, ndim=1] arr = np.PyArray_SimpleNewFromData(1, &N, t, ptr)
-    PyArray_ENABLEFLAGS(arr, np.NPY_OWNDATA)
-    return arr
-
 
 ###############################################################################
 # globals

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -39,7 +39,8 @@ from mdtraj.formats.registry import _FormatRegistry
 cimport trrlib
 from xdrlib cimport _int64_ptr_to_numpy_array
 from libc.stdio cimport SEEK_SET
-from libc.stdint cimport int64_t
+
+ctypedef np.npy_int64   int64_t
 
 __all__ = ['load_trr', 'TRRTrajectoryFile']
 

--- a/mdtraj/formats/xtc/trrlib.pxd
+++ b/mdtraj/formats/xtc/trrlib.pxd
@@ -1,9 +1,12 @@
+from libc.stdint cimport int64_t
+
 cdef extern from "include/xdrfile.h":
     ctypedef struct XDRFILE:
         pass
 
     XDRFILE* xdrfile_open (char * path, char * mode)
     int xdrfile_close (XDRFILE * xfp)
+    int xdr_seek(XDRFILE *xfp, int64_t pos, int whence)
     ctypedef float matrix[3][3]
     ctypedef float rvec[3]
 
@@ -11,7 +14,7 @@ cdef extern from "include/xdrfile.h":
 cdef extern from "include/xdrfile_trr.h":
 
     int read_trr_natoms(char *fn, int *natoms)
-    int read_trr_nframes(char* fn, unsigned long *nframes)
+    int read_trr_nframes(char* fn, unsigned long *nframes, unsigned long *est_nframes, int64_t** offsets)
 
     # Read one frame of an open xtc file. If either of x, v, f, box are
     # NULL the arrays will be read from the file but not used.

--- a/mdtraj/formats/xtc/trrlib.pxd
+++ b/mdtraj/formats/xtc/trrlib.pxd
@@ -1,4 +1,5 @@
-from libc.stdint cimport int64_t
+cimport numpy as np
+ctypedef np.npy_int64 int64_t
 
 cdef extern from "include/xdrfile.h":
     ctypedef struct XDRFILE:

--- a/mdtraj/formats/xtc/xdrlib.pxd
+++ b/mdtraj/formats/xtc/xdrlib.pxd
@@ -17,3 +17,12 @@ cdef extern from "include/xdrfile_xtc.h":
     int write_xtc(XDRFILE *xd, int natoms, int step, float time, matrix box, rvec* x, float prec)
     int read_xtc_nframes(char* fn, unsigned long *nframes, unsigned long *est_nframes, int64_t** offsets)
 
+cdef extern from "include/util.h":
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+
+# utility func to take over memory of a pointer in a ndarray.
+# TODO: this should be more general.
+cdef inline _int64_ptr_to_numpy_array(void * ptr, np.npy_intp N, int t, ):
+    cdef np.ndarray[np.int64_t, ndim=1] arr = np.PyArray_SimpleNewFromData(1, &N, t, ptr)
+    PyArray_ENABLEFLAGS(arr, 0x0004) # NPY_ARRAY_OWNDATA
+    return arr

--- a/mdtraj/formats/xtc/xdrlib.pxd
+++ b/mdtraj/formats/xtc/xdrlib.pxd
@@ -1,3 +1,6 @@
+cimport numpy as np
+ctypedef np.npy_int64 int64_t
+
 cdef extern from "include/xdrfile.h":
     ctypedef struct XDRFILE:
         pass
@@ -6,9 +9,11 @@ cdef extern from "include/xdrfile.h":
     ctypedef float matrix[3][3]
     ctypedef float rvec[3]
     int xdrfile_close (XDRFILE * xfp)
+    int xdr_seek(XDRFILE *xfp, int64_t pos, int whence)
 
 cdef extern from "include/xdrfile_xtc.h":
     int read_xtc_natoms(char* fn, int* natoms)
     int read_xtc(XDRFILE *xd, int natoms, int *step, float *time, matrix box, rvec *x, float *prec)
     int write_xtc(XDRFILE *xd, int natoms, int step, float time, matrix box, rvec* x, float prec)
-    int read_xtc_nframes(char* fn, unsigned long *nframes)
+    int read_xtc_nframes(char* fn, unsigned long *nframes, unsigned long *est_nframes, int64_t** offsets)
+

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -38,7 +38,7 @@ from mdtraj.utils.six import string_types
 from mdtraj.formats.registry import _FormatRegistry
 cimport xdrlib
 from libc.stdio cimport SEEK_SET
-from libc.stdint cimport int64_t
+ctypedef np.npy_int64   int64_t
 
 __all__ = ['load_xtc', 'XTCTrajectoryFile']
 

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -40,17 +40,7 @@ cimport xdrlib
 from libc.stdio cimport SEEK_SET
 from libc.stdint cimport int64_t
 
-
 __all__ = ['load_xtc', 'XTCTrajectoryFile']
-
-# utility func to take over memory of a pointer in a ndarray.
-
-cdef extern from "numpy/arrayobject.h":
-    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
-cdef _int64_ptr_to_numpy_array(void * ptr, np.npy_intp N, int t):
-    cdef np.ndarray[np.int64_t, ndim=1] arr = np.PyArray_SimpleNewFromData(1, &N, t, ptr)
-    PyArray_ENABLEFLAGS(arr, np.NPY_OWNDATA)
-    return arr
 
 
 ###############################################################################
@@ -623,7 +613,7 @@ cdef class XTCTrajectoryFile:
         # overestimation. This number is saved in est_nframes and we need to
         # tell the new numpy array about the whole allocated memory to avoid
         # memory leaks.
-        nd_offsets = _int64_ptr_to_numpy_array(frame_offsets, est_nframes, np.NPY_INT64)
+        nd_offsets = xdrlib._int64_ptr_to_numpy_array(frame_offsets, est_nframes, np.NPY_INT64)
         return nd_offsets[:self.n_frames]
 
     def __enter__(self):

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -613,8 +613,9 @@ cdef class XTCTrajectoryFile:
         # overestimation. This number is saved in est_nframes and we need to
         # tell the new numpy array about the whole allocated memory to avoid
         # memory leaks.
-        nd_offsets = xdrlib._int64_ptr_to_numpy_array(frame_offsets, est_nframes, np.NPY_INT64)
-        return nd_offsets[:self.n_frames]
+        nd_offsets = xdrlib._int64_ptr_to_numpy_array(frame_offsets, self.n_frames, np.NPY_INT64)
+        assert len(nd_offsets) == self.n_frames
+        return nd_offsets
 
     def __enter__(self):
         "Support the context manager protocol"

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -37,8 +37,20 @@ from mdtraj.utils import ensure_type, cast_indices, in_units_of
 from mdtraj.utils.six import string_types
 from mdtraj.formats.registry import _FormatRegistry
 cimport xdrlib
+from libc.stdio cimport SEEK_SET
+from libc.stdint cimport int64_t
+
 
 __all__ = ['load_xtc', 'XTCTrajectoryFile']
+
+# utility func to take over memory of a pointer in a ndarray.
+
+cdef extern from "numpy/arrayobject.h":
+    void PyArray_ENABLEFLAGS(np.ndarray arr, int flags)
+cdef _int64_ptr_to_numpy_array(void * ptr, np.npy_intp N, int t):
+    cdef np.ndarray[np.int64_t, ndim=1] arr = np.PyArray_SimpleNewFromData(1, &N, t, ptr)
+    PyArray_ENABLEFLAGS(arr, np.NPY_OWNDATA)
+    return arr
 
 
 ###############################################################################
@@ -199,6 +211,8 @@ cdef class XTCTrajectoryFile:
     cdef float chunk_size_multiplier
     cdef int with_unitcell    # used in mode='w' to know if we're writing unitcells or nor
     cdef readonly char* distance_unit
+    cdef char _has_offsets
+    cdef np.ndarray _offsets
 
 
     def __cinit__(self, char* filename, char* mode='r', force_overwrite=True, **kwargs):
@@ -209,6 +223,7 @@ cdef class XTCTrajectoryFile:
         self.frame_counter = 0
         self.n_frames = -1  # means unknown
         self.filename = filename
+        self._has_offsets = False
 
         if str(mode) == 'r':
             self.n_atoms = 0
@@ -226,7 +241,6 @@ cdef class XTCTrajectoryFile:
 
             self.min_chunk_size = max(kwargs.pop('min_chunk_size', 100), 1)
             self.chunk_size_multiplier = max(kwargs.pop('chunk_size_multiplier', 1.5), 0.01)
-
 
         elif str(mode) == 'w':
             if force_overwrite and os.path.exists(filename):
@@ -286,7 +300,7 @@ cdef class XTCTrajectoryFile:
             If not none, then read only a subset of the atoms coordinates from the
             file. This may be slightly slower than the standard read because it required
             an extra copy, but will save memory.
-        
+
         Returns
         -------
         trajectory : Trajectory
@@ -544,11 +558,7 @@ cdef class XTCTrajectoryFile:
             2: move relative to the end of file, offset should be <= 0.
             Seeking beyond the end of a file is not supported
         """
-        cdef int i, status, step
-        cdef float time = 0
-        cdef float prec = 0
-        cdef np.ndarray[dtype=np.float_t] box = np.empty(9, dtype=np.float)
-        cdef np.ndarray[dtype=np.float_t] xyz = np.empty(self.n_atoms * 3, dtype=np.float)
+        cdef int status
 
         if str(self.mode) != 'r':
             raise NotImplementedError('seek() only available in mode="r" currently')
@@ -561,14 +571,10 @@ cdef class XTCTrajectoryFile:
         else:
             raise IOError('Invalid argument')
 
-        xdrlib.xdrfile_close(self.fh)
-        self.fh = xdrlib.xdrfile_open(self.filename, self.mode)
-
-        for i in range(absolute):
-            status = xdrlib.read_xtc(self.fh, self.n_atoms, <int*> &step,
-                                     &time, <xdrlib.matrix>&box[0], <xdrlib.rvec*>&xyz[0], &prec)
-            if status != _EXDROK:
-                raise RuntimeError('XTC seek error: %s' % status)
+        pos = self.offsets[absolute]
+        status = xdrlib.xdr_seek(self.fh, pos, SEEK_SET)
+        if status != _EXDROK:
+            raise RuntimeError('XTC seek error: %s' % status)
 
         self.frame_counter = absolute
 
@@ -583,6 +589,42 @@ cdef class XTCTrajectoryFile:
         if str(self.mode) != 'r':
             raise NotImplementedError('tell() only available in mode="r" currently')
         return int(self.frame_counter)
+
+    @property
+    def offsets(self):
+        """get byte offsets from current xtc file
+        See Also
+        --------
+        set_offsets
+        """
+        if not self._has_offsets:
+            self._offsets = self._calc_offsets()
+            self._has_offsets = True
+        return self._offsets
+
+    @offsets.setter
+    def offsets(self, offsets):
+        """set frame offsets"""
+        self._offsets = offsets
+        self._has_offsets = True
+
+    def _calc_offsets(self):
+        """read byte offsets from TRR file directly"""
+        if not self.is_open:
+            return np.array([])
+        cdef unsigned long est_nframes = 0
+        cdef int64_t *frame_offsets
+
+        status = xdrlib.read_xtc_nframes(self.filename, &self.n_frames,
+                                         &est_nframes, &frame_offsets)
+        if status != 0:
+            raise RuntimeError("TRR couldn't calculate offsets: %s" % status)
+        # the read_xtc_n_frames allocates memory for the offsets with an
+        # overestimation. This number is saved in est_nframes and we need to
+        # tell the new numpy array about the whole allocated memory to avoid
+        # memory leaks.
+        nd_offsets = _int64_ptr_to_numpy_array(frame_offsets, est_nframes, np.NPY_INT64)
+        return nd_offsets[:self.n_frames]
 
     def __enter__(self):
         "Support the context manager protocol"
@@ -599,6 +641,7 @@ cdef class XTCTrajectoryFile:
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.n_frames == -1:
-            xdrlib.read_xtc_nframes(self.filename, &self.n_frames)
+            self._calc_offsets()
         return int(self.n_frames)
+
 _FormatRegistry.register_fileobject('.xtc')(XTCTrajectoryFile)

--- a/mdtraj/tests/test_trr.py
+++ b/mdtraj/tests/test_trr.py
@@ -159,3 +159,41 @@ def test_ragged_2():
     with TRRTrajectoryFile(temp, 'w', force_overwrite=True) as f:
         f.write(xyz, time=time, box=box)
         assert_raises(ValueError, lambda: f.write(xyz))
+
+
+def test_tell():
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        eq(f.tell(), 0)
+
+        f.read(101)
+        eq(f.tell(), 101)
+
+        f.read(3)
+        eq(f.tell(), 104)
+
+
+def test_seek():
+    reference = TRRTrajectoryFile(get_fn('frame0.trr')).read()[0]
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+
+        eq(f.tell(), 0)
+        eq(f.read(1)[0][0], reference[0])
+        eq(f.tell(), 1)
+        
+        xyz = f.read(1)[0][0]
+        eq(xyz, reference[1])
+        eq(f.tell(), 2)
+
+        f.seek(0)
+        eq(f.tell(), 0)
+        xyz = f.read(1)[0][0]
+        eq(f.tell(), 1)
+        eq(xyz, reference[0])
+        
+        f.seek(5)
+        eq(f.read(1)[0][0], reference[5])
+        eq(f.tell(), 6)
+        
+        f.seek(-5, 1)
+        eq(f.tell(), 1)
+        eq(f.read(1)[0][0], reference[1])

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ def format_extensions():
     compiler_args = compiler.compiler_args_warn
 
     xtc = Extension('mdtraj.formats.xtc',
-                    sources=['mdtraj/formats/xtc/src/xdrfile.c',
+                    sources=['mdtraj/formats/xtc/src/util.c',
+                             'mdtraj/formats/xtc/src/xdrfile.c',
                              'mdtraj/formats/xtc/src/xdrfile_xtc.c',
                              'mdtraj/formats/xtc/xtc.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
@@ -107,6 +108,7 @@ def format_extensions():
     trr = Extension('mdtraj.formats.trr',
                     sources=['mdtraj/formats/xtc/src/xdrfile.c',
                              'mdtraj/formats/xtc/src/xdrfile_trr.c',
+                             'mdtraj/formats/xtc/src/util.c',
                              'mdtraj/formats/xtc/trr.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
                                   'mdtraj/formats/xtc/',

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,9 @@ def format_extensions():
                              'mdtraj/formats/xtc/src/xdrfile_xtc.c',
                              'mdtraj/formats/xtc/xtc.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
-                                  'mdtraj/formats/xtc/'],
+                                  'mdtraj/formats/xtc/',
+                                  # for fastio.h
+                                  'mdtraj/formats/dcd/include/'],
                     extra_compile_args=compiler_args)
 
     trr = Extension('mdtraj.formats.trr',
@@ -107,7 +109,9 @@ def format_extensions():
                              'mdtraj/formats/xtc/src/xdrfile_trr.c',
                              'mdtraj/formats/xtc/trr.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',
-                                  'mdtraj/formats/xtc/'],
+                                  'mdtraj/formats/xtc/',
+                                  # for fastio.h
+                                  'mdtraj/formats/dcd/include/'],
                     extra_compile_args=compiler_args)
 
     dcd = Extension('mdtraj.formats.dcd',


### PR DESCRIPTION
This method will read an integer per frame to determine the byte offsets between
frames. It will only be called once the user wants to know the lengths of the
trajectory or he/she demands random access (seeking). The offsets are accessible
via a property of the XTC|TRRTrajectoryFile and could in principle cached.

It should be discussed/measured whether the approximations about the total number of frames made are obsolete by this method (of course one has to do a quick scan over the whole file, but it will probably save lots of reallocations/memcopies).

For those concerned about licensing issues, the original source code (xdrlib) is BSD, so a modification to this library should remain under this license. So there should be no issue with MDAnalysis is GPL and mdtraj is LGPL. But I'm no lawyer...