### PR TITLE
Update travis.yml to really only deploy once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,19 @@ os:
   - linux
 
 env:
-  - CONDA_PY=2.7  CONDA_NPY=1.7
-  - CONDA_PY=2.7  CONDA_NPY=1.11
-  - CONDA_PY=3.4  CONDA_NPY=1.10
-  - CONDA_PY=3.5  CONDA_NPY=1.11  DOCDEPLOY=YES
+  - CONDA_PY=2.7 CONDA_NPY=1.7
+  - CONDA_PY=2.7 CONDA_NPY=1.11
+  - CONDA_PY=3.4 CONDA_NPY=1.10
+  - CONDA_PY=3.5 CONDA_NPY=1.11
+
+# Do include/exclude to add "DOCDEPLOY" to one matrix entry.
+matrix:
+  exclude:
+    - os: linux
+      env: CONDA_PY=3.5 CONDA_NPY=1.11
+  include:
+    - os: linux
+      env: CONDA_PY=3.5 CONDA_NPY=1.11 DOCDEPLOY=YES
 
 deploy:
   - provider: s3
@@ -39,6 +48,5 @@ deploy:
     skip_cleanup: true
     local_dir: docs/_deploy/
     on:
-      os: linux
       branch: master
       condition: "-n $DOCDEPLOY"


### PR DESCRIPTION
The `os: linux` condition in the deploy section wasn't doing anything and it was deploying on one of  the macosx builds and one of the linux builds. In practice, this didn't make a difference because the generated docs should be more-or-less identical.