### PR TITLE
Fix pip install?

### DIFF
--- a/mdtraj/rmsd/src/center.c
+++ b/mdtraj/rmsd/src/center.c
@@ -19,7 +19,7 @@ void inplace_center_and_trace_atom_major(float* coords, float* traces, const int
     __m128 x, y, z, x2, y2, z2;
 
     #ifdef _OPENMP
-    #pragma omp parallel for default(none) shared(coords, traces, n_frames, n_atoms) \
+    #pragma omp parallel for shared(coords, traces) \
         private(sx_, sy_, sz_, trace_, mux_, muy_, muz_, sxf, syf, szf, \
         confp, i, x, y, z, x2, y2, z2, sx, sy, sz, trace)
     #endif


### PR DESCRIPTION
hopefully closes #1475.

Following [this guide](https://www.gnu.org/software/gcc/gcc-9/porting_to.html), it has an example for `OpenMP data sharing`:
```c
      int get (void);
      void use (int);
      void foo (void) {
        const int a = get ();
        const int b = 1;
        #pragma omp parallel for default(none)
        for (int i = 0; i < a; i += b)
          ;
        // The above used to compile with GCC 8 and older, but will
        // not anymore with GCC 9.  firstprivate(a, b) clause needs
        // to be added for C, for C++ it could be just firstprivate(a)
        // to make it compatible with all GCC releases.
      }
      const int huge_array[1024] = { ... };
      void bar (void) {
        #pragma omp parallel for default(none)
        for (int i = 0; i < 1024; i++)
          use (huge_array[i]);
        // Similarly, this used to compile with GCC 8 and older and
        // will not anymore.  Adding firstprivate(huge_array) is
        // probably undesirable here, so, either
        // default(none) shared(huge_array) should be used and it will
        // only support GCC 9 and later, or default(none) should be
        // removed and then it will be compatible with all GCC releases
        // and huge_array will be shared.
      }
```
I am not familiar enough with C to recognize if situation 1 or 2 is a more suitable to use here, so I implemented the second one, @rmcgibbo would that be the correct one?

Also, @lfkrapp could you test if this also still compiles for gcc 9.1?
