### PR TITLE
Parsing residues.xml

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -843,8 +843,8 @@ class Topology(object):
         if len(Topology._standardBonds) == 0:
             # Load the standard bond defitions.
 
-            tree = etree.parse(os.path.join(os.path.dirname(__file__), '..',
-                               'formats', 'pdb', 'data', 'residues.xml'))
+            tree = etree.parse(os.path.join(os.path.dirname(
+              os.path.dirname(__file__)),'formats', 'pdb', 'data', 'residues.xml'))
             for residue in tree.getroot().findall('Residue'):
                 bonds = []
                 Topology._standardBonds[residue.attrib['name']] = bonds


### PR DESCRIPTION
I think calling os.path.dirname twice instead of using '..' to go one folder up here is a good idea (in terms of cross-platform compatibility).