### PR TITLE
Replace strip() with split() in `mol2.py`

### DIFF
--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -99,7 +99,7 @@ def load_mol2(filename):
     # If this is a sybyl mol2, there should be NAN (null) values
     if atoms_mdtraj.element.isnull().any():
         # If this is a sybyl mol2, I think this works generally.
-        atoms_mdtraj["element"] = atoms.atype.apply(lambda x: x.strip(".")[0])
+        atoms_mdtraj["element"] = atoms.atype.apply(lambda x: x.split(".")[0])
 
     atoms_mdtraj["resSeq"] = np.ones(len(atoms), 'int')
     atoms_mdtraj["chainID"] = np.ones(len(atoms), 'int')

--- a/tests/data/cl.mol2
+++ b/tests/data/cl.mol2
@@ -1,0 +1,9 @@
+@<TRIPOS>MOLECULE
+*****
+ 1 0 0 0 0
+SMALL
+GASTEIGER
+
+@<TRIPOS>ATOM
+      1 CL         -1.2092    0.7047    0.0000 Cl      1  UNL1        0.0000
+@<TRIPOS>BOND

--- a/tests/data/li.mol2
+++ b/tests/data/li.mol2
@@ -6,7 +6,7 @@ NO_CHARGES
 @<TRIPOS>CRYSIN
    10.0000    10.0000    10.0000    90.0000    90.0000    90.0000  1  1
 @<TRIPOS>ATOM
-       1 Li           0.0000     0.0000     0.0000 opls_404      1 RES     
+       1 Li           0.0000     0.0000     0.0000 Li      1 RES     
 @<TRIPOS>BOND
 @<TRIPOS>SUBSTRUCTURE
        1 RES             1 RESIDUE    0 **** ROOT      0

--- a/tests/test_mol2.py
+++ b/tests/test_mol2.py
@@ -140,3 +140,9 @@ def test_mol2_status_bits(get_fn):
 def test_mol2_without_bonds(get_fn):
     trj = md.load_mol2(get_fn('li.mol2'))
     assert trj.topology.n_bonds == 0
+
+
+def test_mol2_element_name(get_fn):
+    trj = md.load_mol2(get_fn('cl.mol2'))
+    top, bonds = trj.top.to_dataframe()
+    assert top.iloc[0]['element'] == 'Cl'


### PR DESCRIPTION
I attempted to load a mol2 file containing Ti atoms using MDTraj, I would get the error: `KeyError: 'T'`.  After doing some digging in `mol2.py`, I found that the reason for this is because of the following line: `atoms_mdtraj["element"] = atoms.atype.apply(lambda x: x.strip(".")[0])`.  Because strip() returns a string, this line returns the first letter of a two letter element symbol.

As a result, I think split() is a more appropriate method in this case since it returns a list.  For example, `'Ti'.split('.')` will return `['Ti', '']` and `'Ti'.split('.')[0]` will return `'Ti'` which is the desired result.

In addition to this change, I added a unit test to `test_mol2.py`.  By loading in `cl.mol2`, this test ensures that the correct element name is loaded in.