### PR TITLE
Half-fix short xtc file issues

### DIFF
--- a/mdtraj/formats/xtc/include/xdrfile_xtc.h
+++ b/mdtraj/formats/xtc/include/xdrfile_xtc.h
@@ -43,7 +43,7 @@ extern "C" {
   /* This function returns the number of atoms in the xtc file in *natoms */
   extern int read_xtc_natoms(char *fn,int *natoms);
   
-  int read_xtc_nframes(char* fn, unsigned long *nframes);
+  int read_xtc_nframes(char* fn, int64_t *nframes);
 
   /* Read one frame of an open xtc file */
   extern int read_xtc(XDRFILE *xd,int natoms,int *step,float *time,

--- a/mdtraj/formats/xtc/src/xdrfile_xtc.c
+++ b/mdtraj/formats/xtc/src/xdrfile_xtc.c
@@ -102,7 +102,7 @@ int read_xtc_natoms(char *fn,int *natoms)
 	return result;
 }
 
-int read_xtc_nframes(char* fn, unsigned long *nframes) {
+int read_xtc_nframes(char* fn, int64_t *nframes) {
     XDRFILE *xd;
     int result, step;
     float time;

--- a/mdtraj/formats/xtc/xdrlib.pxd
+++ b/mdtraj/formats/xtc/xdrlib.pxd
@@ -1,3 +1,5 @@
+cimport numpy as np
+ctypedef np.npy_int64 int64_t
 
 cdef extern from "include/xdrfile.h":
     ctypedef struct XDRFILE:
@@ -13,10 +15,7 @@ cdef extern from "include/xdrfile_xtc.h":
     int read_xtc(XDRFILE *xd, int natoms, int *step, float *time, matrix box, rvec *x, float *prec)
     int write_xtc(XDRFILE *xd, int natoms, int step, float time, matrix box, rvec* x, float prec)
     int xdrfile_read_int(int * ptr, int ndata, XDRFILE *xfp)
-
-
-cimport numpy as np
-ctypedef np.npy_int64 int64_t
+    int read_xtc_nframes(char* fn, int64_t *nframes)
 
 cdef extern from "include/xdr_seek.h":
     int64_t xdr_tell(XDRFILE *xd)

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -695,7 +695,7 @@ cdef class XTCTrajectoryFile(object):
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.n_frames == -1:
-            self.offsets # invokes _calc_len_and_offsets
+            self.n_frames, self._offsets = self._calc_len_and_offsets()
         return int(self.n_frames)
 
 FormatRegistry.register_fileobject('.xtc')(XTCTrajectoryFile)

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -695,7 +695,7 @@ cdef class XTCTrajectoryFile(object):
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.n_frames == -1:
-            self.n_frames, self._offsets = self._calc_len_and_offsets()
+            xdrlib.read_xtc_nframes(self.filename, &self.n_frames)
         return int(self.n_frames)
 
 FormatRegistry.register_fileobject('.xtc')(XTCTrajectoryFile)

--- a/mdtraj/tests/test_xtc.py
+++ b/mdtraj/tests/test_xtc.py
@@ -281,8 +281,14 @@ def test_ragged_2():
         assert_raises(ValueError, lambda: f.write(xyz))
 
 
-def test_short_traj():
+def test_short_traj_len():
     with XTCTrajectoryFile(temp, 'w') as f:
         f.write(np.random.uniform(size=(5,100000,3)))
     with XTCTrajectoryFile(temp, 'r') as f:
         assert len(f) == 5, len(f)
+
+def test_short_traj_offset():
+    with XTCTrajectoryFile(temp, 'w') as f:
+        f.write(np.random.uniform(size=(5,100000,3)))
+    with XTCTrajectoryFile(temp, 'r') as f:
+        _ = f.offsets

--- a/mdtraj/tests/test_xtc.py
+++ b/mdtraj/tests/test_xtc.py
@@ -4,7 +4,7 @@
 # Copyright 2012-2013 Stanford University and the Authors
 #
 # Authors: Robert McGibbon
-# Contributors:
+# Contributors: Matthew Harrigan
 #
 # MDTraj is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -279,3 +279,10 @@ def test_ragged_2():
     with XTCTrajectoryFile(temp, 'w', force_overwrite=True) as f:
         f.write(xyz, time=time, box=box)
         assert_raises(ValueError, lambda: f.write(xyz))
+
+
+def test_short_traj():
+    with XTCTrajectoryFile(temp, 'w') as f:
+        f.write(np.random.uniform(size=(5,100000,3)))
+    with XTCTrajectoryFile(temp, 'r') as f:
+        assert len(f) == 5, len(f)


### PR DESCRIPTION
see #1078 

This puts `__len__` back to the old method, which works for trajectories with a small number of frames. It's probably faster because it doesn't allocate the offsets array

I added a test (the test from #1078) that fails. @marscher : can you build off this pull request and try to fix that problem?