### PR TITLE
Give more helpful error message when image_molecules fails

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1863,7 +1863,7 @@ class Trajectory(object):
         num_anchors = len(anchor_molecules)
         if num_anchors == 0:
             raise ValueError("Could not find any anchor molecules. Based on "
-                             "out heuristic, those should be molecules with "
+                             "our heuristic, those should be molecules with "
                              "more than {} atoms. Perhaps your topology "
                              "doesn't give an acurate bond graph?"
                              .format(atoms_cutoff))

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1861,6 +1861,12 @@ class Trajectory(object):
         anchor_molecules = [m for m in molecules if len(m) > atoms_cutoff]
         other_molecules = [m for m in molecules if len(m) <= atoms_cutoff]
         num_anchors = len(anchor_molecules)
+        if num_anchors == 0:
+            raise ValueError("Could not find any anchor molecules. Based on "
+                             "out heuristic, those should be molecules with "
+                             "more than {} atoms. Perhaps your topology "
+                             "doesn't give an acurate bond graph?"
+                             .format(atoms_cutoff))
         anchor_atom_indices = []
         for mol in anchor_molecules:
             anchor_atom_indices += [atom.index for atom in mol]


### PR DESCRIPTION
I ran into #1084 when using a `.gro` file as my topology. It looks like it was putting every atom in its own "molecule" and thereby finding no anchor molecules. 

This error message will have to do for now, since there's pressure to cut a new release