### PR TITLE
Load single-element path lists without a copy

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -371,6 +371,10 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         topkwargs.pop("top", None)
         kwargs["top"] = _parse_topology(kwargs["top"], **topkwargs)
 
+    # "Peel" single-member lists
+    if len(filename_or_filenames) == 1:
+        filename_or_filenames = filename_or_filenames[0]
+
     # grab the extension of the filename
     if isinstance(filename_or_filenames, string_types):  # If a single filename
         extension = _get_extension(filename_or_filenames)

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -371,10 +371,6 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         topkwargs.pop("top", None)
         kwargs["top"] = _parse_topology(kwargs["top"], **topkwargs)
 
-    # "Peel" single-member lists
-    if len(filename_or_filenames) == 1:
-        filename_or_filenames = filename_or_filenames[0]
-
     # grab the extension of the filename
     if isinstance(filename_or_filenames, string_types):  # If a single filename
         extension = _get_extension(filename_or_filenames)
@@ -399,9 +395,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
                 if i != 0:
                     t.topology = None
                 trajectories.append(t)
-            return trajectories[0].join(trajectories[1:],
-                                        discard_overlapping_frames=discard_overlapping_frames,
-                                        check_topology=False)
+            return join(trajectories, check_topology=False,
+                        discard_overlapping_frames=discard_overlapping_frames)
 
     try:
         #loader = _LoaderRegistry[extension][0]
@@ -410,7 +405,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         raise IOError('Sorry, no loader for filename=%s (extension=%s) '
                       'was found. I can only load files '
                       'with extensions in %s' % (filename, extension, FormatRegistry.loaders.keys()))
-    
+
     if extension in _TOPOLOGY_EXTS:
         # this is a little hack that makes calling load() more predictable. since
         # most of the loaders take a kwargs "top" except for load_hdf5, (since

--- a/mdtraj/tests/test_load.py
+++ b/mdtraj/tests/test_load.py
@@ -1,30 +1,3 @@
-##############################################################################
-# MDTraj: A Python Library for Loading, Saving, and Manipulating
-#         Molecular Dynamics Trajectories.
-# Copyright 2012-2013 Stanford University and the Authors
-#
-# Authors: Robert McGibbon
-# Contributors:
-#
-# MDTraj is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 2.1
-# of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with MDTraj. If not, see <http://www.gnu.org/licenses/>.
-##############################################################################
-
-
-"""
-Tests of generic loading functionality.
-"""
-
 from mdtraj import load
 from mdtraj.testing import get_fn
 
@@ -44,5 +17,6 @@ def test_load_many_list():
     """
     See if a multi-element list of files is successfully loaded.
     """
-    traj = load(2 * [get_fn('frame0.pdb')], discard_overlapping_frames=False)
-    assert traj.n_frames == 2
+    single = load(get_fn('frame0.pdb'))
+    double = load(2 * [get_fn('frame0.pdb')], discard_overlapping_frames=False)
+    assert 2 * single.n_frames == double.n_frames

--- a/mdtraj/tests/test_load.py
+++ b/mdtraj/tests/test_load.py
@@ -1,0 +1,48 @@
+##############################################################################
+# MDTraj: A Python Library for Loading, Saving, and Manipulating
+#         Molecular Dynamics Trajectories.
+# Copyright 2012-2013 Stanford University and the Authors
+#
+# Authors: Robert McGibbon
+# Contributors:
+#
+# MDTraj is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with MDTraj. If not, see <http://www.gnu.org/licenses/>.
+##############################################################################
+
+
+"""
+Tests of generic loading functionality.
+"""
+
+from mdtraj import load
+from mdtraj.testing import get_fn
+
+def test_load_single():
+    """
+    Just check for any raised errors coming from loading a single file.
+    """
+    load(get_fn('frame0.pdb'))
+
+def test_load_single_list():
+    """
+    See if a single-element list of files is successfully loaded.
+    """
+    load([get_fn('frame0.pdb')])
+
+def test_load_many_list():
+    """
+    See if a multi-element list of files is successfully loaded.
+    """
+    traj = load(2 * [get_fn('frame0.pdb')], discard_overlapping_frames=False)
+    assert traj.n_frames == 2

--- a/mdtraj/tests/test_load.py
+++ b/mdtraj/tests/test_load.py
@@ -2,21 +2,17 @@ from mdtraj import load
 from mdtraj.testing import get_fn
 
 def test_load_single():
-    """
-    Just check for any raised errors coming from loading a single file.
-    """
+    # Just check for any raised errors coming from loading a single file.
     load(get_fn('frame0.pdb'))
 
+
 def test_load_single_list():
-    """
-    See if a single-element list of files is successfully loaded.
-    """
+    # See if a single-element list of files is successfully loaded.
     load([get_fn('frame0.pdb')])
 
+
 def test_load_many_list():
-    """
-    See if a multi-element list of files is successfully loaded.
-    """
+    # See if a multi-element list of files is successfully loaded.
     single = load(get_fn('frame0.pdb'))
     double = load(2 * [get_fn('frame0.pdb')], discard_overlapping_frames=False)
     assert 2 * single.n_frames == double.n_frames


### PR DESCRIPTION
I just got bit by this issue, and I want to make sure others don't run into it.

The `load` function can handle either a single filename or a list of filenames. When dealing with a list of filenames, it loads each trajectory and then joins them together sequentially. This joining process creates copies of the coordinate data.

When passing a one-element list containing only one filepath, `load` attempts to `join` the single loaded trajectory with an empty list (generated from a slice at trajectory.py:96), triggering a copy of the trajectory's coordinate data. Because of this, I was consistently running out of memory when trying to load a particularly large trajectory.

This pull request modifies `load` to "peel" single-element lists, so that they are treated as if the element were passed as the argument to load. Tests are included.