### PR TITLE
Rename `segment_id` to `id`

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -369,7 +369,7 @@ class Topology(object):
         for chain in value.chains():
             c = out.add_chain()
             for residue in chain.residues():
-                r = out.add_residue(residue.name, c, residue.segment_id)
+                r = out.add_residue(residue.name, c, residue.id)
                 for atom in residue.atoms():
                     if atom.element is None:
                         element = elem.virtual


### PR DESCRIPTION
Quickfix to adapt to changes from openmm. They seem to have changed `residue.segment_id` to `residue.id` this causes `mdtraj.Topology.from_openmm` to fail.

Resolves issue #1047.