### PR TITLE
 Fix tranform calculation and Transform object to be more general.

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -6,6 +6,8 @@ These are new features and improvements of note in each release.
 v1.9 (Development)
 ------------------
 
+- PR #1254: Fixed/updated alignment code to be more general.
+
 v1.8 (November 9, 2016)
 -----------------------
 

--- a/mdtraj/geometry/alignment.py
+++ b/mdtraj/geometry/alignment.py
@@ -70,7 +70,7 @@ class Transformation(object):
 
         """
         return coordinates.dot(self.rotation) + self.translation
-        
+
 
     def __call__self(self, coordinates):
         return self.transform(coordinates)
@@ -289,10 +289,10 @@ def compute_average_structure(xyz):
     n_frames = xyz.shape[0]
     n_atoms = xyz.shape[1]
     candidate = xyz[0]
-    
+
     # In practice there is usually negligible improvement after the second iteration.
     # We do three just to be safe.
-    
+
     for iteration in range(3):
         average = np.zeros((n_atoms, 3))
         for frame in range(n_frames):

--- a/mdtraj/geometry/alignment.py
+++ b/mdtraj/geometry/alignment.py
@@ -69,8 +69,8 @@ class Transformation(object):
             xyz coordinates after being rotated and translated
 
         """
-        mu1 = coordinates.mean(0)
-        return coordinates.dot(self.rotation) + self.translation - mu1.dot(self.rotation)
+        return coordinates.dot(self.rotation) + self.translation
+        
 
     def __call__self(self, coordinates):
         return self.transform(coordinates)
@@ -138,8 +138,6 @@ def compute_translation_and_rotation(mobile, target):
     mu1 = mobile.mean(0)
     mu2 = target.mean(0)
 
-    translation = mu2
-
     mobile = mobile - mu1
     target = target - mu2
 
@@ -149,6 +147,8 @@ def compute_translation_and_rotation(mobile, target):
     if is_reflection:
         V[:, -1] = -V[:, -1]
     rotation = np.dot(V, W_tr)
+
+    translation = mu2 - mu1.dot(rotation)
 
     return translation, rotation
 

--- a/mdtraj/geometry/tests/test_alignment.py
+++ b/mdtraj/geometry/tests/test_alignment.py
@@ -31,6 +31,8 @@ offset = 1.0 * np.random.normal(size=(3))
 rotation = np.array([[1,0,0],[0,0,-1],[0,1,0]])
 xyz2 = rotation.dot(xyz1.T).T + offset
 xyz3 = xyz1 + np.random.normal(size=xyz1.shape)
+extra_points = np.array([[1, 2, 3],[4,5,6],[7,8,9],[10,11,12],[13,14,15]])
+xyz4 = rotation.dot(np.concatenate([xyz1, extra_points]).T).T + offset
 
 def test_rmsd_zero():
     rmsd_kabsch = alignment.rmsd_kabsch(xyz1, xyz2)
@@ -48,3 +50,11 @@ def test_transform():
     xyz2_prime = T.transform(xyz2)
 
     eq(xyz1, xyz2_prime)
+
+def test_transform2():
+    # For testing transform on all points when only subset for align
+    xyz1_len = np.shape(xyz1)[0]
+    T = alignment.compute_transformation(xyz4[0:xyz1_len,:], xyz1)
+    xyz4_prime = T.transform(xyz4)
+
+    eq(xyz1, xyz4_prime[0:xyz1_len,:])


### PR DESCRIPTION
Currently, if you create a transform object with `compute_transformation`,
you will get a Transform object that will only be able to correctly
transform groups of atoms that are the same as the target, i.e. you currently
can't align an entire system including water when you just compute
the transformation matrix on protein.

Perhaps there was a reason why it was written this way, but it currently does not deliver the behavior I was expecting. This fix should be more general and what users expect. I will come up with some tests and will commit them also.