### PR TITLE
Use and set resSeq attribute in Topology.to_openmm() and from_openmm()

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -389,7 +389,10 @@ class Topology(object):
         for chain in value.chains():
             c = out.add_chain()
             for residue in chain.residues():
-                r = out.add_residue(residue.name, c, resSeq=residue.id)
+                try:
+                    r = out.add_residue(residue.name, c, resSeq=int(residue.id))
+                except ValueError:
+                    r = out.add_residue(residue.name, c)
                 for atom in residue.atoms():
                     if atom.element is None:
                         element = elem.virtual


### PR DESCRIPTION
This is a small change to `mdtraj.Topology` in order to preserve residue numbering during Topology conversions with `to_openmm()` and `from_openmm()`. 

`to_openmm()` is modified to pass along the `resSeq` info to be set as the `id` for Openmm Residues, and vice versa for `from_openmm()`. 

This is a follow-up to Issue #1422 