### PR TITLE
Ensure 'bond_value' is a string

### DIFF
--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -119,7 +119,7 @@ def load_mol2(filename):
         n_bonds = bonds_mdtraj.shape[0]
         bond_augment = np.zeros([n_bonds, 2], dtype=float)
         # Add bond type information
-        bond_augment[:, 0] = [float(bond_type_map[bond_value]) for bond_value in bonds["bond_type"].values]
+        bond_augment[:, 0] = [float(bond_type_map[str(bond_value)]) for bond_value in bonds["bond_type"].values]
         # Add Bond "order" information, this is not known from Mol2 files
         bond_augment[:, 1] = [0.0 for _ in range(n_bonds)]
         # Augment array, dtype is cast to minimal representation of float

--- a/tests/test_mol2.py
+++ b/tests/test_mol2.py
@@ -143,7 +143,7 @@ def test_mol2_without_bonds(get_fn):
 
 
 @pytest.mark.parametrize('mol2_file', [('li.mol2'),
-('lysozyme-ligand-tripos.mol2'), ('imatinib.mol2'), ('status-bits.mol2'),
-('adp.mol2')])
+('lysozyme-ligand-tripos.mol2'), ('imatinib.mol2'),
+('status-bits.mol2'),('adp.mol2')])
 def test_load_all_mol2(mol2_file, get_fn):
     trj = md.load_mol2(get_fn(mol2_file))

--- a/tests/test_mol2.py
+++ b/tests/test_mol2.py
@@ -140,3 +140,10 @@ def test_mol2_status_bits(get_fn):
 def test_mol2_without_bonds(get_fn):
     trj = md.load_mol2(get_fn('li.mol2'))
     assert trj.topology.n_bonds == 0
+
+
+@pytest.mark.parametrize('mol2_file', [('li.mol2'),
+('lysozyme-ligand-tripos.mol2'), ('imatinib.mol2'), ('status-bits.mol2'),
+('adp.mol2')])
+def test_load_all_mol2(mol2_file, get_fn):
+    trj = md.load_mol2(get_fn(mol2_file))


### PR DESCRIPTION
In reference to #1379, `bond_value` is converted to a string which allows all mol2 files to be loaded in properly.

`test_load_all_mol2` unit test was added to ensure that every mol2 file in the `data` directory is properly loaded.  