### PR TITLE
Fix precentering overflow error in center.c

### DIFF
--- a/mdtraj/rmsd/src/center.c
+++ b/mdtraj/rmsd/src/center.c
@@ -10,7 +10,7 @@ void inplace_center_and_trace_atom_major(float* coords, float* traces, const int
        Also compute the traces of the centered conformations, which are necessary
        for RMSD.
     */ 
-    size_t i, k;
+    long long i, k;
     float* confp;
     __m128d sx_, sy_, sz_, trace_;
     __m128 mux_, muy_, muz_;

--- a/mdtraj/rmsd/src/center.c
+++ b/mdtraj/rmsd/src/center.c
@@ -10,7 +10,7 @@ void inplace_center_and_trace_atom_major(float* coords, float* traces, const int
        Also compute the traces of the centered conformations, which are necessary
        for RMSD.
     */ 
-    int i, k;
+    size_t i, k;
     float* confp;
     __m128d sx_, sy_, sz_, trace_;
     __m128 mux_, muy_, muz_;


### PR DESCRIPTION
Per #1281, when `n_frames * n_atoms * 3` is greater than the maximum size of a signed 32-bit integer, an overflow error causes a segmentation fault in `mdtraj/rmsd/src/center.c`.

This PR fixes this by converting the offending `int` to a ~`size_t`~ `long long`.