### PR TITLE
[TRR] added efficient stride handling

### DIFF
--- a/tests/test_trr.py
+++ b/tests/test_trr.py
@@ -24,6 +24,7 @@ from mdtraj.formats import TRRTrajectoryFile
 import os, tempfile
 import numpy as np
 from mdtraj.testing import eq
+from mdtraj import io
 import pytest
 
 fd, temp = tempfile.mkstemp(suffix='.trr')
@@ -75,6 +76,59 @@ def test_read_stride_n_frames(get_fn):
     assert eq(step[::3], step3)
     assert eq(box[::3], box3)
     assert eq(time[::3], time3)
+
+
+def test_read_stride_offsets(get_fn):
+    # read xtc with stride and offsets
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        xyz, time, step, box, lambd = f.read()
+    for s in (1, 2, 3, 4, 5):
+        with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+            f.offsets # pre-compute byte offsets between frames
+            xyz_s, time_s, step_s, box_s, lamb_s = f.read(stride=s)
+        assert eq(xyz_s, xyz[::s])
+        assert eq(step_s, step[::s])
+        assert eq(box_s, box[::s])
+        assert eq(time_s, time[::s])
+
+
+def test_read_stride_n_frames_offsets(get_fn):
+    # read trr with stride with n_frames and offsets
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        xyz, time, step, box, lambd = f.read()
+    for s in (1, 2, 3, 4, 5):
+        with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+            f.offsets # pre-compute byte offsets between frames
+            xyz_s, time_s, step_s, box_s, lamb_s = f.read(n_frames=1000, stride=s)
+        assert eq(xyz_s, xyz[::s])
+        assert eq(step_s, step[::s])
+        assert eq(box_s, box[::s])
+        assert eq(time_s, time[::s])
+
+
+def test_read_stride_switching(get_fn):
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        xyz, time, step, box, lambd = f.read()
+    with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
+        f.offsets  # pre-compute byte offsets between frames
+        # read the first 10 frames with stride of 2
+        s = 2
+        n_frames = 10
+        xyz_s, time_s, step_s, box_s, lamb_s = f.read(n_frames=n_frames, stride=s)
+        assert eq(xyz_s, xyz[:n_frames*s:s])
+        assert eq(step_s, step[:n_frames*s:s])
+        assert eq(box_s, box[:n_frames*s:s])
+        assert eq(time_s, time[:n_frames*s:s])
+        # now read the rest with stride 3, should start from frame index 8.
+        # eg. np.arange(0, n_frames*s, 2)[-1] == 18
+        offset = f.tell()
+        assert offset == 18
+        s = 3
+        xyz_s, time_s, step_s, box_s, lamb_s = f.read(n_frames=None, stride=s)
+        assert eq(xyz_s, xyz[offset::s])
+        assert eq(step_s, step[offset::s])
+        assert eq(box_s, box[offset::s])
+        assert eq(time_s, time[offset::s])
 
 
 def test_write_read():

--- a/tests/test_xtc.py
+++ b/tests/test_xtc.py
@@ -104,15 +104,15 @@ def test_read_stride_switching(get_fn, fn_xtc):
         s = 2
         n_frames = 10
         xyz, time, step, box = f.read(n_frames=n_frames, stride=s)
-        assert eq(xyz, iofile['xyz'][:n_frames:s])
-        assert eq(step, iofile['step'][:n_frames:s])
-        assert eq(box, iofile['box'][:n_frames:s])
-        assert eq(time, iofile['time'][:n_frames:s])
+        assert eq(xyz, iofile['xyz'][:n_frames*s:s])
+        assert eq(step, iofile['step'][:n_frames*s:s])
+        assert eq(box, iofile['box'][:n_frames*s:s])
+        assert eq(time, iofile['time'][:n_frames*s:s])
         # now read the rest with stride 3, should start from frame index 8.
-        # eg. np.arange(0, 10, 2)[-1] == 8
-        s = 3
+        # eg. np.arange(0, n_frames*s, 2)[-1] == 18
         offset = f.tell()
-        assert offset == 8
+        assert offset == 18
+        s = 3
         xyz, time, step, box = f.read(n_frames=None, stride=s)
         assert eq(xyz, iofile['xyz'][offset::s])
         assert eq(step, iofile['step'][offset::s])


### PR DESCRIPTION
This also changes how many frames will be returned when using the stride. Eg. if one requests 100 frames with stride 2, one will also get 100 frames offset by 2 steps. This is at least what the docstring said, but was not true until this change.