### PR TITLE
Reporters no longer override user request to write unit cell information

### DIFF
--- a/mdtraj/reporters/basereporter.py
+++ b/mdtraj/reporters/basereporter.py
@@ -173,9 +173,6 @@ class _BaseReporter(object):
                 dof -= 3
             self._dof = dof
 
-        if simulation.topology.getUnitCellDimensions() is None:
-            self._cell = False
-
     def describeNextReport(self, simulation):
         """Get information about the next report this object will generate.
 


### PR DESCRIPTION
Addresses #1429 : `Reporter` classes no longer override user request to write unit cell information if `Topology` is missing unit cell information.