### PR TITLE
[xtc|trr] added seek support to provide fast random access.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\devtools\\appveyor-ci\\run_with_env.cmd"
+    PYTHONUNBUFFERED: 1
 
   matrix:
     - PYTHON: "C:\\Miniconda"

--- a/mdtraj/formats/xtc/include/ms_stdint.h
+++ b/mdtraj/formats/xtc/include/ms_stdint.h
@@ -1,0 +1,259 @@
+// ISO C9x  compliant stdint.h for Microsoft Visual Studio
+// Based on ISO/IEC 9899:TC2 Committee draft (May 6, 2005) WG14/N1124
+//
+//  Copyright (c) 2006-2013 Alexander Chemeris
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//   1. Redistributions of source code must retain the above copyright notice,
+//      this list of conditions and the following disclaimer.
+//
+//   2. Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//   3. Neither the name of the product nor the names of its contributors may
+//      be used to endorse or promote products derived from this software
+//      without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _MSC_VER // [
+#error "Use this header only with Microsoft Visual C++ compilers!"
+#endif // _MSC_VER ]
+
+#ifndef _MSC_STDINT_H_ // [
+#define _MSC_STDINT_H_
+
+#if _MSC_VER > 1000
+#pragma once
+#endif
+
+#if _MSC_VER >= 1600 // [
+#include <stdint.h>
+#else // ] _MSC_VER >= 1600 [
+
+#include <limits.h>
+
+// For Visual Studio 6 in C++ mode and for many Visual Studio versions when
+// compiling for ARM we should wrap <wchar.h> include with 'extern "C++" {}'
+// or compiler give many errors like this:
+//   error C2733: second C linkage of overloaded function 'wmemchr' not allowed
+#ifdef __cplusplus
+extern "C" {
+#endif
+#  include <wchar.h>
+#ifdef __cplusplus
+}
+#endif
+
+// Define _W64 macros to mark types changing their size, like intptr_t.
+#ifndef _W64
+#  if !defined(__midl) && (defined(_X86_) || defined(_M_IX86)) && _MSC_VER >= 1300
+#     define _W64 __w64
+#  else
+#     define _W64
+#  endif
+#endif
+
+
+// 7.18.1 Integer types
+
+// 7.18.1.1 Exact-width integer types
+
+// Visual Studio 6 and Embedded Visual C++ 4 doesn't
+// realize that, e.g. char has the same size as __int8
+// so we give up on __intX for them.
+#if (_MSC_VER < 1300)
+   typedef signed char       int8_t;
+   typedef signed short      int16_t;
+   typedef signed int        int32_t;
+   typedef unsigned char     uint8_t;
+   typedef unsigned short    uint16_t;
+   typedef unsigned int      uint32_t;
+#else
+   typedef signed __int8     int8_t;
+   typedef signed __int16    int16_t;
+   typedef signed __int32    int32_t;
+   typedef unsigned __int8   uint8_t;
+   typedef unsigned __int16  uint16_t;
+   typedef unsigned __int32  uint32_t;
+#endif
+typedef signed __int64       int64_t;
+typedef unsigned __int64     uint64_t;
+
+
+// 7.18.1.2 Minimum-width integer types
+typedef int8_t    int_least8_t;
+typedef int16_t   int_least16_t;
+typedef int32_t   int_least32_t;
+typedef int64_t   int_least64_t;
+typedef uint8_t   uint_least8_t;
+typedef uint16_t  uint_least16_t;
+typedef uint32_t  uint_least32_t;
+typedef uint64_t  uint_least64_t;
+
+// 7.18.1.3 Fastest minimum-width integer types
+typedef int8_t    int_fast8_t;
+typedef int16_t   int_fast16_t;
+typedef int32_t   int_fast32_t;
+typedef int64_t   int_fast64_t;
+typedef uint8_t   uint_fast8_t;
+typedef uint16_t  uint_fast16_t;
+typedef uint32_t  uint_fast32_t;
+typedef uint64_t  uint_fast64_t;
+
+// 7.18.1.4 Integer types capable of holding object pointers
+#ifdef _WIN64 // [
+   typedef signed __int64    intptr_t;
+   typedef unsigned __int64  uintptr_t;
+#else // _WIN64 ][
+   typedef _W64 signed int   intptr_t;
+   typedef _W64 unsigned int uintptr_t;
+#endif // _WIN64 ]
+
+// 7.18.1.5 Greatest-width integer types
+typedef int64_t   intmax_t;
+typedef uint64_t  uintmax_t;
+
+
+// 7.18.2 Limits of specified-width integer types
+
+#if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
+
+// 7.18.2.1 Limits of exact-width integer types
+#define INT8_MIN     ((int8_t)_I8_MIN)
+#define INT8_MAX     _I8_MAX
+#define INT16_MIN    ((int16_t)_I16_MIN)
+#define INT16_MAX    _I16_MAX
+#define INT32_MIN    ((int32_t)_I32_MIN)
+#define INT32_MAX    _I32_MAX
+#define INT64_MIN    ((int64_t)_I64_MIN)
+#define INT64_MAX    _I64_MAX
+#define UINT8_MAX    _UI8_MAX
+#define UINT16_MAX   _UI16_MAX
+#define UINT32_MAX   _UI32_MAX
+#define UINT64_MAX   _UI64_MAX
+
+// 7.18.2.2 Limits of minimum-width integer types
+#define INT_LEAST8_MIN    INT8_MIN
+#define INT_LEAST8_MAX    INT8_MAX
+#define INT_LEAST16_MIN   INT16_MIN
+#define INT_LEAST16_MAX   INT16_MAX
+#define INT_LEAST32_MIN   INT32_MIN
+#define INT_LEAST32_MAX   INT32_MAX
+#define INT_LEAST64_MIN   INT64_MIN
+#define INT_LEAST64_MAX   INT64_MAX
+#define UINT_LEAST8_MAX   UINT8_MAX
+#define UINT_LEAST16_MAX  UINT16_MAX
+#define UINT_LEAST32_MAX  UINT32_MAX
+#define UINT_LEAST64_MAX  UINT64_MAX
+
+// 7.18.2.3 Limits of fastest minimum-width integer types
+#define INT_FAST8_MIN    INT8_MIN
+#define INT_FAST8_MAX    INT8_MAX
+#define INT_FAST16_MIN   INT16_MIN
+#define INT_FAST16_MAX   INT16_MAX
+#define INT_FAST32_MIN   INT32_MIN
+#define INT_FAST32_MAX   INT32_MAX
+#define INT_FAST64_MIN   INT64_MIN
+#define INT_FAST64_MAX   INT64_MAX
+#define UINT_FAST8_MAX   UINT8_MAX
+#define UINT_FAST16_MAX  UINT16_MAX
+#define UINT_FAST32_MAX  UINT32_MAX
+#define UINT_FAST64_MAX  UINT64_MAX
+
+// 7.18.2.4 Limits of integer types capable of holding object pointers
+#ifdef _WIN64 // [
+#  define INTPTR_MIN   INT64_MIN
+#  define INTPTR_MAX   INT64_MAX
+#  define UINTPTR_MAX  UINT64_MAX
+#else // _WIN64 ][
+#  define INTPTR_MIN   INT32_MIN
+#  define INTPTR_MAX   INT32_MAX
+#  define UINTPTR_MAX  UINT32_MAX
+#endif // _WIN64 ]
+
+// 7.18.2.5 Limits of greatest-width integer types
+#define INTMAX_MIN   INT64_MIN
+#define INTMAX_MAX   INT64_MAX
+#define UINTMAX_MAX  UINT64_MAX
+
+// 7.18.3 Limits of other integer types
+
+#ifdef _WIN64 // [
+#  define PTRDIFF_MIN  _I64_MIN
+#  define PTRDIFF_MAX  _I64_MAX
+#else  // _WIN64 ][
+#  define PTRDIFF_MIN  _I32_MIN
+#  define PTRDIFF_MAX  _I32_MAX
+#endif  // _WIN64 ]
+
+#define SIG_ATOMIC_MIN  INT_MIN
+#define SIG_ATOMIC_MAX  INT_MAX
+
+#ifndef SIZE_MAX // [
+#  ifdef _WIN64 // [
+#     define SIZE_MAX  _UI64_MAX
+#  else // _WIN64 ][
+#     define SIZE_MAX  _UI32_MAX
+#  endif // _WIN64 ]
+#endif // SIZE_MAX ]
+
+// WCHAR_MIN and WCHAR_MAX are also defined in <wchar.h>
+#ifndef WCHAR_MIN // [
+#  define WCHAR_MIN  0
+#endif  // WCHAR_MIN ]
+#ifndef WCHAR_MAX // [
+#  define WCHAR_MAX  _UI16_MAX
+#endif  // WCHAR_MAX ]
+
+#define WINT_MIN  0
+#define WINT_MAX  _UI16_MAX
+
+#endif // __STDC_LIMIT_MACROS ]
+
+
+// 7.18.4 Limits of other integer types
+
+#if !defined(__cplusplus) || defined(__STDC_CONSTANT_MACROS) // [   See footnote 224 at page 260
+
+// 7.18.4.1 Macros for minimum-width integer constants
+
+#define INT8_C(val)  val##i8
+#define INT16_C(val) val##i16
+#define INT32_C(val) val##i32
+#define INT64_C(val) val##i64
+
+#define UINT8_C(val)  val##ui8
+#define UINT16_C(val) val##ui16
+#define UINT32_C(val) val##ui32
+#define UINT64_C(val) val##ui64
+
+// 7.18.4.2 Macros for greatest-width integer constants
+// These #ifndef's are needed to prevent collisions with <boost/cstdint.hpp>.
+// Check out Issue 9 for the details.
+#ifndef INTMAX_C //   [
+#  define INTMAX_C   INT64_C
+#endif // INTMAX_C    ]
+#ifndef UINTMAX_C //  [
+#  define UINTMAX_C  UINT64_C
+#endif // UINTMAX_C   ]
+
+#endif // __STDC_CONSTANT_MACROS ]
+
+#endif // _MSC_VER >= 1600 ]
+
+#endif // _MSC_STDINT_H_ ]

