### PR TITLE
Add Bond Order information to Topology

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
       - csh
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install md5sha1sum; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install md5sha1sum; fi
   - source devtools/travis-ci/install_miniconda.sh
   - source devtools/travis-ci/install_sparta.sh
   - source devtools/travis-ci/install_ppm.sh

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -34,7 +34,7 @@ test:
     - pytest
     - networkx
     - matplotlib
-    - openmm  # [not (win32 or (win and py2k))]
+    - openmm >=7.1  # [not (win32 or (win and py2k))]
     - shiftx2  # [linux and py2k]
     - nbformat
     - ipykernel

--- a/mdtraj/__init__.py
+++ b/mdtraj/__init__.py
@@ -52,7 +52,7 @@ from .formats.tng import load_tng
 from .core import element
 from ._rmsd import rmsd
 from ._lprmsd import lprmsd
-from .core.topology import Topology
+from .core.topology import Topology, Single, Double, Triple, Amide, Aromatic
 from .geometry import *
 from .core.trajectory import *
 from .nmr import *

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1621,14 +1621,10 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
             return False
         if {other[0], other[1]} != {self[0], self[1]}:
             return False
-        # Optional consideration, but this is more like metadata on the bond,
-        # If the above checks out, but the below does not, then there are
-        # now two bonds between the same atoms, which makes no sense
-
-        # if other.type != self.type:
-        #     return False
-        # if other.order != self.order:
-        #     return False
+        if other.type != self.type:
+            return False
+        if other.order != self.order:
+            return False
         return True
 
     def __repr__(self):

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1619,8 +1619,8 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
     def _equality_tuple(self):
         # Hierarchy of parameters: Atom1 index -> Atom2 index -> type -> order
         return (self[0].index, self[1].index,
-                self.order if self.order is not None else 0,
-                float(self.type) if self.type is not None else 0.0)
+                float(self.type) if self.type is not None else 0.0,
+                self.order if self.order is not None else 0)
 
     def __deepcopy__(self, memo):
         return Bond(self[0], self[1], self.type, self.order)
@@ -1646,10 +1646,31 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
         # Set of atoms making up bonds, the type, and the order
         return hash((self[0], self[1], self.type, self.order))
 
-    def __gt__(self, other):
-        # Uses the total_ordering to handle all other comparators
+    @staticmethod
+    def _other_is_bond(other):
+        # Ensure other type for inequalities is a bond
         if not isinstance(other, Bond):
             raise TypeError("Bond inequalities can only be compared with other bonds")
+
+    def __gt__(self, other):
+        # Cannot use total_ordering because namedtuple
+        # has its own __gt__, __lt__, etc. methods, which
+        # supersede total_ordering
+        self._other_is_bond(other)
         return self._equality_tuple > other._equality_tuple
 
+    def __ge__(self, other):
+        self._other_is_bond(other)
+        return self._equality_tuple >= other._equality_tuple
+
+    def __lt__(self, other):
+        self._other_is_bond(other)
+        return self._equality_tuple < other._equality_tuple
+
+    def __le__(self, other):
+        self._other_is_bond(other)
+        return self._equality_tuple <= other._equality_tuple
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -54,7 +54,6 @@ import numpy as np
 import os
 import xml.etree.ElementTree as etree
 from collections import namedtuple
