### PR TITLE
Optimize baker_hubbard and wernet_nilsson functions

### DIFF
--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -26,7 +26,7 @@
 ##############################################################################
 
 from __future__ import print_function, division
-from itertools import product
+import itertools
 import numpy as np
 from mdtraj.utils import ensure_type
 from mdtraj.geometry import compute_distances, compute_angles
@@ -37,7 +37,6 @@ __all__ = ['wernet_nilsson', 'baker_hubbard', 'kabsch_sander']
 ##############################################################################
 # Functions
 ##############################################################################
-
 
 def wernet_nilsson(traj, exclude_water=True, periodic=True):
     """Identify hydrogen bonds based on cutoffs for the Donor-H...Acceptor
@@ -123,52 +122,36 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True):
         raise ValueError('wernet_nilsson requires that traj contain topology '
                          'information')
 
-    def get_donors(e0, e1):
-        elems = set((e0, e1))
-        bonditer = traj.topology.bonds
-        atoms = [(b[0], b[1]) for b in bonditer if set((b[0].element.symbol, b[1].element.symbol)) == elems]
+    # Get the possible donor-hydrogen...acceptor triplets
+    bond_triplets = _get_bond_triplets(traj.topology, exclude_water=exclude_water)
 
-        indices = []
-        for a0, a1 in atoms:
-            if exclude_water and (a0.residue.name == 'HOH' or a1.residue.name == 'HOH'):
-                continue
-            pair = (a0.index, a1.index)
-            # make sure to get the pair in the right order, so that the index
-            # for e0 comes before e1
-            if a0.element.symbol == e1:
-                pair = pair[::-1]
-            indices.append(pair)
+    # Calculate donor-acceptor distances
+    da_distances = compute_distances(traj, bond_triplets[:, [0, 2]], periodic=periodic)
 
-        return indices
+    # Determine which triplets can still be hydrogen bonds
+    possibilities = np.any(da_distances < distance_cutoff, axis=0)
 
-    nh_donors = get_donors('N', 'H')
-    oh_donors = get_donors('O', 'H')
-    xh_donors = np.array(nh_donors + oh_donors)
+    # Update data structures to include only possible bonds
+    bond_triplets = bond_triplets[possibilities, :]
+    da_distances = da_distances[:, possibilities]
 
-    if len(xh_donors) == 0:
-        # if there are no hydrogens or protein in the trajectory, we get
-        # no possible pairs and return nothing
-        return [np.zeros((0, 3), dtype=int) for _ in range(traj.n_frames)]
+    # Calculate angles using the law of cosines
+    dh_distances = compute_distances(traj, bond_triplets[:, [0, 1]], periodic=periodic)
+    ha_distances = compute_distances(traj, bond_triplets[:, [1, 2]], periodic=periodic)
 
-    if not exclude_water:
-        acceptors = [a.index for a in traj.topology.atoms if a.element.symbol == 'O' or a.element.symbol == 'N']
-    else:
-        acceptors = [a.index for a in traj.topology.atoms if (a.element.symbol == 'O' and a.residue.name != 'HOH') or a.element.symbol == 'N']
+    # Law of cosines calculation (a, b = dh, da; c = ha; C = A-D-H)
+    numerator = dh_distances ** 2 + da_distances ** 2 - ha_distances ** 2
+    cosines = numerator / (2 * dh_distances * da_distances)
+    np.clip(cosines, -1, 1, out=cosines) # avoid NaN error
+    angles = np.arccos(cosines) * 180.0 / np.pi
 
-    # This is used to compute the angles
-    angle_triplets = np.array([(e[0][1], e[0][0], e[1]) for e in product(xh_donors, acceptors) if e[0][0] != e[1]])
-    distance_pairs = angle_triplets[:, [0, 2]]  # possible O..acceptor pairs
-
-    angles = compute_angles(traj, angle_triplets, periodic=periodic) * 180.0 / np.pi  # degrees
-    distances = compute_distances(traj, distance_pairs, periodic=periodic, opt=True)
+    # Calculate the true cutoffs for distances
     cutoffs = distance_cutoff - angle_const * angles ** 2
 
-    mask = np.logical_and(distances < cutoffs, angles < angle_cutoff)
+    # Find triplets that meet the criteria
+    mask = np.logical_and(da_distances < cutoffs, angles < angle_cutoff)
 
-    # The triplets that are returned are O-H ... O, different
-    # from what's used to compute the angles.
-    angle_triplets2 = angle_triplets[:, [1, 0, 2]]
-    return [angle_triplets2[i] for i in mask]
+    return bond_triplets[mask, :]
 
 
 def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True):
@@ -254,49 +237,38 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True):
         raise ValueError('baker_hubbard requires that traj contain topology '
                          'information')
 
-    def get_donors(e0, e1):
-        elems = set((e0, e1))
-        bonditer = traj.topology.bonds
-        atoms = [(b[0], b[1]) for b in bonditer if set((b[0].element.symbol, b[1].element.symbol)) == elems]
+    # Get the possible donor-hydrogen...acceptor triplets
+    bond_triplets = _get_bond_triplets(traj.topology, exclude_water=exclude_water)
 
-        indices = []
-        for a0, a1 in atoms:
-            if exclude_water and (a0.residue.name == 'HOH' or a1.residue.name == 'HOH'):
-                continue
-            pair = (a0.index, a1.index)
-            # make sure to get the pair in the right order, so that the index
-            # for e0 comes before e1
-            if a0.element.symbol == e1:
-                pair = pair[::-1]
-            indices.append(pair)
+    # Calculate hydrogen-acceptor distances
+    ha_distances = compute_distances(traj, bond_triplets[:, [1, 2]])
 
-        return indices
+    # Determine which triplets can still be hydrogen bonds
+    distance_mask = ha_distances < distance_cutoff
+    possibilities = np.mean(distance_mask, axis=0) > freq
 
-    nh_donors = get_donors('N', 'H')
-    oh_donors = get_donors('O', 'H')
-    xh_donors = np.concatenate((nh_donors, oh_donors))
+    # Update data structures to include only possible bonds
+    bond_triplets = bond_triplets[possibilities, :]
+    ha_distances = ha_distances[:, possibilities]
+    distance_mask = distance_mask[:, possibilities]
 
-    if len(xh_donors) == 0:
-        # if there are no hydrogens or protein in the trajectory, we get
-        # no possible pairs and return nothing
-        return np.zeros((0, 3), dtype=int)
+    # Calculate angles using the law of cosines
+    dh_distances = compute_distances(traj, triplets[:, [0, 1]])
+    da_distances = compute_distances(traj, triplets[:, [0, 2]])
 
-    if not exclude_water:
-        acceptors = [a.index for a in traj.topology.atoms if a.element.symbol == 'O' or a.element.symbol == 'N']
-    else:
-        acceptors = [a.index for a in traj.topology.atoms if (a.element.symbol == 'O' and a.residue.name != 'HOH') or a.element.symbol == 'N']
+    # Law of cosines calculation (a, b = dh, ha; c = da; C = D-H-A)
+    numerator = dh_distances ** 2 + ha_distances ** 2 - da_distances ** 2
+    cosines = numerator / (2 * dh_distances * ha_distances)
+    np.clip(cosines, -1, 1, out=cosines) # avoid NaN error
+    angles = np.arccos(cosines)
 
-    angle_triplets = np.array([(e[0][0], e[0][1], e[1]) for e in product(xh_donors, acceptors)])
-    distance_pairs = angle_triplets[:, [1, 2]]  # possible H..acceptor pairs
+    # Find triplets that meet the criteria
+    mask = np.logical_and(distance_mask, angles > angle_cutoff)
 
-    angles = compute_angles(traj, angle_triplets, periodic=periodic)
-    distances = compute_distances(traj, distance_pairs, periodic=periodic)
+    # Frequency of each hydrogen bond's presence in the trajectory
+    prevalence = np.mean(mask, axis=0)
 
-    mask = np.logical_and(distances < distance_cutoff, angles > angle_cutoff)
-    # frequency of occurance of each hydrogen bond in the trajectory
-    occurance = np.sum(mask, axis=0).astype(np.double) / traj.n_frames
-
-    return angle_triplets[occurance > freq]
+    return bond_triplets[prevalence > freq]
 
 
 def kabsch_sander(traj):
@@ -375,6 +347,52 @@ def kabsch_sander(traj):
             (data, indices, indptr), shape=(n_residues, n_residues)).T)
 
     return matrices
+
+
+def _get_bond_triplets(topology, exclude_water=True):
+    def get_donors(e0, e1):
+        elems = set((e0, e1))
+        bonditer = topology.bonds
+        atoms = [(b[0], b[1]) for b in bonditer if set((b[0].element.symbol, b[1].element.symbol)) == elems]
+
+        indices = []
+        for a0, a1 in atoms:
+            if exclude_water and (a0.residue.name == 'HOH' or a1.residue.name == 'HOH'):
+                continue
+            pair = (a0.index, a1.index)
+            # make sure to get the pair in the right order, so that the index
+            # for e0 comes before e1
+            if a0.element.symbol == e1:
+                pair = pair[::-1]
+            indices.append(pair)
+
+        return indices
+
+    nh_donors = get_donors('N', 'H')
+    oh_donors = get_donors('O', 'H')
+    xh_donors = np.array(nh_donors + oh_donors)
+
+    if len(xh_donors) == 0:
+        # if there are no hydrogens or protein in the trajectory, we get
+        # no possible pairs and return nothing
+        return [np.zeros((0, 3), dtype=int) for _ in range(traj.n_frames)]
+
+    if not exclude_water:
+        acceptors = [a.index for a in topology.atoms if a.element.symbol == 'O' or a.element.symbol == 'N']
+    else:
+        acceptors = [a.index for a in topology.atoms if (a.element.symbol == 'O' and a.residue.name != 'HOH') or a.element.symbol == 'N']
+
+    # Make acceptors a 2-D numpy array
+    acceptors = np.array(acceptors)[:, np.newaxis]
+
+    # Generate the cartesian product of the donors and acceptors
+    xh_donors_repeated = np.repeat(xh_donors, acceptors.shape[0], axis=0)
+    acceptors_tiled = np.tile(acceptors, (xh_donors.shape[0], 1))
+    bond_triplets = np.hstack((xh_donors_repeated, acceptors_tiled))
+
+    # Filter out self-bonds
+    self_bond_mask = (bond_triplets[:, 0] == bond_triplets[:, 2])
+    return bond_triplets[np.logical_not(self_bond_mask), :]
 
 
 def _get_or_minus1(f):

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -37,7 +37,7 @@ __all__ = ['wernet_nilsson', 'baker_hubbard', 'kabsch_sander']
 # Functions
 ##############################################################################
 
-def wernet_nilsson(traj, exclude_water=True, sidechain_only=False, periodic=True):
+def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False):
     """Identify hydrogen bonds based on cutoffs for the Donor-H...Acceptor
     distance and angle according to the criterion outlined in [1].
     As opposed to Baker-Hubbard, this is a "cone" criterion where the
