### PR TITLE
Added support for prm7 topology file extension.

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -75,7 +75,7 @@ from mdtraj.geometry import _geometry
 __all__ = ['open', 'load', 'iterload', 'load_frame', 'load_topology', 'join',
            'Trajectory']
 # supported extensions for constructing topologies
-_TOPOLOGY_EXTS = ['.pdb', '.pdb.gz', '.h5','.lh5', '.prmtop', '.parm7',
+_TOPOLOGY_EXTS = ['.pdb', '.pdb.gz', '.h5','.lh5', '.prmtop', '.parm7', '.prm7',
                   '.psf', '.mol2', '.hoomdxml', '.gro', '.arc', '.hdf5']
 
 
@@ -141,7 +141,7 @@ def load_topology(filename, **kwargs):
     filename : str
         Path to a file containing a system topology. The following extensions
         are supported: '.pdb', '.pdb.gz', '.h5','.lh5', '.prmtop', '.parm7',
-            '.psf', '.mol2', '.hoomdxml'
+            '.prm7', '.psf', '.mol2', '.hoomdxml'
 
     Returns
     -------
@@ -168,7 +168,7 @@ def _parse_topology(top, **kwargs):
     if isinstance(top, string_types) and (ext in ['.pdb', '.pdb.gz', '.h5','.lh5']):
         _traj = load_frame(top, 0, **kwargs)
         topology = _traj.topology
-    elif isinstance(top, string_types) and (ext in ['.prmtop', '.parm7']):
+    elif isinstance(top, string_types) and (ext in ['.prmtop', '.parm7', '.prm7']):
         topology = load_prmtop(top, **kwargs)
     elif isinstance(top, string_types) and (ext in ['.psf']):
         topology = load_psf(top, **kwargs)


### PR DESCRIPTION
The .prm7 topology file extension appears to be widely used as an alternative to .parm7 within the AMBER community. I've added support for this.