### PR TITLE
Remove "lib" from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ var
 sdist
 develop-eggs
 .installed.cfg
-lib
 lib64
 
 # Installer logs


### PR DESCRIPTION
mdtraj/formats/tng/lib matches this, but it shouldn't be ignored.
Luckily it was checked in anyways :)