@@ -138,7 +138,7 @@ def wernet_nilsson(traj, exclude_water=True, sidechain_only=False, periodic=True
     return bond_triplets[mask, :]
 
 
-def baker_hubbard(traj, freq=0.1, exclude_water=True, sidechain_only=False, periodic=True):
+def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_only=False):
     """Identify hydrogen bonds based on cutoffs for the Donor-H...Acceptor
     distance and angle.
 

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -131,13 +131,16 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False
     mask, distances, angles = _compute_bounded_geometry(traj, bond_triplets,
         distance_cutoff, [0, 2], [2, 0, 1], periodic=periodic)
 
+    # Update triplets under consideration
+    bond_triplets = bond_triplets[mask]
+
     # Calculate the true cutoffs for distances
     cutoffs = distance_cutoff - angle_const * (angles * 180.0 / np.pi) ** 2
 
     # Find triplets that meet the criteria
-    mask[mask] = np.logical_and(distances < cutoffs, angles < angle_cutoff)
+    presence = np.logical_and(distances < cutoffs, angles < angle_cutoff)
 
-    return bond_triplets[mask, :]
+    return [bond_triplets[present] for present in presence]
 
 
 def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_only=False):

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -132,7 +132,7 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False
         distance_cutoff, [0, 2], [2, 0, 1], periodic=periodic)
 
     # Update triplets under consideration
-    bond_triplets = bond_triplets[mask]
+    bond_triplets = bond_triplets.compress(mask, axis=0)
 
     # Calculate the true cutoffs for distances
     cutoffs = distance_cutoff - angle_const * (angles * 180.0 / np.pi) ** 2
@@ -140,7 +140,7 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False
     # Find triplets that meet the criteria
     presence = np.logical_and(distances < cutoffs, angles < angle_cutoff)
 
-    return [bond_triplets[present] for present in presence]
+    return [bond_triplets.compress(present, axis=0) for present in presence]
 
 
 def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_only=False):
@@ -239,7 +239,7 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_o
     presence = np.logical_and(distances < distance_cutoff, angles > angle_cutoff)
     mask[mask] = np.mean(presence, axis=0) > freq
 
-    return bond_triplets[mask, :]
+    return bond_triplets.compress(mask, axis=0)
 
 
 def kabsch_sander(traj):
@@ -410,8 +410,8 @@ def _compute_bounded_geometry(traj, triplets, distance_cutoff, distance_indices,
                 periodic=periodic))
 
     # Law of cosines calculation
-    numerator = abc_distances[0] ** 2 + abc_distances[1] ** 2 - abc_distances[2] ** 2
-    cosines = numerator / (2 * abc_distances[0] * abc_distances[1])
+    a, b, c = abc_distances
+    cosines = (a ** 2 + b ** 2 - c ** 2) / (2 * a * b)
     np.clip(cosines, -1, 1, out=cosines) # avoid NaN error
     angles = np.arccos(cosines)
 

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -26,7 +26,6 @@
 ##############################################################################
 
 from __future__ import print_function, division
-import itertools
 import numpy as np
 from mdtraj.utils import ensure_type
 from mdtraj.geometry import compute_distances, compute_angles

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -61,6 +61,8 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False
         Exclude solvent molecules from consideration.
     periodic : bool, default=True
         Set to True to calculate displacements and angles across periodic box boundaries.
+    sidechain_only : bool, default=False
+        Set to True to only consider sidechain-sidechain interactions.
 
     Returns
     -------
@@ -160,6 +162,8 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_o
         Exclude solvent molecules from consideration
     periodic : bool, default=True
         Set to True to calculate displacements and angles across periodic box boundaries.
+    sidechain_only : bool, default=False
+        Set to True to only consider sidechain-sidechain interactions.
 
     Returns
     -------

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -228,10 +228,9 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_o
     mask, distances, angles = _compute_bounded_geometry(traj, bond_triplets,
         distance_cutoff, [1, 2], [0, 1, 2], freq=freq, periodic=periodic)
 
-    # Find triplets that meet the criteria. The _compute_bounded_geometry function
-    # has already performed the distance cutoff for us, so now we just need to
-    # factor in the angle cutoff.
-    mask[mask] = angles > angle_cutoff
+    # Find triplets that meet the criteria
+    presence = np.logical_and(distances < distance_cutoff, angles > angle_cutoff)
+    mask[mask] = np.mean(presence, axis=0) > freq
 
     return bond_triplets[mask, :]
 

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -227,8 +227,8 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True):
     mask, distances, angles = _compute_bounded_geometry(traj, triplets,
         distance_cutoff, [1, 2], [0, 1, 2], freq=freq, periodic=periodic)
 
-    # Find triplets that meet the criteria. The _compute_bounded_geometry has
-    # already performed the distance cutoff for us, so now we just need to
+    # Find triplets that meet the criteria. The _compute_bounded_geometry function
+    # has already performed the distance cutoff for us, so now we just need to
     # factor in the angle cutoff.
     mask[mask] = angles > angle_cutoff
 

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -130,7 +130,7 @@ def wernet_nilsson(traj, exclude_water=True, periodic=True, sidechain_only=False
         distance_cutoff, [0, 2], [2, 0, 1], periodic=periodic)
 
     # Calculate the true cutoffs for distances
-    cutoffs = distance_cutoff - angle_const * angles ** 2
+    cutoffs = distance_cutoff - angle_const * (angles * 180.0 / np.pi) ** 2
 
     # Find triplets that meet the criteria
     mask[mask] = np.logical_and(distances < cutoffs, angles < angle_cutoff)
@@ -354,7 +354,7 @@ def _get_bond_triplets(topology, exclude_water=True, sidechain_only=False):
     if len(xh_donors) == 0:
         # if there are no hydrogens or protein in the trajectory, we get
         # no possible pairs and return nothing
-        return [np.zeros((0, 3), dtype=int) for _ in range(traj.n_frames)]
+        return np.zeros((0, 3), dtype=int)
 
     acceptor_elements = frozenset(('O', 'N'))
     acceptors = [a.index for a in topology.atoms


### PR DESCRIPTION
Hi MDTraj team,

Here are some changes I've made to the hbond-finding functions to make them run about six times faster, as well as adding the option sidechain_only, to consider only sidechain-sidechain interactions. I still have to write a test for the code, but in my ad-hoc testing all outputs have been identical to previous versions of mdtraj, just faster. Feel free to integrate this code however you like.

Note: I also haven't added documentation for the sidechain_only option, which should be done if it's something you want to support.

Thanks,
Connor