### PR TITLE
Add gyration tensor calculation

### DIFF
--- a/docs/analysis.rst
+++ b/docs/analysis.rst
@@ -42,6 +42,14 @@ Secondary Structure
     compute_dssp
 
 
+Shape Metrics
+-------------------
+.. autosummary::
+    :toctree: api/generated/
+
+    compute_gyration_tensor
+
+
 Surface Area, Radius of Gyration and Inertia
 --------------------------------------------
 .. autosummary::

--- a/mdtraj/geometry/__init__.py
+++ b/mdtraj/geometry/__init__.py
@@ -30,7 +30,7 @@ __all__ = ['baker_hubbard', 'shrake_rupley', 'kabsch_sander', 'compute_distances
            'compute_center_of_mass', 'compute_center_of_geometry',
            'wernet_nilsson', 'compute_dssp', 'compute_neighbors',
            'compute_neighborlist', 'compute_rdf', 'compute_nematic_order',
-           'compute_inertia_tensor', 'find_closest_contact',
+           'compute_inertia_tensor', 'compute_gyration_tensor', 'find_closest_contact',
            'compute_directors',
 
            # from thermodynamic_properties

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -361,3 +361,25 @@ def _compute_inertia_tensor_slow(traj):
         I_ab[n, 2, 0] = I_ab[n, 0, 2]
         I_ab[n, 2, 1] = I_ab[n, 1, 2]
     return I_ab
+
+def _compute_gyration_tensor_slow(traj):
+    """Compute the gyration tensor of a trajectory. """
+    xyz = traj.xyz
+    center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
+    centered_xyz = xyz - center_of_geom
+
+    S_nm = np.zeros(shape=(traj.n_frames, 3, 3), dtype=np.float64)
+    for n, xyz in enumerate(centered_xyz):
+        N = xyz.shape[0]
+        for r in xyz:
+            S_nm[n, 0, 0] += r[0] * r[0]
+            S_nm[n, 1, 1] += r[1] * r[1]
+            S_nm[n, 2, 2] += r[2] * r[2]
+            S_nm[n, 0, 1] += r[0] * r[1]
+            S_nm[n, 0, 2] += r[0] * r[2]
+            S_nm[n, 1, 2] += r[1] * r[2]
+        S_nm[n, 1, 0] = S_nm[n, 0, 1]
+        S_nm[n, 2, 0] = S_nm[n, 0, 2]
+        S_nm[n, 2, 1] = S_nm[n, 1, 2]
+        S_nm[n, :, :] /= N
+    return S_nm

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -206,7 +206,7 @@ def compute_gyration_tensor(traj):
         Gyration tensors for each frame.
 
     """
-    xyz = trj.xyz
+    xyz = traj.xyz
     center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
     xyz -= center_of_geom
 

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -189,6 +189,31 @@ def compute_inertia_tensor(traj):
     return A * eyes - B
 
 
+def compute_gyration_tensor(traj):
+    """Compute the gyration tensor of a trajectory.
+
+    For each frame,
+        S_{nm} = sum_{i_atoms} r^{i}_m r^{i}_n
+
+    Parameters
+    ----------
+    traj : Trajectory
+        Trajectory to compute gyration tensor of.
+
+    Returns
+    -------
+    S_xy:  np.ndarray, shape=(traj.n_frames, 3, 3), dtype=float64
+        Gyration tensors for each frame.
+
+    """
+    xyz = trj.xyz
+    center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
+    xyz -= center_of_geom
+
+    return np.array([snap.T.dot(snap)/snap.shape[0] for snap in xyz])
+
+    
+
 def _get_indices(traj, indices):
     if isinstance(indices, string_types):
         if indices.lower() == 'chains':

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -209,8 +209,7 @@ def compute_gyration_tensor(traj):
     xyz = traj.xyz
     center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
     xyz -= center_of_geom
-
-    return np.array([snap.T.dot(snap)/snap.shape[0] for snap in xyz])
+    return np.einsum('...ji,...jk->...ik', xyz, xyz)
 
     
 

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -32,7 +32,7 @@ from mdtraj.utils import ensure_type
 from mdtraj.utils.six import string_types
 
 
-__all__ = ['compute_nematic_order', 'compute_inertia_tensor', 'compute_directors']
+__all__ = ['compute_nematic_order', 'compute_inertia_tensor', 'compute_directors', 'compute_gyration_tensor']
 
 
 def compute_nematic_order(traj, indices='chains'):
@@ -209,7 +209,7 @@ def compute_gyration_tensor(traj):
     xyz = traj.xyz
     center_of_geom = np.expand_dims(compute_center_of_geometry(traj), axis=1)
     xyz -= center_of_geom
-    return np.einsum('...ji,...jk->...ik', xyz, xyz)
+    return np.einsum('...ji,...jk->...ik', xyz, xyz) / traj.n_atoms
 
     
 
@@ -364,7 +364,7 @@ def _compute_inertia_tensor_slow(traj):
 def _compute_gyration_tensor_slow(traj):
     """Compute the gyration tensor of a trajectory. """
     xyz = traj.xyz
-    center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
+    center_of_geom = np.expand_dims(compute_center_of_geometry(traj), axis=1)
     centered_xyz = xyz - center_of_geom
 
     S_nm = np.zeros(shape=(traj.n_frames, 3, 3), dtype=np.float64)

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -193,7 +193,10 @@ def compute_gyration_tensor(traj):
     """Compute the gyration tensor of a trajectory.
 
     For each frame,
-        S_{nm} = sum_{i_atoms} r^{i}_m r^{i}_n
+
+    .. math::
+
+        S_{xy} = sum_{i_atoms} r^{i}_x r^{i}_y
 
     Parameters
     ----------
@@ -204,11 +207,14 @@ def compute_gyration_tensor(traj):
     -------
     S_xy:  np.ndarray, shape=(traj.n_frames, 3, 3), dtype=float64
         Gyration tensors for each frame.
+    
+    References
+    ----------
+    .. [1] https://isg.nist.gov/deepzoomweb/measurement3Ddata_help#shape-metrics-formulas
 
     """
-    xyz = traj.xyz
     center_of_geom = np.expand_dims(compute_center_of_geometry(traj), axis=1)
-    xyz -= center_of_geom
+    xyz = traj.xyz - center_of_geom
     return np.einsum('...ji,...jk->...ik', xyz, xyz) / traj.n_atoms
 
     

--- a/mdtraj/geometry/order.py
+++ b/mdtraj/geometry/order.py
@@ -27,7 +27,7 @@ from pkg_resources import parse_version
 import numpy as np
 NP18 = parse_version(np.__version__) >= parse_version('1.8.0')
 
-from mdtraj.geometry.distance import compute_center_of_mass
+from mdtraj.geometry.distance import compute_center_of_mass, compute_center_of_geometry
 from mdtraj.utils import ensure_type
 from mdtraj.utils.six import string_types
 
@@ -207,7 +207,7 @@ def compute_gyration_tensor(traj):
 
     """
     xyz = traj.xyz
-    center_of_geom = np.expand_dims(xyz.mean(axis=0), axis=1)
+    center_of_geom = np.expand_dims(compute_center_of_geometry(traj), axis=1)
     xyz -= center_of_geom
     return np.einsum('...ji,...jk->...ik', xyz, xyz)
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -103,6 +103,13 @@ def test_inertia(traj1, traj2, traj3):
     assert eq(order.compute_inertia_tensor(traj3),
               order._compute_inertia_tensor_slow(traj3))
 
+def test_gyration(traj1, traj2, traj3):
+    assert eq(order.compute_gyration_tensor(traj1),
+              order._compute_gyration_tensor_slow(traj1))
+    assert eq(order.compute_gyration_tensor(traj2),
+              order._compute_gyration_tensor_slow(traj2))
+    assert eq(order.compute_gyration_tensor(traj3),
+              order._compute_gyration_tensor_slow(traj3))
 
 def test_nematic_order_args(traj2):
     with pytest.raises(ValueError):


### PR DESCRIPTION
Easy access to the gyration tensor has a number of useful properties related to [calculating a number of shape metrics of a system](https://isg.nist.gov/deepzoomweb/measurement3Ddata_help). With access to the gyration tensor calculation of the principal moments, axis, asphericity, acylindricity, and relative shape anisotropy can all be computed relatively easily.

This pull request adds `compute_gyration_tensor` to geometry/order.py with associated unit tests in `test_order.py` in much of the same style as `compute_inertial_tensor` is currently implemented. Calculations of the shape descriptions listed above can also be implemented, if you would like.

1. [x] Added `compute_gyration_tensor` and `_compute_gyration_tensor_slow` to `geometry/order.py`
2. [x] Added unit test to `test_order.py`
