### PR TITLE
Fix bugs in load with atom_indices and frame args

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -369,6 +369,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     if "top" in kwargs:  # If applicable, pre-loads the topology from PDB for major performance boost.
         topkwargs = kwargs.copy()
         topkwargs.pop("top", None)
+        topkwargs.pop("atom_indices", None)
+        topkwargs.pop("frame", None)
         kwargs["top"] = _parse_topology(kwargs["top"], **topkwargs)
 
     # grab the extension of the filename

--- a/mdtraj/tests/test_trajectory.py
+++ b/mdtraj/tests/test_trajectory.py
@@ -704,3 +704,17 @@ def test_load_pdb_no_standard_names():
     # to NOT replace any non-standard atom or residue names in the topology
     md.load(get_fn('native2.pdb'), standard_names=False)
     md.load_pdb(get_fn('native2.pdb'), standard_names=False)
+
+def test_load_with_atom_indices():
+    t1 = md.load(get_fn('frame0.xtc'), top=get_fn('frame0.gro'), atom_indices=[5])
+    t2 = md.load(get_fn('frame0.xtc'), top=get_fn('frame0.gro'))
+    t2 = t2.atom_slice([5])
+    eq(t1.xyz, t2.xyz)
+    eq(t1.time, t2.time)
+
+def test_load_with_frame():
+    t1 = md.load(get_fn('frame0.xtc'), top=get_fn('frame0.pdb'), frame=3)
+    t2 = md.load(get_fn('frame0.xtc'), top=get_fn('frame0.pdb'))
+    t2 = t2.slice([3])
+    eq(t1.xyz, t2.xyz)
+    eq(t1.time, t2.time)


### PR DESCRIPTION
Both bugs occur for topology formats that can also be trajectories
because MDTraj attempts to apply the args twice. When passing `frame`,
it's simply the `TypeError` reported in #1226. When it's `atom_indices`,
the topology gets sliced once when loading the topology and then again
when loading the trajectory. This does not cause any problems when
slicing from 0:n but fails when slicing indices past that.

Resolves #1226

cc @mattwthompson who found the `atom_indices` issue