### PR TITLE
[formats/xtc] use byte offsets between frames for stride if avail

### DIFF
--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -384,7 +384,7 @@ cdef class XTCTrajectoryFile(object):
             # if they supply the number of frames they want, that's easy
             if not int(n_frames) == n_frames:
                 raise ValueError('n_frames must be an int, you supplied "%s"' % n_frames)
-            if stride > 1 and self._offsets is not None:
+            if stride is not None and int(stride) > 1 and self._offsets is not None:
                 xyz, time, step, box = self._read_with_stride(int(n_frames), atom_indices, stride)
             else:
                 xyz, time, step, box = self._read(int(n_frames), atom_indices)

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -495,9 +495,6 @@ cdef class XTCTrajectoryFile(object):
 
         # absolute positions
         stride = np.arange(self.frame_counter, min(self.frame_counter + n_frames, len(self)), stride)
-        print('stride array:', stride)
-        print('stride array shape:', stride.shape)
-        #assert len(stride) == n_frames, len(stride)
         n_frames = len(stride)
 
         cdef int i = 0
@@ -531,7 +528,6 @@ cdef class XTCTrajectoryFile(object):
         cdef np.ndarray[dtype=np.float32_t, ndim=2] framebuffer = np.zeros((self.n_atoms, 3), dtype=np.float32)
 
         for i, frame_index in enumerate(stride):
-            print('seek to ', frame_index)
             self.seek(frame_index)
 
             # read
@@ -546,7 +542,6 @@ cdef class XTCTrajectoryFile(object):
             if status != _EXDRENDOFFILE and status != _EXDROK:
                 raise RuntimeError('XTC read error: %s' % _EXDR_ERROR_MESSAGES.get(status, 'unknown'))
             self.frame_counter = frame_index  # set absolute position
-            print('frame counter:', self.frame_counter)
 
         return xyz, time, step, box
 

--- a/tests/test_xtc.py
+++ b/tests/test_xtc.py
@@ -96,6 +96,30 @@ def test_read_stride_n_frames_offsets(get_fn, fn_xtc):
         assert eq(time, iofile['time'][::s])
 
 
+def test_read_stride_switching(get_fn, fn_xtc):
+    iofile = io.loadh(get_fn('frame0.xtc.h5'), deferred=False)
+    with XTCTrajectoryFile(fn_xtc) as f:
+        f.offsets  # pre-compute byte offsets between frames
+        # read the first 10 frames with stride of 2
+        s = 2
+        n_frames = 10
+        xyz, time, step, box = f.read(n_frames=n_frames, stride=s)
+        assert eq(xyz, iofile['xyz'][:n_frames:s])
+        assert eq(step, iofile['step'][:n_frames:s])
+        assert eq(box, iofile['box'][:n_frames:s])
+        assert eq(time, iofile['time'][:n_frames:s])
+        # now read the rest with stride 3, should start from frame index 8.
+        # eg. np.arange(0, 10, 2)[-1] == 8
+        s = 3
+        offset = f.tell()
+        assert offset == 8
+        xyz, time, step, box = f.read(n_frames=None, stride=s)
+        assert eq(xyz, iofile['xyz'][offset::s])
+        assert eq(step, iofile['step'][offset::s])
+        assert eq(box, iofile['box'][offset::s])
+        assert eq(time, iofile['time'][offset::s])
+
+
 def test_read_atomindices_1(get_fn, fn_xtc):
     iofile = io.loadh(get_fn('frame0.xtc.h5'), deferred=False)
     with XTCTrajectoryFile(fn_xtc) as f:

--- a/tests/test_xtc.py
+++ b/tests/test_xtc.py
@@ -70,6 +70,32 @@ def test_read_stride_n_frames(get_fn, fn_xtc):
     assert eq(time, iofile['time'][::3])
 
 
+def test_read_stride_offsets(get_fn, fn_xtc):
+    # read xtc with stride and offsets
+    iofile = io.loadh(get_fn('frame0.xtc.h5'), deferred=False)
+    for s in (1, 2, 3, 4, 5):
+        with XTCTrajectoryFile(fn_xtc) as f:
+            f.offsets # pre-compute byte offsets between frames
+            xyz, time, step, box = f.read(stride=s)
+        assert eq(xyz, iofile['xyz'][::s])
+        assert eq(step, iofile['step'][::s])
+        assert eq(box, iofile['box'][::s])
+        assert eq(time, iofile['time'][::s])
+
+
+def test_read_stride_n_frames_offsets(get_fn, fn_xtc):
+    # read xtc with stride with n_frames and offsets
+    iofile = io.loadh(get_fn('frame0.xtc.h5'), deferred=False)
+    for s in (1, 2, 3, 4, 5):
+        with XTCTrajectoryFile(fn_xtc) as f:
+            f.offsets # pre-compute byte offsets between frames
+            xyz, time, step, box = f.read(n_frames=1000, stride=s)
+        assert eq(xyz, iofile['xyz'][::s])
+        assert eq(step, iofile['step'][::s])
+        assert eq(box, iofile['box'][::s])
+        assert eq(time, iofile['time'][::s])
+
+
 def test_read_atomindices_1(get_fn, fn_xtc):
     iofile = io.loadh(get_fn('frame0.xtc.h5'), deferred=False)
     with XTCTrajectoryFile(fn_xtc) as f:


### PR DESCRIPTION
This should avoid a lot of IO for high stride arguments,
because unwanted frames are just seeked over.

This feature relies on the byte offsets, which have to be provided
or explicitly computed by accessing the offsets property once.

If no bytes offset is available, the current behaviour is untouched.

Added tests.