### PR TITLE
silence cython related numpy warnings

### DIFF
--- a/mdtraj/__init__.py
+++ b/mdtraj/__init__.py
@@ -25,6 +25,7 @@
 trajectories in a variety of formats, including Gromacs XTC & TRR, CHARMM/NAMD
 DCD, AMBER BINPOS, PDB, and HDF5.
 """
+import numpy as _  # silence cython related numpy warnings, see github.com/numpy/numpy/pull/432
 
 from .formats.registry import FormatRegistry
 from .formats.xtc import load_xtc


### PR DESCRIPTION
by importing numpy before loading cython extensions,
because numpy inserts a proper warning filter

Fixes #1390 