--- a/mdtraj/formats/xtc/include/trr_header.h
+++ b/mdtraj/formats/xtc/include/trr_header.h
@@ -1,0 +1,30 @@
+#ifndef _trr_header_h_
+#define _trr_header_h_
+
+typedef struct		/* This struct describes the order and the	*/
+/* sizes of the structs in a trjfile, sizes are given in bytes.	*/
+{
+    int  bDouble;        /* Double precision?                            */
+    int	ir_size;	/* Backward compatibility		        */
+    int	e_size;		/* Backward compatibility		        */
+    int	box_size;	/* Non zero if a box is present			*/
+    int   vir_size;       /* Backward compatibility		        */
+    int   pres_size;      /* Backward compatibility		        */
+    int	top_size;	/* Backward compatibility		        */
+    int	sym_size;	/* Backward compatibility		        */
+    int	x_size;		/* Non zero if coordinates are present		*/
+    int	v_size;		/* Non zero if velocities are present		*/
+    int	f_size;		/* Non zero if forces are present		*/
+
+    int	natoms;		/* The total number of atoms			*/
+    int	step;		/* Current step number				*/
+    int	nre;		/* Backward compatibility		        */
+    float	tf;		/* Current time					*/
+    float	lambdaf;		/* Current value of lambda			*/
+    double	td;		/* Current time					*/
+    double	lambdad;		/* Current value of lambda			*/
+} t_trnheader;
+
+int do_trnheader(XDRFILE *xd, char bRead, t_trnheader *sh);
+
+#endif

