### PR TITLE
Fix the build bug caused by incorrect plumbing the `numpy include path` into the cflags

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -249,6 +249,16 @@ release = {release}
                            release=isreleased))
 
 
+def numpy_include_dir():
+    """Get the path of numpy headers."""
+    try:
+        import numpy as np
+    except ImportError:
+        print("Cannot build mdtraj extensions without numpy installed.")
+        sys.exit(1)
+    return np.get_include()
+
+
 class StaticLibrary(Extension):
     def __init__(self, *args, **kwargs):
         self.export_include = kwargs.pop('export_include', [])
@@ -256,14 +266,9 @@ class StaticLibrary(Extension):
 
 
 class build_ext(_build_ext):
-    def initialize_options(self):
-        _build_ext.initialize_options(self)
-        import pkg_resources
-        dir = pkg_resources.resource_filename('numpy', 'core/include')
-        assert os.path.exists(dir), "Numpy include dir not found"
-        self.include_dirs = [dir]
 
     def build_extension(self, ext):
+        ext.include_dirs.append(numpy_include_dir())
         if isinstance(ext, StaticLibrary):
             self.build_static_extension(ext)
         else:


### PR DESCRIPTION
Fixes the buggy code that adds the include path of numpy headers to the c compiler.

This pull request does two jobs:
1) Clears the buggy code in basesetup.py (the useless initialize_options() override)
2) Add a common and reliable mechanism that finds the numpy include path and plumbs
the path to the Extension objects.

This pull request affects:
1) Building mdtraj with pip/from source.

Rationales:
1) the build_ext class is ultimately subclassing the distutils.command.build_ext. See [setuptools.command.build_ext, line 5](https://github.com/pypa/setuptools/blob/aa41a7a58d0e1cd0dd6715b2d4057666410114c7/setuptools/command/build_ext.py#L5) and [cython.Distutils.build_ext, line 5](https://github.com/cython/cython/blob/ef241f5bc514075aea713d0e93aad3239df253b4/Cython/Distutils/build_ext.py#L5). Cython's `build_ext` actually loops back to setuptools and ultimately they both use `distutils.command.build_ext`.

2) The `distutils.command.build_ext` is an instance of the abstract class `distutils.cmd.Command`. See [distutils.command.build_ext](https://github.com/python/cpython/blob/772d809a63f40fd35679da3fb115cdf7fa81bd20/Lib/distutils/command/build_ext.py#L33). 

3) The design of `distutils.cmd.Command` says the `initialize_options()` is used to DECLARE all options of such specific command object. And `finalize_options()` is used to finalize all options of the command. And the magic happens in between `initialize_options()` and `finalize_options()` that set the value of all options. See the comment [distutils.command.build_ext comment](https://github.com/python/cpython/blob/772d809a63f40fd35679da3fb115cdf7fa81bd20/Lib/distutils/command/build_ext.py#L52).

4) The magic in 3) actually happens here: [distutils.dist](https://github.com/python/cpython/blob/772d809a63f40fd35679da3fb115cdf7fa81bd20/Lib/distutils/dist.py#L861). If you turn on the DEBUG macro in the distutils package, you will see the creating build_ext message get printed out and when setting the options of the command `build_ext`, the `numpy_include_dir` set in the `basesetup.build_ext.initialize_options` is ignored (disrespected) and the value is directly set to what distutils find (in distutils.cfg/command line).

According to above, the numpy include path could actually be NOT included in the c compiler's include paths 1) if the distutils.cfg is not containing the numpy path 2) not provided by the command line. To fix this,

1) Delete the `initialize_options()` override, that function only works for declaring options but not initializing them. All initialization will be disrespected.

2) Use a global function, a standard way to find numpy include path.

3) Plumbs the path into each extension.