### PR TITLE
Add compute_center_of_geometry

### DIFF
--- a/mdtraj/geometry/__init__.py
+++ b/mdtraj/geometry/__init__.py
@@ -25,11 +25,13 @@ from __future__ import print_function, division
 __all__ = ['baker_hubbard', 'shrake_rupley', 'kabsch_sander', 'compute_distances',
            'compute_displacements', 'compute_angles', 'compute_dihedrals',
            'compute_phi', 'compute_psi', 'compute_chi1', 'compute_chi2',
-           'compute_chi3', 'compute_chi4','compute_chi5', 'compute_omega', 'compute_rg',
-           'compute_contacts', 'compute_drid', 'compute_center_of_mass',
-           'wernet_nilsson', 'compute_dssp', 'compute_neighbors', 'compute_neighborlist',
-           'compute_rdf', 'compute_nematic_order', 'compute_inertia_tensor',
-           'find_closest_contact', 'compute_directors',
+           'compute_chi3', 'compute_chi4','compute_chi5', 'compute_omega',
+           'compute_rg', 'compute_contacts', 'compute_drid',
+           'compute_center_of_mass', 'compute_center_of_geometry',
+           'wernet_nilsson', 'compute_dssp', 'compute_neighbors',
+           'compute_neighborlist', 'compute_rdf', 'compute_nematic_order',
+           'compute_inertia_tensor', 'find_closest_contact',
+           'compute_directors',
 
            # from thermodynamic_properties
            'dipole_moments', 'static_dielectric', 'isothermal_compressability_kappa_T',

--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -30,7 +30,8 @@ from . import _geometry
 
 
 __all__ = ['compute_distances', 'compute_displacements',
-           'compute_center_of_mass', 'find_closest_contact']
+           'compute_center_of_mass', 'compute_center_of_geometry',
+           'find_closest_contact']
 
 
 
@@ -130,6 +131,28 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
         _geometry._dist_displacement(xyz, pairs, out)
         return out
     return _displacement(xyz, pairs)
+
+
+def compute_center_of_geometry(traj):
+    """Compute the center of geometry for each frame.
+
+     Parameters
+    ----------
+    traj : Trajectory
+        Trajectory to compute center of geometry for
+
+     Returns
+    -------
+    com : np.ndarray, shape=(n_frames, 3)
+         Coordinates of the center of mass for each frame
+
+    """
+
+    centers = np.zeros((traj.n_frames, 3))
+
+    for i, x in enumerate(traj.xyz):
+        centers[i, :] = x.astype('float64').T.mean(axis=1) 
+    return centers
 
 
 def compute_center_of_mass(traj):

--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -133,28 +133,6 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
     return _displacement(xyz, pairs)
 
 
-def compute_center_of_geometry(traj):
-    """Compute the center of geometry for each frame.
-
-     Parameters
-    ----------
-    traj : Trajectory
-        Trajectory to compute center of geometry for
-
-     Returns
-    -------
-    com : np.ndarray, shape=(n_frames, 3)
-         Coordinates of the center of mass for each frame
-
-    """
-
-    centers = np.zeros((traj.n_frames, 3))
-
-    for i, x in enumerate(traj.xyz):
-        centers[i, :] = x.astype('float64').T.mean(axis=1) 
-    return centers
-
-
 def compute_center_of_mass(traj):
     """Compute the center of mass for each frame.
 
@@ -176,6 +154,28 @@ def compute_center_of_mass(traj):
     for i, x in enumerate(traj.xyz):
         com[i, :] = x.astype('float64').T.dot(masses)
     return com
+
+
+def compute_center_of_geometry(traj):
+    """Compute the center of geometry for each frame.
+
+    Parameters
+    ----------
+    traj : Trajectory
+        Trajectory to compute center of geometry for
+
+    Returns
+    -------
+    com : np.ndarray, shape=(n_frames, 3)
+         Coordinates of the center of geometry for each frame
+
+    """
+
+    centers = np.zeros((traj.n_frames, 3))
+
+    for i, x in enumerate(traj.xyz):
+        centers[i, :] = x.astype('float64').T.mean(axis=1) 
+    return centers
 
 
 def find_closest_contact(traj, group1, group2, frame=0, periodic=True):

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -98,7 +98,7 @@ def test_center_of_geometry():
     center_test = mdtraj.geometry.distance.compute_center_of_geometry(traj)
 
     center_actual = np.array([
-        [1 / 3, 1 / 3, 0.0],
+        [1.0 / 3, 1.0 / 3, 0.0],
         [1.5 / 3, 1.5 / 3, 0.0],
     ])
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -76,6 +76,35 @@ def test_center_of_mass():
     eq(com_actual, com_test, decimal=4)
 
 
+def test_center_of_geometry():
+    top = md.Topology()
+    chain = top.add_chain()
+    resi = top.add_residue("NA", chain)
+    top.add_atom('H1', md.element.hydrogen, resi)
+    top.add_atom('H2', md.element.hydrogen, resi)
+    top.add_atom('O', md.element.oxygen, resi)
+
+    xyz = np.array([
+        [
+            # Frame 1 - Right triangle
+            [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]
+        ],
+        [
+            # Frame 2
+            [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.5, 0.5, 0.0]
+        ]
+    ])
+    traj = md.Trajectory(xyz, top)
+    center_test = mdtraj.geometry.distance.compute_center_of_geometry(traj)
+
+    center_actual = np.array([
+        [1 / 3, 1 / 3, 0.0],
+        [1.5 / 3, 1.5 / 3, 0.0],
+    ])
+
+    eq(center_actual, center_test, decimal=4)
+
+
 def test_dihedral_indices(get_fn):
     traj = md.load(get_fn('1bpi.pdb'))
     # Manually compare generated indices to known answers.


### PR DESCRIPTION
Seems to be low-hanging fruit, sometimes we deal with non-element "sites," i.e. coarse-grained beads. In my case I happen to be using LAMMPS files for which reading masses is cumbersome and a center of geometry is good enough.