--- a/mdtraj/formats/xtc/include/xdr_seek.h
+++ b/mdtraj/formats/xtc/include/xdr_seek.h
@@ -1,0 +1,16 @@
+#ifndef _xdr_seek_h
+#define _xdr_seek_h
+
+// for int64_t on older M$ Visual Studio
+#if _MSC_VER && _MSVC_VER < 1600 && !__INTEL_COMPILER
+	#include "ms_stdint.h"
+#else
+	#include <stdint.h>
+#endif
+
+#include "xdrfile.h"
+
+int64_t xdr_tell(XDRFILE *xd);
+int xdr_seek(XDRFILE *xd, int64_t pos, int whence);
+
+#endif

--- a/mdtraj/formats/xtc/include/xdrfile.h
+++ b/mdtraj/formats/xtc/include/xdrfile.h
@@ -70,9 +70,9 @@
  * documentation on the FORTRAN interface!
  */
 
-
 #ifndef _XDRFILE_H_
 #define _XDRFILE_H_
+
 
 #ifdef __cplusplus
 extern "C" 

--- a/mdtraj/formats/xtc/include/xdrfile_trr.h
+++ b/mdtraj/formats/xtc/include/xdrfile_trr.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #include "xdrfile.h"
   
-  /* All functions return exdrOK if succesfull. 
+  /* All functions return exdrOK if successful.
    * (error codes defined in xdrfile.h).
    */  
    

--- a/mdtraj/formats/xtc/src/README
+++ b/mdtraj/formats/xtc/src/README
@@ -14,3 +14,4 @@ Changes from upsteam's xdrfile-1.1.4 include:
  - Addition of read_trr_nframes function in xdrfile_trr.c
  - Bugfix in do_trnheader to return the appropriate error code when reading magic, and properly check the value of the magic in xdrfile_trr.c
  - Bugfix of float exception (divide by zero) in xdrfile.c, see https://github.com/SimTk/mdtraj/issues/616
+ - Implemented efficient seeking pattern inspired by xdrlib2 (part of MDAnalysis)

