### PR TITLE
[dcd] return last successful read frame

### DIFF
--- a/mdtraj/formats/dcd/dcdlib.pxd
+++ b/mdtraj/formats/dcd/dcdlib.pxd
@@ -1,6 +1,21 @@
+
 cdef extern from "include/dcdplugin.h":
     ctypedef struct dcdhandle:
-        pass
+      long fd
+      int natoms
+      int nsets
+      int setsread
+      int istart
+      int nsavc
+      double delta
+      int nfixed
+      float *x, *y, *z
+      int *freeind
+      float *fixedcoords
+      int reverse
+      int charmm
+      int first
+      int with_unitcell
 
     dcdhandle* open_dcd_read(char *path, char *filetype, int *natoms, int* nsets)
     int read_next_timestep(dcdhandle *v, int natoms, molfile_timestep_t *ts)


### PR DESCRIPTION
Because the stride seeking after reading the actual
frame did assign the same status variable used to truncate
the output, there were frames missing at the end of the trajectory.

Also used internal frame counter instead of doubling the book keeping.