### PR TITLE
[xtc] fix a bug in calc of offsets array for short trajs.

### DIFF
--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -39,6 +39,7 @@ from mdtraj.utils.six import string_types
 from mdtraj.formats.registry import FormatRegistry
 cimport xdrlib
 from libc.stdio cimport SEEK_SET, SEEK_CUR
+from libc.math cimport ceil
 ctypedef np.npy_int64   int64_t
 
 
@@ -643,7 +644,7 @@ cdef class XTCTrajectoryFile(object):
                         break
 
                     if n_frames == len(offsets):
-                        new_len = int(len(offsets)*1.2)
+                        new_len = int(ceil(len(offsets)*1.2))
                         offsets = resize(offsets, new_len)
 
                     offsets[n_frames] = xdrlib.xdr_tell(self.fh) - 4 - XTC_HEADER_SIZE

--- a/mdtraj/tests/test_xtc.py
+++ b/mdtraj/tests/test_xtc.py
@@ -279,3 +279,10 @@ def test_ragged_2():
     with XTCTrajectoryFile(temp, 'w', force_overwrite=True) as f:
         f.write(xyz, time=time, box=box)
         assert_raises(ValueError, lambda: f.write(xyz))
+
+def test_short_traj():
+    with XTCTrajectoryFile(temp, 'w') as f:
+        f.write(np.random.uniform(size=(5,100000,3)))
+    with XTCTrajectoryFile(temp, 'r') as f:
+        assert len(f) == 5, len(f)
+


### PR DESCRIPTION
Fixes #1078. For short trajs there is a rounding error (forced cast
to integer) to the next smallest integral. Passed new_size to ceil.