-from functools import total_ordering
 
 from mdtraj.core import element as elem
 from mdtraj.core.residue_names import (_PROTEIN_RESIDUES, _WATER_RESIDUES,
@@ -1581,7 +1580,6 @@ def float_to_bond_type(bond_float):
     return None
 
 
-@total_ordering
 class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
     """A Bond representation of a bond between two Atoms within a Topology
 
@@ -1674,3 +1672,7 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __getstate__(self):
+        # This is required for pickle because the parent class
+        # does not properly return a state
+        return self.__dict__

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -1615,19 +1615,20 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
         """
         return self[0], self[1], self.type, self.order
 
+    @property
+    def _equality_tuple(self):
+        # Hierarchy of parameters: Atom1 index -> Atom2 index -> type -> order
+        return (self[0].index, self[1].index,
+                self.order if self.order is not None else 0,
+                float(self.type) if self.type is not None else 0.0)
+
     def __deepcopy__(self, memo):
         return Bond(self[0], self[1], self.type, self.order)
 
     def __eq__(self, other):
         if not isinstance(other, Bond):
             return False
-        if {other[0], other[1]} != {self[0], self[1]}:
-            return False
-        if other.type != self.type:
-            return False
-        if other.order != self.order:
-            return False
-        return True
+        return self._equality_tuple == other._equality_tuple
 
     def __repr__(self):
         s = "Bond(%s, %s" % (self[0], self[1])
@@ -1649,24 +1650,6 @@ class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
         # Uses the total_ordering to handle all other comparators
         if not isinstance(other, Bond):
             raise TypeError("Bond inequalities can only be compared with other bonds")
-        # Hierarchy of parameters: Atom1 index -> Atom2 index -> type -> order
-        # Use advantage of the namedtuple to check indices
-        if self > other:
-            return True
-        elif self == other:  # let the self < other fall to the default
-            if self.type == other.type:
-                # Trap the None object
-                self_order = self.order if self.order is not None else 0
-                other_order = other.order if other.order is not None else 0
-                if self_order > other_order:  # let self.order < other.order
-                    return True
-                # Don't check self.order == other.order as no more hierarchy of things to check
-            else:
-                # Trap the None object
-                self_type = float(self.type) if self.type is not None else 0.0
-                other_type = float(other.type) if other.type is not None else 0.0
-                if self_type > other_type:  # let self.type < other.type fall to default
-                    return True
-        return False
+        return self._equality_tuple > other._equality_tuple
 
 

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -53,6 +53,7 @@ import itertools
 import numpy as np
 import os
 import xml.etree.ElementTree as etree
+from collections import namedtuple
 
 from mdtraj.core import element as elem
 from mdtraj.core.residue_names import (_PROTEIN_RESIDUES, _WATER_RESIDUES,
@@ -60,6 +61,7 @@ from mdtraj.core.residue_names import (_PROTEIN_RESIDUES, _WATER_RESIDUES,
 from mdtraj.core.selection import parse_selection
 from mdtraj.utils import ilen, import_, ensure_type
 from mdtraj.utils.six import string_types
+from mdtraj.utils.singleton import Singleton
 
 ##############################################################################
 # Utilities
@@ -105,10 +107,13 @@ def _topology_from_subset(topology, atom_indices):
     if not hasattr(bondsiter, '__iter__'):
         bondsiter = bondsiter()
 
-    for atom1, atom2 in bondsiter:
+    for bond in bondsiter:
         try:
+            atom1, atom2 = bond
             newTopology.add_bond(old_atom_to_new_atom[atom1],
-                                 old_atom_to_new_atom[atom2])
+                                 old_atom_to_new_atom[atom2],
+                                 type=bond.type,
+                                 order=bond.order)
         except KeyError:
             pass
             # we only put bonds into the new topology if both of their partners
@@ -155,6 +160,8 @@ class Topology(object):
         Iterator over all Residues in the Chain.
     atoms : generator
         Iterator over all Atoms in the Chain.
+    bonds : generator
+        Iterator over all Bonds in the Topology
 
     Examples
     --------
@@ -222,8 +229,9 @@ class Topology(object):
                 for atom in residue.atoms:
                     out.add_atom(atom.name, atom.element, r, serial=atom.serial)
 
-        for a1, a2 in self.bonds:
-            out.add_bond(a1, a2)
+        for bond in self.bonds:
+            a1, a2 = bond
+            out.add_bond(a1, a2, type=bond.type, order=bond.order)
 
         return out
 
@@ -269,8 +277,9 @@ class Topology(object):
                                      serial=atom.serial)
                     atom_mapping[atom] = a
 
-        for a1, a2 in other.bonds:
-            out.add_bond(atom_mapping[a1], atom_mapping[a2])
+        for bond in other.bonds:
+            a1, a2 = bond
+            out.add_bond(atom_mapping[a1], atom_mapping[a2], type=bond.type, order=bond.order)
 
         return out
 
@@ -317,6 +326,12 @@ class Topology(object):
 
         out = app.Topology()
         atom_mapping = {}
+        bond_mapping = {Single: app.Single,
+                        Double: app.Double,
+                        Triple: app.Triple,
+                        Amide: app.Amide,
+                        Aromatic: app.Aromatic,
+                        None: None}
 
         for chain in self.chains:
             c = out.addChain()
@@ -330,8 +345,9 @@ class Topology(object):
                     a = out.addAtom(atom.name, element, r)
                     atom_mapping[atom] = a
 
-        for a1, a2 in self.bonds:
-            out.addBond(atom_mapping[a1], atom_mapping[a2])
+        for bond in self.bonds:
+            a1, a2 = bond
+            out.addBond(atom_mapping[a1], atom_mapping[a2], type=bond_mapping[bond.type], order=bond.order)
 
         if traj is not None:
             angles = traj.unitcell_angles[0]
@@ -356,6 +372,12 @@ class Topology(object):
             mdtraj topology.
         """
         app = import_('simtk.openmm.app')
+        bond_mapping = {app.Single: Single,
+                        app.Double: Double,
+                        app.Triple: Triple,
+                        app.Amide: Amide,
+                        app.Aromatic: Aromatic,
+                        None: None}
 
         if not isinstance(value, app.Topology):
             raise TypeError('value must be an OpenMM Topology. '
@@ -376,8 +398,9 @@ class Topology(object):
                     a = out.add_atom(atom.name, element, r)
                     atom_mapping[atom] = a
 
-        for a1, a2 in value.bonds():
-            out.add_bond(atom_mapping[a1], atom_mapping[a2])
+        for bond in value.bonds():
+            a1, a2 = bond
+            out.add_bond(atom_mapping[a1], atom_mapping[a2], type=bond_mapping[bond.type], order=bond.order)
 
         return out
 
@@ -388,9 +411,10 @@ class Topology(object):
         -------
         atoms : pandas.DataFrame
             The atoms in the topology, represented as a data frame.
-        bonds : np.ndarray
-            The bonds in this topology, represented as an n_bonds x 2 array
-            of the indices of the atoms involved in each bond.
+        bonds : np.ndarray, shape=(n_bonds, 4), dtype=float, Optional
+            The bonds in this topology, represented as an n_bonds x 4 array indicating the two atom indices of the bond,
+            the bond type, and bond order, cast to floats as the type is mapped from the classes to fractional.
+            The atom indices and order are integers cast to float
         """
         pd = import_('pandas')
         data = [(atom.serial, atom.name, atom.element.symbol,
@@ -400,7 +424,18 @@ class Topology(object):
         atoms = pd.DataFrame(data, columns=["serial", "name", "element",
                                             "resSeq", "resName", "chainID","segmentID"])
 
-        bonds = np.array([(a.index, b.index) for (a, b) in self.bonds])
+        bonds = np.zeros([len(self._bonds), 4], dtype=float)
+        for index, bond in enumerate(self.bonds):
+            if bond.order is None:
+                order = 0.0
+            else:
+                order = bond.order
+            try:
+                bond_type = float(bond.type)
+            except TypeError:
+                # Trap the None case
+                bond_type = 0.0
+            bonds[index] = bond.atom1.index, bond.atom2.index, bond_type, order
         return atoms, bonds
 
     @classmethod
@@ -416,12 +451,14 @@ class Topology(object):
             "resName" (name of the residue), "chainID" (index of the chain),
             and optionally "segmentID", following the same conventions
             as wwPDB 3.0 format.
-        bonds : np.ndarray, shape=(n_bonds, 2), dtype=int, optional
-            The bonds in the topology, represented as an n_bonds x 2 array
-            of the indices of the atoms involved in each bond. Specifiying
-            bonds here is optional. To create standard protein bonds, you can
-            use `create_standard_bonds` to "fill in" the bonds on your newly
-            created Topology object
+        bonds : np.ndarray, shape=(n_bonds, 4) or (n_bonds, 2), dtype=float, Optional
+            The bonds in the topology, represented as a n_bonds x 4 or n_bonds x 2
+            size array of the indices of the atoms involved, type, and order of each
+            bond, represented as floats. Type and order are optional. Specifying bonds
+            here is optional. To create standard protein bonds, you can use
+            `create_standard_bonds` to "fill in" the bonds on your newly created
+            Topology object, although type and order of bond are not computed if
+            that method is used.
 
         See Also
         --------
@@ -430,7 +467,7 @@ class Topology(object):
         pd = import_('pandas')
 
         if bonds is None:
-            bonds = np.zeros((0, 2))
+            bonds = np.zeros([0, 4], dtype=float)
 
         for col in ["name", "element", "resSeq",
                     "resName", "chainID", "serial"]:
@@ -475,8 +512,19 @@ class Topology(object):
                     out._atoms[atom_index] = a
                     r._atoms.append(a)
 
-        for ai1, ai2 in bonds:
-            out.add_bond(out.atom(ai1), out.atom(ai2))
+        for bond in bonds:
+            ai1 = int(bond[0])
+            ai2 = int(bond[1])
+            try:
+                bond_type = float_to_bond_type(bond[2])
+                bond_order = int(bond[3])
+                if bond_order == 0:
+                    bond_order = None
+            except IndexError:
+                # Does not exist
+                bond_type = None
+                bond_order = None
+            out.add_bond(out.atom(ai1), out.atom(ai2), bond_type, bond_order)
 
         out._numAtoms = out.n_atoms
         return out
@@ -551,15 +599,11 @@ class Topology(object):
             return False
 
         # the bond ordering is somewhat ambiguous, so try and fix it for comparison
-        self_sorted_bonds = sorted([(a1.index, b1.index)
-                                    for (a1, b1) in self.bonds])
-        other_sorted_bonds = sorted([(a2.index, b2.index)
-                                     for (a2, b2) in other.bonds])
+        self_sorted_bonds = sorted([bond for bond in self.bonds])
+        other_sorted_bonds = sorted([bond for bond in other.bonds])
 
-        for i in range(len(self._bonds)):
-            (a1, b1) = self_sorted_bonds[i]
-            (a2, b2) = other_sorted_bonds[i]
-            if (a1 != a2) or (b1 != b2):
+        for i, bond in enumerate(self_sorted_bonds):
+            if bond != other_sorted_bonds[i]:
                 return False
 
         return True
@@ -633,7 +677,7 @@ class Topology(object):
         residue._atoms.append(atom)
         return atom
 
-    def add_bond(self, atom1, atom2):
+    def add_bond(self, atom1, atom2, type=None, order=None):
         """Create a new bond and add it to the Topology.
 
         Parameters
@@ -642,11 +686,15 @@ class Topology(object):
             The first Atom connected by the bond
         atom2 : mdtraj.topology.Atom
             The second Atom connected by the bond
+        type : mdtraj.topology.Singleton or None, Default: None, Optional
+            Bond type of the bond, or None if not known/provided
+        order : 1, 2, 3 or None, Default: None, Optional
+            Characteristic order of the bond if known, defaults None
         """
         if atom1.index < atom2.index:
-            self._bonds.append((atom1, atom2))
+            self._bonds.append(Bond(atom1, atom2, type=type, order=order))
         else:
-            self._bonds.append((atom2, atom1))
+            self._bonds.append(Bond(atom2, atom1, type=type, order=order))
 
     def chain(self, index):
         """Get a specific chain by index.  These indices
@@ -776,8 +824,11 @@ class Topology(object):
 
         Returns
         -------
-        atomiter : generator
-            Iterator over all tuple of Atoms in the Trajectory involved in a bond.
+        bonditer : generator
+            Iterator over all bonds between Atoms in the Trajectory.
+            Each bond can then be iterated to get the atoms.
+            I.e.: `for atom1, atom2 in Topology.bonds` yields iterator over pairs of Atoms
+                  `for bond in Topology.bonds` yields iterator over bonds
         """
         return iter(self._bonds)
 
@@ -1134,7 +1185,7 @@ class Topology(object):
             raise ValueError("Could not find any anchor molecules. Based on "
                              "our heuristic, those should be molecules with "
                              "more than {} atoms. Perhaps your topology "
-                             "doesn't give an acurate bond graph?"
+                             "doesn't give an accurate bond graph?"
                              .format(atoms_cutoff))
         return anchor_molecules
 
@@ -1458,3 +1509,163 @@ class Atom(object):
     def __repr__(self):
         return str(self)
 
+
+# Enumerated values for bond type
+
+class Single(Singleton):
+    def __repr__(self):
+        return 'Single'
+
+    def __float__(self):
+        return 1.0
+Single = Single()
+
+
+class Double(Singleton):
+    def __repr__(self):
+        return 'Double'
+
+    def __float__(self):
+        return 2.0
+Double = Double()
+
+
+class Triple(Singleton):
+    def __repr__(self):
+        return 'Triple'
+
+    def __float__(self):
+        return 3.0
+Triple = Triple()
+
+
+class Aromatic(Singleton):
+    def __repr__(self):
+        return 'Aromatic'
+
+    def __float__(self):
+        return 1.5
+Aromatic = Aromatic()
+
+
+class Amide(Singleton):
+    def __repr__(self):
+        return 'Amide'
+
+    def __float__(self):
+        return 1.25
+Amide = Amide()
+
+
+def float_to_bond_type(bond_float):
+    """
+
+    Parameters
+    ----------
+    bond_float: float
+        Representation of built in bond types as a float,
+        Maps this float to specific bond class, if the float has no map, None is returned instead
+
+    Returns
+    -------
+    bond_type : mdtraj.topology.Singleton subclass or None
+        Bond type matched to the float if known
+        If no match is found, returns None (which is also a valid type for the Bond class)
+    """
+    all_bond_types = [Single, Double, Triple, Aromatic, Amide]
+    for bond_type in all_bond_types:
+        if float(bond_type) == float(bond_float):
+            return bond_type
+    return None
+
+
+class Bond(namedtuple('Bond', ['atom1', 'atom2'])):
+    """A Bond representation of a bond between two Atoms within a Topology
+
+    Attributes
+    ----------
+    atom1 : mdtraj.topology.Atom
+        The first atom in the bond
+    atom2 : mdtraj.topology.Atom
+        The second atom in the bond
+    order : instance of mdtraj.topology.Singleton or None
+    type : int on [1,3] domain or None
+    """
+
+
+    _STR_TO_BOND_TYPE = {value: key for key, value in _BOND_TYPE_TO_STR.items()}
+
+    def __new__(cls, atom1, atom2, type=None, order=None):
+        """Construct a new Bond.  You should call add_bond()
+        on the Topology instead of calling this directly.
+
+        Must use __new__ constructor since this is an immutable class
+        """
+        bond = super(Bond, cls).__new__(cls, atom1, atom2)
+        assert isinstance(type, Singleton) or type is None, "Type must be None or a Singleton"
+        assert 1 <= order <= 3 or order is None, "Order must be int between 1 to 3 or None"
+        bond.type = type
+        bond.order = order
+        return bond
+
+    @classmethod
+    def from_numpy(cls, np_bond):
+        """
+        Create a bond from a numpy structured array of dtype
+        , often created from a bond using `to_numpy`
+        function.
+
+        Parameters
+        ----------
+        np_bond: numpy.ndarray
+            Structured numpy array
+
+        Returns
+        -------
+        bond : mdtraj.topology.Bond
+            New Bond from the array
+        """
+        atom1 = np_bond['atom1']
+        atom2 = np_bond['atom2']
+        bond_type = cls._STR_TO_BOND_TYPE[np_bond['type']]
+        order = np_bond['order']
+        if order == 0:
+            order = None
+        out = cls(atom1, atom2, )
+
+    def __getnewargs__(self):
+        """
+        Support for pickle protocol 2:
+        http://docs.python.org/2/library/pickle.html#pickling-and-unpickling-normal-class-instances
+        """
+        return self[0], self[1], self.type, self.order
+
+    def __deepcopy__(self, memo):
+        return Bond(self[0], self[1], self.type, self.order)
+
+    def __eq__(self, other):
+        if not isinstance(other, Bond):
+            return False
+        if {other[0], other[1]} != {self[0], self[1]}:
+            return False
+        if other.type != self.type:
+            return False
+        if other.order != self.order:
+            return False
+        return True
+
+    def __repr__(self):
+        s = "Bond(%s, %s" % (self[0], self[1])
+        if self.type is not None:
+            s = "%s, type=%s" % (s, self.type)
+        if self.order is not None:
+            s = "%s, order=%d" % (s, self.order)
+        s += ")"
+        return s
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __hash__(self):
+        # Set of atoms making up bonds, the type, and the order
+        return hash(({(self[0], self[1])}, self.type, self.order))

--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -137,6 +137,8 @@ def load_mol2(filename):
     return traj
 
 
+
+
 def mol2_to_dataframes(filename):
     """Convert a GAFF (or sybyl) mol2 file to a pair of pandas dataframes.
 
@@ -202,6 +204,8 @@ def _parse_mol2_sections(x):
     if x.startswith('@<TRIPOS>'):
         _parse_mol2_sections.key = x
     return _parse_mol2_sections.key
+
+
 
 
 gaff_elements = {

--- a/mdtraj/utils/singleton.py
+++ b/mdtraj/utils/singleton.py
@@ -7,6 +7,7 @@ pickling/unpickling
 
 class Singleton(object):
     _inst = None
+
     def __new__(cls):
         if cls._inst is None:
             cls._inst = super(Singleton, cls).__new__(cls)
@@ -14,3 +15,6 @@ class Singleton(object):
 
     def __reduce__(self):
         return repr(self)
+
+    def __float__(self):
+        return 0.0

--- a/mdtraj/utils/singleton.py
+++ b/mdtraj/utils/singleton.py
@@ -1,0 +1,16 @@
+"""
+Creates a subclass for all classes intended to be a singleton. This
+maintains the correctness of instance is instance even following
+pickling/unpickling
+"""
+
+
+class Singleton(object):
+    _inst = None
+    def __new__(cls):
+        if cls._inst is None:
+            cls._inst = super(Singleton, cls).__new__(cls)
+        return cls._inst
+
+    def __reduce__(self):
+        return repr(self)

--- a/tests/test_mol2.py
+++ b/tests/test_mol2.py
@@ -39,6 +39,16 @@ def test_load_mol2(get_fn):
 
     ref_top, ref_bonds = ref_trj.top.to_dataframe()
     top, bonds = trj.top.to_dataframe()
+    # PDB Does not have bond order, ensure that the equality fails
+    try:
+        eq(bonds, ref_bonds)
+    except AssertionError:
+        # This is what we wanted to happen, its fine
+        pass
+    else:
+        raise AssertionError("Reference bonds with no bond order should not equal Mol2 bonds with bond order")
+    # Strip bond order info since PDB does not have it
+    bonds[:, -2:] = np.zeros([bonds.shape[0], 2])
     eq(bonds, ref_bonds)
 
 

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -196,7 +196,7 @@ def test_3nch_conect(get_fn):
     # This has conect entries that use all available digits, good failure case.
     t1 = load_pdb(get_fn('3nch.pdb.gz'))
     top, bonds = t1.top.to_dataframe()
-    bonds = dict(((a, b), 1) for (a, b) in bonds)
+    bonds = dict(((a, b), 1) for (a, b, _, _) in bonds)
     eq(bonds[19782, 19783], 1)  # Check that last SO4 molecule has right bonds
     eq(bonds[19782, 19784], 1)  # Check that last SO4 molecule has right bonds
     eq(bonds[19782, 19785], 1)  # Check that last SO4 molecule has right bonds

--- a/tests/test_tng.py
+++ b/tests/test_tng.py
@@ -23,7 +23,7 @@ def test_load_topology(get_fn):
     top = traj.topology
     eq(5, top.n_residues)
     eq(10, top.n_bonds)
-    bonds = list(top.bonds)
+    bonds = [(a, b) for a, b in top.bonds]
     for res in top.residues:
         eq('HOH', res.name)
         eq(3, res.n_atoms)

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -43,16 +43,18 @@ needs_openmm = pytest.mark.skipif(not HAVE_OPENMM, reason='needs OpenMM')
 @needs_openmm
 def test_topology_openmm(get_fn):
     topology = md.load(get_fn('1bpi.pdb')).topology
+    topology_with_bond_order = md.load(get_fn('imatinib.mol2')).topology
 
     # the openmm trajectory doesn't have the distinction
     # between resSeq and index, so if they're out of whack
     # in the openmm version, that cant be preserved
-    for residue in topology.residues:
-        residue.resSeq = residue.index
-    mm = topology.to_openmm()
-    assert isinstance(mm, app.Topology)
-    topology2 = md.Topology.from_openmm(mm)
-    eq(topology, topology2)
+    for top in [topology, topology_with_bond_order]:
+        for residue in top.residues:
+            residue.resSeq = residue.index
+        mm = top.to_openmm()
+        assert isinstance(mm, app.Topology)
+        topology2 = md.Topology.from_openmm(mm)
+        eq(top, topology2)
 
 
 @needs_openmm

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -143,7 +143,11 @@ def test_nonconsective_resSeq(get_fn):
 
 def test_pickle(get_fn):
     # test pickling of topology (bug #391)
-    pickle.loads(pickle.dumps(md.load(get_fn('bpti.pdb')).topology))
+    topology_without_bond_order = md.load(get_fn('bpti.pdb')).topology
+    topology_with_bond_order = md.load(get_fn('imatinib.mol2')).topology
+    for top in [topology_with_bond_order, topology_without_bond_order]:
+        loaded_top = pickle.loads(pickle.dumps(top))
+        assert loaded_top == top
 
 
 def test_atoms_by_name(get_fn):


### PR DESCRIPTION
This PR ports the [OpenMM bond order](https://github.com/pandegroup/openmm/pull/1668) representation into MDTraj. Implements the `Bond` class to Topology and updates the Mol2 reader to use bond_order field.

This does change the API a bit since bonds are now represented by a class instead of just two atoms. However, most backwards compatibility should be preserved as each `Bond` is subclass of the `namedtuple` so you can iterate by `for a,b in top.bonds` and still get a `Atom` class for `a` and `b`. This behavior is only different in the `to_dataframe` output (see below).

There are a couple of points which I implemented which I would like some additional feedback on.

1. Equality/Less than/Greater than of a Bond: Right now I only compare Atom index and not Type/Order since defining these does not change which atoms are bound. I could compare these, but it seemed redundant unless you wanted to define two bonds for the same pair of atoms? The only place I see this being used is in `Topology` equality checks.
2. `to_/from_dataframe` representation of `Bond`. I changed the output of this to float to represent the `Bond.type` as fractional for things like Aromatic and Amide, without having to have a numpy array of mixed type or structured arrays. Since this is the main API breaking component, it would be good to get some feedback on this implementation and if others have a better way of making this conversion.

Fixes #1307 