### PR TITLE
Remove PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Anaconda-Server Version](https://anaconda.org/omnia/mdtraj/badges/version.svg)](https://anaconda.org/omnia/mdtraj)
 [![Anaconda-Server Downloads](https://anaconda.org/omnia/mdtraj/badges/downloads.svg)](https://anaconda.org/omnia/mdtraj)
 [![Research software impact](http://depsy.org/api/package/pypi/mdtraj/badge.svg)](http://depsy.org/package/python/mdtraj)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/mdtraj.svg)](https://pypi.python.org/pypi/mdtraj)
 
 Read, write and analyze MD trajectories with only a few lines of Python code.
 


### PR DESCRIPTION
I think this is broken. It reports 0/mo (which doesn't look good anyway). But also the shields.io example for django also reports 0/mo which doesn't seem right :)