### PR TITLE
[XTC|TRR] striding relative to current position + build_docs fix

### DIFF
--- a/devtools/travis-ci/build_docs.sh
+++ b/devtools/travis-ci/build_docs.sh
@@ -8,11 +8,11 @@ conda create --yes -n docenv python=$CONDA_PY
 source activate docenv
 conda install -yq --use-local mdtraj
 
-# We don't use conda for these
-pip install -I sphinx_rtd_theme==0.1.9 msmb_theme==1.2.0
-
 # Install doc requirements
 conda install -yq --file docs/requirements.txt
+
+# We don't use conda for these
+pip install -I msmb_theme==1.2.0
 
 # Make docs
 cd docs && make html && cd -

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
+sphinx_rtd_theme
 matplotlib
 jupyter
 jinja2

--- a/docs/sphinxext/notebook_sphinxext.py
+++ b/docs/sphinxext/notebook_sphinxext.py
@@ -9,9 +9,8 @@ from __future__ import print_function
 import os
 import shutil
 
-from sphinx.util.compat import Directive
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import directives, Directive
 import nbformat
 from nbconvert import HTMLExporter, PythonExporter
 

--- a/tests/test_trr.py
+++ b/tests/test_trr.py
@@ -100,7 +100,7 @@ def test_read_stride_n_frames_offsets(get_fn):
         with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
             f.offsets # pre-compute byte offsets between frames
             xyz_s, time_s, step_s, box_s, lamb_s = f.read(n_frames=1000, stride=s)
-        assert eq(xyz_s, xyz[::s])
+        assert eq(xyz_s, xyz[::s], err_msg='stride=%s' % s)
         assert eq(step_s, step[::s])
         assert eq(box_s, box[::s])
         assert eq(time_s, time[::s])
@@ -120,9 +120,9 @@ def test_read_stride_switching(get_fn):
         assert eq(box_s, box[:n_frames*s:s])
         assert eq(time_s, time[:n_frames*s:s])
         # now read the rest with stride 3, should start from frame index 8.
-        # eg. np.arange(0, n_frames*s, 2)[-1] == 18
+        # eg. np.arange(0, n_frames*s + 1, 2)[-1] == 18
         offset = f.tell()
-        assert offset == 18
+        assert offset == 20
         s = 3
         xyz_s, time_s, step_s, box_s, lamb_s = f.read(n_frames=None, stride=s)
         assert eq(xyz_s, xyz[offset::s])

--- a/tests/test_xtc.py
+++ b/tests/test_xtc.py
@@ -109,9 +109,9 @@ def test_read_stride_switching(get_fn, fn_xtc):
         assert eq(box, iofile['box'][:n_frames*s:s])
         assert eq(time, iofile['time'][:n_frames*s:s])
         # now read the rest with stride 3, should start from frame index 8.
-        # eg. np.arange(0, n_frames*s, 2)[-1] == 18
+        # eg. np.arange(0, n_frames*s + 1, 2)[-1] == 20
         offset = f.tell()
-        assert offset == 18
+        assert offset == 20
         s = 3
         xyz, time, step, box = f.read(n_frames=None, stride=s)
         assert eq(xyz, iofile['xyz'][offset::s])


### PR DESCRIPTION
My previous patch in #1331 and #1332 borked chunked operations with stride > 1, because the desired frames were being calculated from the last frame_counter. This leads to problems when reading with a chunksize. Luckily we have not released this yet.

Now the stride handling is performed either by dummy reads or efficiently by seeking over the skipped frames. This yields the same frame indices like numpy.arange(0, traj_len, stride).

I promise I am certain now about these changes, because we are wrapping up very detailed reader tests in PyEMMA and everything is working as expected with this patch. The existing mdtraj tests pass as well (locally).