### PR TITLE
Handle unexpected keyword arguments gracefully in psf and prmtop parsers

### DIFF
--- a/mdtraj/formats/prmtop.py
+++ b/mdtraj/formats/prmtop.py
@@ -85,7 +85,7 @@ def _get_pointer_value(pointer_label, raw_data):
     return float(raw_data['POINTERS'][index])
 
 
-def load_prmtop(filename):
+def load_prmtop(filename, **kwargs):
     """Load an AMBER prmtop topology file from disk.
 
     Parameters

--- a/mdtraj/formats/psf.py
+++ b/mdtraj/formats/psf.py
@@ -161,7 +161,7 @@ def _parse_psf_section(psf):
             line = psf.readline().strip()
     return title, pointers, data
     
-eef load_psf(fname, **kwargs):
+def load_psf(fname, **kwargs):
     """Load a CHARMM or XPLOR PSF file from disk
 
     Parameters

--- a/mdtraj/formats/psf.py
+++ b/mdtraj/formats/psf.py
@@ -161,7 +161,7 @@ def _parse_psf_section(psf):
             line = psf.readline().strip()
     return title, pointers, data
     
-def load_psf(fname):
+eef load_psf(fname, **kwargs):
     """Load a CHARMM or XPLOR PSF file from disk
 
     Parameters


### PR DESCRIPTION
When loading a trajectory with a psf topology and using the stride or atom_indices arguments, the following error message would be produced:

```
a=md.load('test.nc', top='test.psf', stride=10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/anaconda/lib/python2.7/site-packages/mdtraj-1.8.0.dev0-py2.7-linux-x86_64.egg/mdtraj/core/trajectory.py", line 372, in load
    kwargs["top"] = _parse_topology(kwargs["top"], **topkwargs)
  File "/opt/anaconda/lib/python2.7/site-packages/mdtraj-1.8.0.dev0-py2.7-linux-x86_64.egg/mdtraj/core/trajectory.py", line 174, in _parse_topology
    topology = load_psf(top, **kwargs)
TypeError: load_psf() got an unexpected keyword argument 'stride'
```

This is from a bug introduced in 68d6232d9e5f421a695dadf689cad3d0bd1655a2 where keyword arguments from `md.load` are passed to the topology loader. I just added `**kwargs` to each of these two loaders so they don't freak out with the unexpected arguments.