--- a/mdtraj/formats/xtc/src/xdr_seek.c
+++ b/mdtraj/formats/xtc/src/xdr_seek.c
@@ -1,0 +1,50 @@
+/* 64 bit fileseek operations */
+#define _FILE_OFFSETS_BITS 64
+#include "xdr_seek.h"
+#include <stdio.h>
+
+/// copied from xtcfile.c (version 1.1.4)
+struct XDRFILE
+{
+    FILE *   fp;       /**< pointer to standard C library file handle */
+    void * /*this used to be (XDR*) */   xdr;      /**< pointer to corresponding XDR handle       */
+    char     mode;     /**< r=read, w=write, a=append                 */
+    int *    buf1;     /**< Buffer for internal use                   */
+    int      buf1size; /**< Current allocated length of buf1          */
+    int *    buf2;     /**< Buffer for internal use                   */
+    int      buf2size; /**< Current allocated length of buf2          */
+};
+//// end of copied
+
+int64_t xdr_tell(XDRFILE *xd)
+{
+	FILE* fptr = xd->fp;
+
+#ifndef _WIN32
+	// use posix 64 bit ftell version
+	return ftello(fptr);
+#elif defined(_MSVC_VER) && !__INTEL_COMPILER
+	return _ftelli64(fptr);
+#else
+	return ftell(fptr);
+#endif
+}
+
+int xdr_seek(XDRFILE *xd, int64_t pos, int whence)
+{
+	int result = 1;
+	FILE* fptr = xd->fp;
+
+#ifndef _WIN32
+	// use posix 64 bit ftell version
+	result = fseeko(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
+#elif _MSVC_VER && !__INTEL_COMPILER
+	result = _fseeki64(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
+#else
+	result = fseek(fptr, pos, whence) < 0 ? exdrNR : exdrOK;
+#endif
+	if (result != exdrOK)
+		return result;
+
+	return exdrOK;
+}

--- a/mdtraj/formats/xtc/src/xdrfile_trr.c
+++ b/mdtraj/formats/xtc/src/xdrfile_trr.c
@@ -87,7 +87,7 @@ static int nFloatSize(t_trnheader *sh,int *nflsz)
     return exdrOK;
 }
 
-static int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
+extern int do_trnheader(XDRFILE *xd,mybool bRead,t_trnheader *sh)
 {
 	int magic=GROMACS_MAGIC;
 	int nflsz,slen,result;

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -29,6 +29,7 @@
 import os
 import warnings
 import cython
+import xdrlib
 cimport cython
 import numpy as np
 cimport numpy as np
@@ -37,9 +38,12 @@ from mdtraj.utils import ensure_type, cast_indices, in_units_of
 from mdtraj.utils.six import string_types
 from mdtraj.formats.registry import FormatRegistry
 cimport trrlib
+cimport xdrlib
+from libc.stdio cimport SEEK_SET, SEEK_CUR
+
+ctypedef np.npy_int64   int64_t
 
 __all__ = ['load_trr', 'TRRTrajectoryFile']
-
 
 ###############################################################################
 # globals
@@ -73,7 +77,7 @@ if sizeof(float) != sizeof(np.float32_t):
 # Code
 ###############################################################################
 
-@FormatRegistry.register_loader('.trr')
+@_FormatRegistry.register_loader('.trr')
 def load_trr(filename, top=None, stride=None, atom_indices=None, frame=None):
     """load_trr(filename, top=None, stride=None, atom_indices=None, frame=None)
 
@@ -127,7 +131,7 @@ def load_trr(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     if not isinstance(filename, string_types):
         raise TypeError('filename must be of type string for load_trr. '
-            'you supplied %s' % type(filename))
+                        'you supplied %s' % type(filename))
 
     topology = _parse_topology(top)
     atom_indices = cast_indices(atom_indices)
@@ -189,16 +193,16 @@ cdef class TRRTrajectoryFile:
     cdef trrlib.XDRFILE* fh
     cdef str filename
     cdef int n_atoms          # number of atoms in the file
-    cdef unsigned long n_frames  # numnber of frames in the file, cached
-    cdef int frame_counter    # current position in the file, in read mode
-    cdef int is_open          # is the file handle currently open?
-    cdef int approx_n_frames  # appriximate number of frames in the file, as guessed based on its size
+    cdef int64_t n_frames  # numnber of frames in the file, cached
+    cdef int64_t frame_counter    # current position in the file, in read mode
+    cdef char is_open          # is the file handle currently open?
+    cdef int64_t approx_n_frames  # appriximate number of frames in the file, as guessed based on its size
     cdef char* mode           # mode in which the file is open, either 'r' or 'w'
     cdef int min_chunk_size
     cdef float chunk_size_multiplier
-    cdef int with_unitcell    # used in mode='w' to know if we're writing unitcells or nor
+    cdef char with_unitcell    # used in mode='w' to know if we're writing unitcells or nor
     cdef readonly char* distance_unit
-
+    cdef np.ndarray _offsets
 
     def __cinit__(self, char* filename, char* mode='r', force_overwrite=True, **kwargs):
         """Open a GROMACS TRR file for reading/writing.
@@ -208,6 +212,7 @@ cdef class TRRTrajectoryFile:
         self.frame_counter = 0
         self.n_frames = -1
         self.filename = filename
+        self._offsets = None
 
         if str(mode) == 'r':
             self.n_atoms = 0
@@ -225,7 +230,6 @@ cdef class TRRTrajectoryFile:
 
             self.min_chunk_size = max(kwargs.pop('min_chunk_size', 100), 1)
             self.chunk_size_multiplier = max(kwargs.pop('chunk_size_multiplier', 1.5), 0.01)
-
 
         elif str(mode) == 'w':
             if force_overwrite and os.path.exists(filename):
@@ -245,10 +249,24 @@ cdef class TRRTrajectoryFile:
         self.mode = mode
 
     def _estimate_n_frames_from_filesize(self, filesize):
-        # this approximation is pretty bad. on 5000/500 frames, 50/100 atoms,
-        # it seems to be about 30%
-        approx_n_frames = filesize / ((self.n_atoms * 2 * + 16) / 2)
-        return approx_n_frames
+        # read the first header, sum the size of all data fields and extrapolate.
+        cdef trrlib.t_trnheader header
+        cdef int frame_size, header_size
+        cdef int64_t n_frames, old_pos
+
+        old_pos = xdrlib.xdr_tell(self.fh)
+        try:
+            xdrlib.xdr_seek(self.fh, 0, SEEK_SET)
+            if trrlib.do_trnheader(self.fh, 1, &header) != 0:
+                raise RuntimeError("could not read header of first frame!")
+        finally:
+            xdrlib.xdr_seek(self.fh, old_pos, SEEK_SET)
+
+        header_size = xdrlib.xdr_tell(self.fh)
+        frame_size = sum((<int*> &header)[i] for i in range(1, 11))
+        n_frames = filesize / (frame_size + header_size)
+
+        return n_frames
 
     def __dealloc__(self):
         self.close()
@@ -354,6 +372,7 @@ cdef class TRRTrajectoryFile:
                 box = None
             return xyz, time, step, box, lambd
 
+        # TODO: investigate if this is neccessary because TRR should have constant offsets!
         # if they want ALL of the remaining frames, we need to guess at the chunk
         # size, and then check the exit status to make sure we're really at the EOF
         all_xyz, all_time, all_step, all_box, all_lambd = [], [], [], [], []
@@ -363,6 +382,7 @@ cdef class TRRTrajectoryFile:
             # think are in the file and how many we've currently read
             chunk = max(abs(int((self.approx_n_frames - self.frame_counter) * self.chunk_size_multiplier)),
                         self.min_chunk_size)
+
             xyz, time, step, box, lambd = self._read(chunk, atom_indices)
             if len(xyz) <= 0:
                 break
@@ -382,7 +402,7 @@ cdef class TRRTrajectoryFile:
             all_box = None
         return all_xyz, all_time, all_step, all_box, all_lambd
 
-    def _read(self, int n_frames, atom_indices):
+    def _read(self, int64_t n_frames, atom_indices):
         """Read a specified number of TRR frames from the buffer"""
 
         cdef int i = 0
@@ -414,8 +434,6 @@ cdef class TRRTrajectoryFile:
 
         # only used if atom_indices is given
         cdef np.ndarray[dtype=np.float32_t, ndim=2] framebuffer = np.zeros((self.n_atoms, 3), dtype=np.float32)
-
-
 
         while (i < n_frames) and (status != _EXDRENDOFFILE):
             if atom_indices is None:
@@ -547,10 +565,8 @@ cdef class TRRTrajectoryFile:
             2: move relative to the end of file, offset should be <= 0.
             Seeking beyond the end of a file is not supported
         """
-        cdef int i, status, step
-        cdef float time, prec, lambd
-        cdef np.ndarray[dtype=np.float_t] box = np.empty(9, dtype=np.float)
-        cdef np.ndarray[dtype=np.float_t] xyz = np.empty(self.n_atoms * 3, dtype=np.float)
+        cdef int status
+        cdef int64_t pos
 
         if str(self.mode) != 'r':
             raise NotImplementedError('seek() only available in mode="r" currently')
@@ -563,14 +579,10 @@ cdef class TRRTrajectoryFile:
         else:
             raise IOError('Invalid argument')
 
-        trrlib.xdrfile_close(self.fh)
-        self.fh = trrlib.xdrfile_open(self.filename, self.mode)
-
-        for i in range(absolute):
-            status = trrlib.read_trr(self.fh, self.n_atoms, &step, &time,
-                &lambd, <trrlib.matrix>&box[0], <trrlib.rvec*>&xyz[0], NULL, NULL)
-            if status != _EXDROK:
-                raise RuntimeError('TRR seek error: %s' % status)
+        pos = self.offsets[absolute]
+        status = xdrlib.xdr_seek(self.fh, pos, SEEK_SET)
+        if status != 0:
+            raise RuntimeError('TRR seek error: %s' % status)
 
         self.frame_counter = absolute
 
@@ -585,6 +597,64 @@ cdef class TRRTrajectoryFile:
         if str(self.mode) != 'r':
             raise NotImplementedError('tell() only available in mode="r" currently')
         return int(self.frame_counter)
+
+    @property
+    def offsets(self):
+        """get byte offsets from current xtc file
+        See Also
+        --------
+        set_offsets
+        """
+        if self._offsets is None:
+            self.n_frames, self._offsets = self._calc_len_and_offsets()
+        return self._offsets
+
+    @offsets.setter
+    def offsets(self, offsets):
+        """set frame offsets"""
+        self._offsets = offsets
+
+    def _calc_len_and_offsets(self):
+        """read byte offsets from TRR file directly"""
+        cdef int status, i, frame_size, frame_offset, header_size
+        cdef int64_t file_size
+        cdef unsigned long n_frames
+        cdef np.ndarray[ndim=1, dtype=np.npy_int64] offsets
+        cdef trrlib.t_trnheader header
+
+        import os
+        file_size = os.stat(self.filename).st_size
+        cdef int64_t old_pos = xdrlib.xdr_tell(self.fh)
+
+        try:
+            xdrlib.xdr_seek(self.fh, 0, SEEK_SET)
+            if trrlib.do_trnheader(self.fh, 1, &header) != 0:
+                raise RuntimeError("could not read header of first frame!")
+            header_size = xdrlib.xdr_tell(self.fh)
+            frame_size = sum((<int*> &header)[i] for i in range(1, 11))
+
+            size = file_size / (frame_size + header_size)
+            offsets = np.empty(size, dtype=np.int64)
+            n_frames = 1
+            offsets[0] = 0
+
+            while True:
+                status = xdrlib.xdr_seek(self.fh, frame_size, SEEK_CUR)
+                if status != 0:
+                    raise RuntimeError("could not seek...")
+                frame_offset = xdrlib.xdr_tell(self.fh)
+                if trrlib.do_trnheader(self.fh, 1, &header) != 0:
+                    break
+
+                frame_size = sum((<int*> &header)[i] for i in range(1, 11))
+                if n_frames == len(offsets):
+                    offsets = np.resize(offsets, int(len(offsets)*1.2))
+                offsets[n_frames] = frame_offset
+                n_frames += 1
+        finally:
+            xdrlib.xdr_seek(self.fh, old_pos, SEEK_SET)
+
+        return n_frames, offsets[:n_frames]
 
     def __enter__(self):
         "Support the context manager protocol"
@@ -601,6 +671,7 @@ cdef class TRRTrajectoryFile:
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.n_frames == -1:
-            trrlib.read_trr_nframes(self.filename, &self.n_frames)
+            self.offsets
         return int(self.n_frames)
-FormatRegistry.register_fileobject('.trr')(TRRTrajectoryFile)
+
+_FormatRegistry.register_fileobject('.trr')(TRRTrajectoryFile)

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -77,7 +77,7 @@ if sizeof(float) != sizeof(np.float32_t):
 # Code
 ###############################################################################
 
-@_FormatRegistry.register_loader('.trr')
+@FormatRegistry.register_loader('.trr')
 def load_trr(filename, top=None, stride=None, atom_indices=None, frame=None):
     """load_trr(filename, top=None, stride=None, atom_indices=None, frame=None)
 
@@ -674,4 +674,4 @@ cdef class TRRTrajectoryFile:
             self.offsets
         return int(self.n_frames)
 
-_FormatRegistry.register_fileobject('.trr')(TRRTrajectoryFile)
+FormatRegistry.register_fileobject('.trr')(TRRTrajectoryFile)

--- a/mdtraj/formats/xtc/trrlib.pxd
+++ b/mdtraj/formats/xtc/trrlib.pxd
@@ -9,7 +9,6 @@ cdef extern from "include/xdrfile.h":
 
 
 cdef extern from "include/xdrfile_trr.h":
-
     int read_trr_natoms(char *fn, int *natoms)
     int read_trr_nframes(char* fn, unsigned long *nframes)
 
@@ -21,3 +20,10 @@ cdef extern from "include/xdrfile_trr.h":
     # Write a frame to xtc file
     int write_trr(XDRFILE *xd, int natoms, int step, float t, float lambd,
         matrix box, rvec* x, rvec* v, rvec* f)
+
+cdef extern from "include/trr_header.h":
+    ctypedef struct t_trnheader:
+        pass
+
+    # header
+    int do_trnheader(XDRFILE *xd, int bRead, t_trnheader *sh)

--- a/mdtraj/formats/xtc/xdrlib.pxd
+++ b/mdtraj/formats/xtc/xdrlib.pxd
@@ -1,3 +1,4 @@
+
 cdef extern from "include/xdrfile.h":
     ctypedef struct XDRFILE:
         pass
@@ -11,4 +12,12 @@ cdef extern from "include/xdrfile_xtc.h":
     int read_xtc_natoms(char* fn, int* natoms)
     int read_xtc(XDRFILE *xd, int natoms, int *step, float *time, matrix box, rvec *x, float *prec)
     int write_xtc(XDRFILE *xd, int natoms, int step, float time, matrix box, rvec* x, float prec)
-    int read_xtc_nframes(char* fn, unsigned long *nframes)
+    int xdrfile_read_int(int * ptr, int ndata, XDRFILE *xfp)
+
+
+cimport numpy as np
+ctypedef np.npy_int64 int64_t
+
+cdef extern from "include/xdr_seek.h":
+    int64_t xdr_tell(XDRFILE *xd)
+    int xdr_seek(XDRFILE *xd, int64_t pos, int whence)

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -104,7 +104,7 @@ cdef int XTC_HEADER_SIZE = 11*sizeof(np.int32_t) + 2*sizeof(np.float32_t) + DIM*
 # Code
 ###############################################################################
 
-@_FormatRegistry.register_loader('.xtc')
+@FormatRegistry.register_loader('.xtc')
 def load_xtc(filename, top=None, stride=None, atom_indices=None, frame=None):
     """load_xtc(filename, top=None, stride=None, atom_indices=None, frame=None)
 
@@ -697,4 +697,4 @@ cdef class XTCTrajectoryFile(object):
             self.offsets # invokes _calc_len_and_offsets
         return int(self.n_frames)
 
-_FormatRegistry.register_fileobject('.xtc')(XTCTrajectoryFile)
+FormatRegistry.register_fileobject('.xtc')(XTCTrajectoryFile)

--- a/mdtraj/tests/test_trr.py
+++ b/mdtraj/tests/test_trr.py
@@ -55,25 +55,25 @@ def test_1():
 
 def test_read_stride():
     with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
-         xyz, time, step, box, lambd = f.read()
+        xyz, time, step, box, lambd = f.read()
     with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
-         xyz3, time3, step3, box3, lambd3 = f.read(stride=3)
+        xyz3, time3, step3, box3, lambd3 = f.read(stride=3)
     yield lambda: eq(xyz[::3], xyz3)
     yield lambda: eq(step[::3], step3)
     yield lambda: eq(box[::3], box3)
     yield lambda: eq(time[::3], time3)
+
 
 def test_read_stride_2():
     "trr read stride when n_frames is supplied (different path)"
     with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
-         xyz, time, step, box, lambd = f.read()
+        xyz, time, step, box, lambd = f.read()
     with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
-         xyz3, time3, step3, box3, lambd3 = f.read(n_frames=1000, stride=3)
+        xyz3, time3, step3, box3, lambd3 = f.read(n_frames=1000, stride=3)
     yield lambda: eq(xyz[::3], xyz3)
     yield lambda: eq(step[::3], step3)
     yield lambda: eq(box[::3], box3)
     yield lambda: eq(time[::3], time3)
-
 
 
 def test_15():
@@ -96,22 +96,23 @@ def test_15():
 
 def test_read_atomindices_1():
     with TRRTrajectoryFile(temp) as f:
-         xyz, time, step, box, lambd = f.read()
+        xyz, time, step, box, lambd = f.read()
 
     with TRRTrajectoryFile(temp) as f:
-         xyz2, time2, step2, box2, lambd2 = f.read(atom_indices=[0,1,2])
+        xyz2, time2, step2, box2, lambd2 = f.read(atom_indices=[0,1,2])
     yield lambda: eq(xyz[:, [0,1,2]], xyz2)
     yield lambda: eq(step, step2)
     yield lambda: eq(box, box2)
     yield lambda: eq(lambd, lambd2)
     yield lambda: eq(time, time2)
 
+
 def test_read_atomindices_2():
     with TRRTrajectoryFile(temp) as f:
-         xyz, time, step, box, lambd = f.read()
+        xyz, time, step, box, lambd = f.read()
 
     with TRRTrajectoryFile(temp) as f:
-         xyz2, time2, step2, box2, lambd2 = f.read(atom_indices=slice(None, None, 2))
+        xyz2, time2, step2, box2, lambd2 = f.read(atom_indices=slice(None, None, 2))
     yield lambda: eq(xyz[:, ::2], xyz2)
     yield lambda: eq(step, step2)
     yield lambda: eq(box, box2)
@@ -138,7 +139,6 @@ def test_2():
     yield lambda: eq(lambd, lambd2)
 
 
-
 def test_ragged_1():
     # try first writing no box vectors,, and then adding some
     xyz = np.random.randn(100, 5, 3)
@@ -159,3 +159,43 @@ def test_ragged_2():
     with TRRTrajectoryFile(temp, 'w', force_overwrite=True) as f:
         f.write(xyz, time=time, box=box)
         assert_raises(ValueError, lambda: f.write(xyz))
+
+
+def test_tell():
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        eq(f.tell(), 0)
+
+        f.read(101)
+        eq(f.tell(), 101)
+
+        f.read(3)
+        eq(f.tell(), 104)
+
+
+def test_seek():
+    reference = TRRTrajectoryFile(get_fn('frame0.trr')).read()[0]
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        eq(len(f), len(reference))
+        eq(len(f.offsets), len(reference))
+
+        eq(f.tell(), 0)
+        eq(f.read(1)[0][0], reference[0])
+        eq(f.tell(), 1)
+
+        xyz = f.read(1)[0][0]
+        eq(xyz, reference[1])
+        eq(f.tell(), 2)
+
+        f.seek(0)
+        eq(f.tell(), 0)
+        xyz = f.read(1)[0][0]
+        eq(f.tell(), 1)
+        eq(xyz, reference[0])
+
+        f.seek(5)
+        eq(f.read(1)[0][0], reference[5])
+        eq(f.tell(), 6)
+
+        f.seek(-5, 1)
+        eq(f.tell(), 1)
+        eq(f.read(1)[0][0], reference[1])

--- a/mdtraj/tests/test_xtc.py
+++ b/mdtraj/tests/test_xtc.py
@@ -216,7 +216,7 @@ def test_seek():
         eq(f.tell(), 0)
         eq(f.read(1)[0][0], reference[0])
         eq(f.tell(), 1)
-        
+
         xyz = f.read(1)[0][0]
         eq(xyz, reference[1])
         eq(f.tell(), 2)
@@ -226,14 +226,36 @@ def test_seek():
         xyz = f.read(1)[0][0]
         eq(f.tell(), 1)
         eq(xyz, reference[0])
-        
-        f.seek(5)
+
+        f.seek(5) # offset array is going to be built
+        assert len(f.offsets) == len(reference)
         eq(f.read(1)[0][0], reference[5])
         eq(f.tell(), 6)
-        
+
         f.seek(-5, 1)
         eq(f.tell(), 1)
         eq(f.read(1)[0][0], reference[1])
+
+
+def test_seek_natoms9():
+    # create a xtc file with 9 atoms and seek it.
+    with XTCTrajectoryFile(get_fn('frame0.xtc'), 'r') as fh:
+        xyz = fh.read()[0][:, :9, :]
+
+    with XTCTrajectoryFile(temp, 'w', force_overwrite=True) as f:
+        f.write(xyz)
+
+    with XTCTrajectoryFile(temp, 'r') as f:
+        eq(f.read(1)[0].shape, (1, 9, 3))
+        eq(f.tell(), 1)
+        f.seek(99)
+        eq(f.read(1)[0].squeeze(), xyz[99])
+        # seek relative
+        f.seek(-1, 1)
+        eq(f.read(1)[0].squeeze(), xyz[99])
+
+        f.seek(0, 0)
+        eq(f.read(1)[0].squeeze(), xyz[0])
 
 
 def test_ragged_1():

--- a/setup.py
+++ b/setup.py
@@ -96,14 +96,17 @@ def format_extensions():
 
     xtc = Extension('mdtraj.formats.xtc',
                     sources=['mdtraj/formats/xtc/src/xdrfile.c',
+                             'mdtraj/formats/xtc/src/xdr_seek.c',
                              'mdtraj/formats/xtc/src/xdrfile_xtc.c',
-                             'mdtraj/formats/xtc/xtc.pyx'],
+                             'mdtraj/formats/xtc/xtc.pyx',
+                             ],
                     include_dirs=['mdtraj/formats/xtc/include/',
                                   'mdtraj/formats/xtc/'],
                     extra_compile_args=compiler_args)
 
     trr = Extension('mdtraj.formats.trr',
                     sources=['mdtraj/formats/xtc/src/xdrfile.c',
+                             'mdtraj/formats/xtc/src/xdr_seek.c',
                              'mdtraj/formats/xtc/src/xdrfile_trr.c',
                              'mdtraj/formats/xtc/trr.pyx'],
                     include_dirs=['mdtraj/formats/xtc/include/',


### PR DESCRIPTION
This method will read an integer per frame to determine the byte offsets between
frames for XTC files. TRR files on the other hand store the sizes of a frame in
a private data structure in xdrlib (which has been exposed to handle this).

For small XTC files (<= 9 atoms), the coordinates are written uncompressed,
which is reflected in the offset calculation.

Note that the amount of bytes needed for frames can be figured out by reading
the original source code of xdrlib (GROMACS).

The byte offset array will only be constructed if requested by the user,if he/she
wants to know the lengths of the trajectory or he/she demands random access
(seeking). The offsets are accessible via a property of the
XTC|TRRTrajectoryFile and cached (stored to disk and restored via the setter).