### PR TITLE
Amber restart file convention

### DIFF
--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -764,7 +764,7 @@ class AmberNetCDFRestartFile(object):
             v.units = 'degree'
         if set_time:
             v = ncfile.createVariable('time', 'd', ('time',))
-            v.units = 'picoseconds'
+            v.units = 'picosecond'
         self.flush()
 
     def __enter__(self):


### PR DESCRIPTION
Got this message from pmemd:

> Warning: In netcdf file, expected picosecond for attribute units, got picoseconds