### PR TITLE
Generalized gro file parsing of file comment

### DIFF
--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -52,7 +52,7 @@
 import os
 import sys
 import itertools
-from re import sub, match
+from re import sub, match, findall
 # import element as elem
 import numpy as np
 
@@ -372,7 +372,7 @@ class GroTrajectoryFile(object):
         time = None
         if 't=' in comment:
             # title string (free format string, optional time in ps after 't=')
-            time = float(comment[comment.index('t=')+2:].strip())
+            time = float(findall('t= *(\d+\.\d+)',comment)[-1])
 
         # box vectors (free format, space separated reals), values: v1(x) v2(y)
         # v3(z) v1(y) v1(z) v2(x) v2(z) v3(x) v3(y), the last 6 values may be


### PR DESCRIPTION
When you extract a GRO file using ```trjconv``` it often auto generates a comment for the top of the file that includes the text t= framenum. In my workflow, I extract frames and then resolvate the target protein. The gromacs tool ```solvate``` then adds "in water" to the end of the comment string. 

 This results in the following auto-generated GRO file, where the comment includes text after the numeric timestep value.

```
Protein t= 3000.00000 in water
13
    2ALA      N    1   7.293   1.835   0.876 -0.6990 -0.1367  0.0623
    2ALA    HT1    2   7.295   1.777   0.794 -0.8018 -0.1406  0.0630
    2ALA    HT2    3   7.249   1.836   0.966 -0.7856 -0.0003  0.0192
    2ALA     CA    4   7.379   1.951   0.859 -0.3148 -0.4056  0.1486
    2ALA     HA    5   7.423   1.943   0.761 -0.2301 -0.6462  0.2067
    2ALA   MCB1    6   7.249   2.050   0.819 -0.5195 -0.6462  0.2166
    2ALA   MCB2    7   7.294   2.093   0.889  0.3479  0.2217 -0.7950
    2ALA     CB    8   7.276   2.066   0.854 -0.0968 -0.2215 -0.2684
    2ALA    HB1    9   7.201   2.046   0.775 -1.0098 -1.1434  0.7559
    2ALA    HB2   10   7.224   2.074   0.952  0.9527  1.1953  0.2402
    2ALA    HB3   11   7.327   2.162   0.832 -0.0708 -0.5792 -2.1119
    2ALA      C   12   7.491   1.978   0.954 -0.3717  0.2391  0.0445
    2ALA      O   13   7.599   1.920   0.944 -0.5665 -0.0399 -0.5726
   9.90561   9.90561   7.00433   0.00000   0.00000   0.00000   0.00000   4.95281   4.95281
```

This causes the GRO parser to crash at `mdtraj/formats/gro.py:375` since it is assumed that no text will occur after the timestep.:
```
time = float(comment[comment.index('t=')+2:].strip())
```
The fix is quite simple with a regular expression, which `gro.py` already imports. My RE string, matches any decimal number after "dt=" and in the bizarre case where multiple dt= instances exist, it selects the last number found.