### PR TITLE
Fixes 'Buffer dtype mismatch' error on 64-bit Windows

### DIFF
--- a/mdtraj/geometry/src/image_molecules.pxi
+++ b/mdtraj/geometry/src/image_molecules.pxi
@@ -4,8 +4,7 @@
 import numpy as np
 cimport numpy as np
 from libcpp.vector cimport vector
-
-ctypedef np.npy_intp intp
+from libc.stdint cimport int32_t, int64_t
 
 cdef extern from "math_patch.h" nogil:
     float roundf(float x)
@@ -13,7 +12,7 @@ cdef extern from "math_patch.h" nogil:
 
 cdef void make_whole(float[:,::1] frame_positions,
                 float[:,::1] frame_unitcell_vectors,
-                intp[:,:] sorted_bonds) nogil:
+                int32_t[:,:] sorted_bonds) nogil:
     # Fix each molecule to ensure the periodic boundary conditions are not
     # splitting it into pieces.
     cdef int atom1, atom2, j, k


### PR DESCRIPTION
Trying to run `trajectory.make_molecules_whole()` on a medium-sized trajectory (101k atoms) on Windows 10 (64-bit) gives the following error:

```In [3]: t.make_molecules_whole()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-cf06762aa5a9> in <module>
----> 1 t.make_molecules_whole()

~\Miniconda3\envs\py36\lib\site-packages\mdtraj-1.9.3-py3.6-win-amd64.egg\mdtraj\core\trajectory.py in make_molecules_whole(self, inplace, sorted_bonds)
   1901         box = np.asarray(result.unitcell_vectors, order='c')
   1902         print(result.xyz.shape, box.shape, len(sorted_bonds), max(map(len, sorted_bonds)))
-> 1903         _geometry.whole_molecules(result.xyz, box, sorted_bonds)
   1904         if not inplace:
   1905             return result

mdtraj\geometry\src\image_molecules.pxi in mdtraj.geometry._geometry.whole_molecules()

ValueError: Buffer dtype mismatch, expected 'intp' but got 'long'
```

According to [this](https://github.com/akaszynski/pyansys/issues/14) issue posted on another project, this is because of how different OSes interpret `intp`. Changing the `intp` definition on the `sorted_bonds` array on the function definition fixes the problem. No other `.pyx` or `.pxi` uses intp, but several `.c` files do, so not sure this should be changed there too.