### PR TITLE
updates setup/build requirements for pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ build.log
 
 # export of libtheolib
 /mdtraj/core/lib/*
+*~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['setuptools', 'wheel', 'cython>=0.28', 'numpy']

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+# core
+pip >= 19.1
+wheel
+twine

--- a/setup.py
+++ b/setup.py
@@ -19,27 +19,32 @@ sys.path.insert(0, '.')
 from basesetup import (write_version_py, build_ext,
                        StaticLibrary, CompilerDetection)
 
-try:
-    import numpy
-    import Cython
-    if Cython.__version__ < '0.28':
-        raise ImportError
-    from Cython.Build import cythonize
-except ImportError:
-    print('-'*80, file=sys.stderr)
-    print('''Error: building mdtraj requires numpy and cython>=0.19
+import numpy as np
+from Cython.Build import cythonize
 
-Try running the command ``pip install numpy cython`` or
-``conda install numpy cython``.
 
-or see http://docs.scipy.org/doc/numpy/user/install.html and
-http://cython.org/ for more information.
 
-If you're feeling lost, we recommend downloading the (free) Anaconda python
-distribution https://www.continuum.io/downloads, because it comes with
-these components included.''', file=sys.stderr)
-    print('-'*80, file=sys.stderr)
-    sys.exit(1)
+# try:
+#     import numpy
+#     import Cython
+#     if Cython.__version__ < '0.28':
+#         raise ImportError
+#     from Cython.Build import cythonize
+# except ImportError:
+#     print('-'*80, file=sys.stderr)
+#     print('''Error: building mdtraj requires numpy and cython>=0.19
+#
+# Try running the command ``pip install numpy cython`` or
+# ``conda install numpy cython``.
+#
+# or see http://docs.scipy.org/doc/numpy/user/install.html and
+# http://cython.org/ for more information.
+#
+# If you're feeling lost, we recommend downloading the (free) Anaconda python
+# distribution https://www.continuum.io/downloads, because it comes with
+# these components included.''', file=sys.stderr)
+#     print('-'*80, file=sys.stderr)
+#     sys.exit(1)
 
 
 try:
@@ -288,6 +293,15 @@ setup(name='mdtraj',
       # Also, install_requires is no better, especially with numpy.
       # See http://article.gmane.org/gmane.comp.python.distutils.devel/24218
       # install_requires=['numpy>=1.6'],
+
+      install_requires=[
+          'numpy',
+          'scipy',
+          'pandas',
+          'tables',
+      ],
+
+      include_dirs=[np.get_include()],
 
       package_data={'mdtraj.formats.pdb': ['data/*'], },
       zip_safe=False,


### PR DESCRIPTION
Previously the handling of build/setup requirements was foregone
because setuptools couldn't handle this correctly. This seems to now
be cleared up and the inclusion of PEP 517 and implementation in pip
allows for specification of build requirements in the pyproject.toml
file which is included.

I can report that this works for me. Let me know if there is something else you would want from me.

The motivation for this is that I have mdtraj as a dependency (optional albeit) for another project, and want it to be installable through pip and I had trouble with mdtraj raising the errors in the setup.py even though I was declaring it's dependencies for it in my project.