### PR TITLE
Notebook tests: `from __future__` must come first

### DIFF
--- a/examples/principal-components.ipynb
+++ b/examples/principal-components.ipynb
@@ -15,8 +15,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import print_function\n",
+    "%matplotlib inline\n",
     "import mdtraj as md\n",
     "import matplotlib.pyplot as plt\n",
     "from sklearn.decomposition import PCA"

--- a/examples/ramachandran-plot.ipynb
+++ b/examples/ramachandran-plot.ipynb
@@ -8,8 +8,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import print_function\n",
+    "%matplotlib inline\n",
     "import mdtraj as md"
    ]
   },

--- a/examples/rmsd-drift.ipynb
+++ b/examples/rmsd-drift.ipynb
@@ -6,8 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import print_function\n",
+    "%matplotlib inline\n",
     "import mdtraj as md"
    ]
   },

--- a/examples/solvent-accessible-surface-area.ipynb
+++ b/examples/solvent-accessible-surface-area.ipynb
@@ -18,8 +18,8 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "from __future__ import print_function\n",
+    "%matplotlib inline\n",
     "import numpy as np\n",
     "import mdtraj as md"
    ]


### PR DESCRIPTION
A few tests are failing because recent versions of Jupyter strictly enfore the rule that `from __future__` imports must be the first line in a cell (see, for example, the Py-3.6 test [here](https://travis-ci.org/mdtraj/mdtraj/jobs/454545185#L3469)). These notebooks had cells like:

```python
%matplotlib inline
from __future__ import print_function
```

This PR just switches the order of those first two.