### PR TITLE
fix typo in docs

### DIFF
--- a/mdtraj/geometry/contact.py
+++ b/mdtraj/geometry/contact.py
@@ -96,7 +96,7 @@ def compute_contacts(traj, contacts='all', scheme='closest-heavy', ignore_nonpro
         to a residue without an alpha carbon (e.g. HOH) is ignored from the
         input contacts list, meanings that the indexing of the
         output `distances` may not match up with the indexing of the input
-        `contacts`. But the indexing of `distance` *will* match up with
+        `contacts`. But the indexing of `distances` *will* match up with
         the indexing of `residue_pairs`
 
     Examples


### PR DESCRIPTION
In the docs for `compute_contacts`, the first return value is referred to as `distances`, but then in the description of `residue_pairs`, the text refers to `distance`. If I understand correctly, this should actually be `distances`