### PR TITLE
Improve load_frame to support partial loading

### DIFF
--- a/mdtraj/formats/arc.py
+++ b/mdtraj/formats/arc.py
@@ -82,8 +82,15 @@ def load_arc(filename, stride=None, atom_indices=None, frame=None):
 
     with ArcTrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(n_frames=n_frames, stride=stride,

--- a/mdtraj/formats/binpos/binpos.pyx
+++ b/mdtraj/formats/binpos/binpos.pyx
@@ -122,8 +122,15 @@ def load_binpos(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with BINPOSTrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
 

--- a/mdtraj/formats/dcd/dcd.pyx
+++ b/mdtraj/formats/dcd/dcd.pyx
@@ -135,8 +135,15 @@ def load_dcd(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with DCDTrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = int((stop - start) / stride)
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(topology, n_frames=n_frames, stride=stride, atom_indices=atom_indices)

--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -90,8 +90,15 @@ def load_gro(filename, stride=None, atom_indices=None, frame=None):
     with GroTrajectoryFile(filename, 'r') as f:
         topology = f.topology
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(n_frames=n_frames, stride=stride,

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -112,8 +112,15 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
 
     with HDF5TrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(n_frames=n_frames, stride=stride, atom_indices=atom_indices)

--- a/mdtraj/formats/lammpstrj.py
+++ b/mdtraj/formats/lammpstrj.py
@@ -103,8 +103,15 @@ def load_lammpstrj(filename, top=None, stride=None, atom_indices=None,
         else:
             raise ValueError('Unsupported unit set specified: {0}.'.format(unit_set))
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = int((stop - start) / stride)
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
 

--- a/mdtraj/formats/lh5.py
+++ b/mdtraj/formats/lh5.py
@@ -146,8 +146,15 @@ def load_lh5(filename, top=None, stride=None, atom_indices=None, frame=None):
     atom_indices = cast_indices(atom_indices)
     with LH5TrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(n_frames=n_frames, stride=stride, atom_indices=atom_indices)

--- a/mdtraj/formats/mdcrd.py
+++ b/mdtraj/formats/mdcrd.py
@@ -94,8 +94,15 @@ def load_mdcrd(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with MDCRDTrajectoryFile(filename, topology.n_atoms) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = int((stop - start) / stride)
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(topology, n_frames=n_frames, stride=stride,

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -94,8 +94,15 @@ def load_netcdf(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with NetCDFTrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
 

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -150,7 +150,10 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
     with PDBTrajectoryFile(filename) as f:
         atom_slice = slice(None) if atom_indices is None else atom_indices
         if frame is not None:
-            coords = f.positions[[frame], atom_slice, :]
+            if isinstance(frame, slice):
+                coords = f.positions[frame, atom_slice, :]
+            else:
+                coords = f.positions[[frame], atom_slice, :]
         else:
             coords = f.positions[::stride, atom_slice, :]
         assert coords.ndim == 3, 'internal shape error'
@@ -172,7 +175,11 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
 
     time = np.arange(len(coords))
     if frame is not None:
-        time += frame
+        if isinstance(frame, slice):
+            time *= 1 if frame.step is None else frame.step
+            time += 0 if frame.start is None else frame.start
+        else:
+            time += frame
     elif stride is not None:
         time *= stride
 

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -172,7 +172,7 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
 
     time = np.arange(len(coords))
     if frame is not None:
-        time *= frame
+        time += frame
     elif stride is not None:
         time *= stride
 

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -137,8 +137,15 @@ def load_trr(filename, top=None, stride=None, atom_indices=None, frame=None):
     atom_indices = cast_indices(atom_indices)
     with TRRTrajectoryFile(filename, 'r') as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
 

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -163,8 +163,15 @@ def load_xtc(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with XTCTrajectoryFile(filename, 'r') as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = stop - start
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
 

--- a/mdtraj/formats/xyzfile.py
+++ b/mdtraj/formats/xyzfile.py
@@ -105,8 +105,15 @@ def load_xyz(filename, top=None, stride=None, atom_indices=None, frame=None):
 
     with XYZTrajectoryFile(filename) as f:
         if frame is not None:
-            f.seek(frame)
-            n_frames = 1
+            if isinstance(frame, slice):
+                start  = 0 if frame.start is None else frame.start
+                stop   = frame.stop
+                stride = stride if frame.step is None else frame.step
+                f.seek(start)
+                n_frames = int((stop - start) / stride)
+            else:
+                f.seek(frame)
+                n_frames = 1
         else:
             n_frames = None
         return f.read_as_traj(topology, n_frames=n_frames, stride=stride,

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -498,6 +498,7 @@ def test_load_frame():
     r = np.random.randint(len(t1))
     t2 = md.load_frame(get_fn('2EQQ.pdb'), r)
     eq(t1[r].xyz, t2.xyz)
+    eq(t1[r].time, t2.time)
 
 
 def test_iterload():

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -500,6 +500,39 @@ def test_load_frame():
     eq(t1[r].xyz, t2.xyz)
     eq(t1[r].time, t2.time)
 
+def test_load_frame_slice():
+    files = ['frame0.nc', 'frame0.h5', 'frame0.xtc', 'frame0.trr',
+             'frame0.dcd', 'frame0.mdcrd', 'frame0.binpos', 'frame0.xyz',
+             'frame0.lammpstrj']
+    if not (on_win and on_py3):
+        files.append('legacy_msmbuilder_trj0.lh5')
+
+    trajectories = [md.load(get_fn(f), top=get_fn('native.pdb')) for f in files]
+    frames = [md.load_frame(get_fn(f), index=slice(10, 20, 2), top=get_fn('native.pdb')) for f in files]
+
+    for traj, frame, f in zip(trajectories, frames, files):
+        def test():
+            eq(len(frame), 5)
+            eq(traj[10].xyz, frame[0].xyz)
+            eq(traj[10].unitcell_vectors, frame[0].unitcell_vectors)
+            eq(traj[10].time, frame[0].time, err_msg='%d, %d: %s' % (
+                traj[10].time[0], frame[0].time[0], f)
+            )
+            eq(traj[12].xyz, frame[1].xyz)
+            eq(traj[12].unitcell_vectors, frame[1].unitcell_vectors)
+            eq(traj[12].time, frame[1].time, err_msg='%d, %d: %s' % (
+                traj[12].time[0], frame[1].time[0], f)
+            )
+        test.description = 'test_load_frame: %s' % f
+        yield test
+
+    t1 = md.load(get_fn('2EQQ.pdb'))
+    t2 = md.load_frame(get_fn('2EQQ.pdb'), slice(10, 20, 2))
+    eq(len(t2), 5)
+    eq(t1[10].xyz, t2[0].xyz)
+    eq(t1[10].time, t2[0].time)
+    eq(t1[12].xyz, t2[1].xyz)
+    eq(t1[12].time, t2[1].time)
 
 def test_iterload():
     t_ref = md.load(get_fn('frame0.h5'))[:20]


### PR DESCRIPTION
I'm not really sure if you guys like this approach but I think partial loading is fundamental feature so I would like to ask you to review.

While there are `load_frame` function and it seems @rmcgibbo is not comfortable to add `load_partial` function which I proposed in https://github.com/mdtraj/mdtraj/issues/1034, I decided to make `load_frame` function to support `slice` instance. So when `index` argument of `load_frame` is an instance of `slice`, it returns trajectories within the range specified by `slice`.

Note that I didn't touch docstrings while I'm not sure if this PR is acceptable. Let me know if this PR is acceptable then I'll modify docstrings (but sometime I feel that my English is not clear enough to explain things so I'd prefer you to write if possible...)
#### Usage

``` python
import mdtraj as md
t = md.load_frame('traj.h5', slice(10, 20, 2))
print(t)
# <mdtraj.Trajectory with 5 frames, 22 atoms>
```
#### Supported formats

Same formats as `load_frame` (single frame version) supports.
