### PR TITLE
Avoid infinite recursion error in mol2 parser

### DIFF
--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -113,7 +113,7 @@ def load_mol2(filename):
                 from mdtraj.core.element import Element
                 Element.getBySymbol(x)
             except KeyError:
-                return to_element(x[0])
+                return x[0]
             return x
         atoms_mdtraj["element"] = atoms.atype.apply(to_element)
 


### PR DESCRIPTION
In #1407 an little function was added to try and more intelligently parse the various atomtypes that can be included in a mol2 file. However, it can hit an infinite loop if the string and its first element each do not constitute an element. Currently trying to parse a bad element, i.e. `'L'` will cause a recursion error from repeatedly calling itself and hitting the key error, whereas this change will cause it to simply fail out with a key error without hitting the recursion limit. This shouldn't affect any existing behavior since the other checks in the function already happened.

cc @marscher 