### PR TITLE
Ensure correct dtype in neighborlist box vectors

### DIFF
--- a/mdtraj/geometry/neighborlist.pyx
+++ b/mdtraj/geometry/neighborlist.pyx
@@ -27,6 +27,7 @@
 
 from __future__ import print_function, division
 import numpy as np
+from mdtraj.utils import ensure_type
 
 from libcpp.vector cimport vector
 
@@ -73,7 +74,10 @@ def compute_neighborlist(traj, cutoff, frame=0, periodic=True):
     cdef float* box_matrix_pointer
     cdef int is_periodic = periodic and (traj.unitcell_vectors is not None)
     if is_periodic:
-        unitcell_vectors = ensure_type(traj.unitcell_vectors[frame], dtype=np.float32, ndim=3, name='unitcell_vectors', warn_on_cast=False)
+        unitcell_vectors = ensure_type(traj.unitcell_vectors[frame],
+                                       dtype=np.float32, ndim=2,
+                                       name='unitcell_vectors',
+                                       warn_on_cast=False)
         box_matrix = np.asarray(unitcell_vectors, order='c')
         box_matrix_pointer = &box_matrix[0,0]
     else:

--- a/mdtraj/geometry/neighborlist.pyx
+++ b/mdtraj/geometry/neighborlist.pyx
@@ -73,7 +73,8 @@ def compute_neighborlist(traj, cutoff, frame=0, periodic=True):
     cdef float* box_matrix_pointer
     cdef int is_periodic = periodic and (traj.unitcell_vectors is not None)
     if is_periodic:
-        box_matrix = np.asarray(traj.unitcell_vectors[frame], order='c')
+        unitcell_vectors = ensure_type(traj.unitcell_vectors[frame], dtype=np.float32, ndim=3, name='unitcell_vectors', warn_on_cast=False)
+        box_matrix = np.asarray(unitcell_vectors, order='c')
         box_matrix_pointer = &box_matrix[0,0]
     else:
         box_matrix_pointer = NULL


### PR DESCRIPTION
This is essentially the same as #1146, but that only changed `compute_neighbors`. This provides the same fix for `compute_neighborlist`.

(For search results) The error we'd been getting was:
```pytb
  File "mdtraj/geometry/neighborlist.pyx", line 76, in mdtraj.geometry.neighborlist.compute_neighborlist (mdtraj/geometry/neighborlist.cpp:1943)
ValueError: Buffer dtype mismatch, expected 'float' but got 'double'
```

CC: @Nicole-de-groot