### PR TITLE
Skip renumbering if no bonds in mol2

### DIFF
--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -105,8 +105,10 @@ def load_mol2(filename):
     atoms_mdtraj["chainID"] = np.ones(len(atoms), 'int')
 
     bonds_mdtraj = bonds[["id0", "id1"]].values
-    offset = bonds_mdtraj.min()  # Should this just be 1???
-    bonds_mdtraj -= offset
+
+    if bonds_mdtraj.any():
+        offset = bonds_mdtraj.min()  # Should this just be 1???
+        bonds_mdtraj -= offset
 
     top = Topology.from_dataframe(atoms_mdtraj, bonds_mdtraj)
 

--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -104,11 +104,12 @@ def load_mol2(filename):
     atoms_mdtraj["resSeq"] = np.ones(len(atoms), 'int')
     atoms_mdtraj["chainID"] = np.ones(len(atoms), 'int')
 
-    bonds_mdtraj = bonds[["id0", "id1"]].values
-
-    if bonds_mdtraj.any():
+    if bonds is not None:
+        bonds_mdtraj = bonds[["id0", "id1"]].values
         offset = bonds_mdtraj.min()  # Should this just be 1???
         bonds_mdtraj -= offset
+    else:
+        bonds_mdtraj = None
 
     top = Topology.from_dataframe(atoms_mdtraj, bonds_mdtraj)
 
@@ -161,11 +162,15 @@ def mol2_to_dataframes(filename):
     status_bit_regex = "BACKBONE|DICT|INTERRES|\|"
     data["@<TRIPOS>BOND\n"] = [re.sub(status_bit_regex, lambda _: "", s)
                                for s in data["@<TRIPOS>BOND\n"]]
-    csv = StringIO()
-    csv.writelines(data["@<TRIPOS>BOND\n"][1:])
-    csv.seek(0)
-    bonds_frame = pd.read_table(csv, names=["bond_id", "id0", "id1", "bond_type"],
-        index_col=0, header=None, sep="\s*", engine='python')
+
+    if len(data["@<TRIPOS>BOND\n"]) > 1:
+        csv = StringIO()
+        csv.writelines(data["@<TRIPOS>BOND\n"][1:])
+        csv.seek(0)
+        bonds_frame = pd.read_table(csv, names=["bond_id", "id0", "id1", "bond_type"],
+            index_col=0, header=None, sep="\s*", engine='python')
+    else:
+        bonds_frame = None
 
     csv = StringIO()
     csv.writelines(data["@<TRIPOS>ATOM\n"][1:])

--- a/mdtraj/testing/reference/li.mol2
+++ b/mdtraj/testing/reference/li.mol2
@@ -1,0 +1,12 @@
+@<TRIPOS>MOLECULE
+RES
+1 0 1 0 1
+SMALL
+NO_CHARGES
+@<TRIPOS>CRYSIN
+   10.0000    10.0000    10.0000    90.0000    90.0000    90.0000  1  1
+@<TRIPOS>ATOM
+       1 Li           0.0000     0.0000     0.0000 opls_404      1 RES     
+@<TRIPOS>BOND
+@<TRIPOS>SUBSTRUCTURE
+       1 RES             1 RESIDUE    0 **** ROOT      0

--- a/mdtraj/tests/test_mol2.py
+++ b/mdtraj/tests/test_mol2.py
@@ -121,3 +121,7 @@ def test_mol2_status_bits():
     trj = md.load_mol2(get_fn('status-bits.mol2'))
     eq(trj.topology.n_atoms, 18)
     eq(trj.topology.n_bonds, 18)
+
+def test_mol2_without_bonds():
+    trj = md.load_mol2(get_fn('li.mol2'))
+    assert trj.topology.n_bonds == 0


### PR DESCRIPTION
Currently, reading in a mol2 without bonds fails when it tries to renumber the bonds to 0 index:

```
import mdtraj as md

md.load('li.mol2')
```

with mol2 file:

```
@<TRIPOS>MOLECULE
RES
1 0 1 0 1 
SMALL
NO_CHARGES
@<TRIPOS>CRYSIN
   10.0000    10.0000    10.0000    90.0000    90.0000    90.0000  1  1
@<TRIPOS>ATOM
       1 Li           0.0000     0.0000     0.0000 opls_404      1 RES    
@<TRIPOS>BOND
@<TRIPOS>SUBSTRUCTURE
       1 RES             1 RESIDUE    0 **** ROOT      0 
```


> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "//anaconda/lib/python3.5/site-packages/mdtraj/core/trajectory.py", line 428, in load
    value = loader(filename, **kwargs)
  File "//anaconda/lib/python3.5/site-packages/mdtraj/formats/mol2.py", line 108, in load_mol2
    offset = bonds_mdtraj.min()  # Should this just be 1???
  File "//anaconda/lib/python3.5/site-packages/numpy/core/_methods.py", line 29, in _amin
    return umr_minimum(a, axis, None, out, keepdims)
ValueError: zero-size array to reduction operation minimum which has no identity

I changed this to only renumber bonds if ```mdraj_bonds``` is not empty. I also added a test with a mol2 file that has no bonds. All of the mol2 files currently being tested have bonds.