### PR TITLE
Compile geometry extension with OpenMP.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,9 +214,12 @@ def rmsd_extensions():
 
 def geometry_extensions():
     compiler.initialize()
-    compiler_args = (compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
-                     compiler.compiler_args_opt + compiler.compiler_args_warn)
+    compiler_args = (
+        compiler.compiler_args_openmp +
+        compiler.compiler_args_sse2 + compiler.compiler_args_sse3 +
+        compiler.compiler_args_opt + compiler.compiler_args_warn)
     define_macros = None
+    compiler_libraries = compiler.compiler_libraries_openmp + extra_cpp_libraries
 
     return [
         Extension('mdtraj.geometry._geometry',
@@ -231,7 +234,7 @@ def geometry_extensions():
                      'mdtraj/geometry/src/kernels/distancekernels.h'],
             define_macros=define_macros,
             extra_compile_args=compiler_args,
-            libraries=extra_cpp_libraries,
+            libraries=compiler_libraries,
             language='c++'),
         Extension('mdtraj.geometry.drid',
             sources=["mdtraj/geometry/drid.pyx",
@@ -240,6 +243,7 @@ def geometry_extensions():
             include_dirs=["mdtraj/geometry/include"],
             define_macros=define_macros,
             extra_compile_args=compiler_args,
+            libraries=compiler_libraries,
             language='c++'),
         Extension('mdtraj.geometry.neighbors',
             sources=["mdtraj/geometry/neighbors.pyx",
@@ -247,14 +251,15 @@ def geometry_extensions():
             include_dirs=["mdtraj/geometry/include",],
             define_macros=define_macros,
             extra_compile_args=compiler_args,
+            libraries=compiler_libraries,
             language='c++'),
         Extension('mdtraj.geometry.neighborlist',
             sources=["mdtraj/geometry/neighborlist.pyx",
                      "mdtraj/geometry/src/neighborlist.cpp"],
             include_dirs=["mdtraj/geometry/include",],
             define_macros=define_macros,
-            extra_compile_args=compiler_args+compiler.compiler_args_openmp,
-            libraries=compiler.compiler_libraries_openmp,
+            extra_compile_args=compiler_args,
+            libraries=compiler_libraries,
             language='c++'),
         ]
 


### PR DESCRIPTION
Adding OpenMP compiler flags to the geometry extension, fixes #1335.

Should this also be done for `format_extensions`? If you grep many of the `.c` files built by cython, there is an `#ifdef _OPENMP`/`#endif` block, but I don't see where parallelism is actually used... maybe someone more familiar with that code could comment? (@Lnaden @mpharrigan @marscher)