### PR TITLE
Fix `read_trr_natoms` leaving malformed file open

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -53,6 +53,7 @@ test:
     - pytest-ignore-flaky =1
     - pandas
     - pytables
+    - psutil
 
   source_files:
     - examples/*

--- a/mdtraj/formats/xtc/src/xdrfile_trr.c
+++ b/mdtraj/formats/xtc/src/xdrfile_trr.c
@@ -480,8 +480,10 @@ int read_trr_natoms(char *fn,int *natoms)
 	xd = xdrfile_open(fn,"r");
 	if (NULL == xd)
 		return exdrFILENOTFOUND;
-	if ((result = do_trnheader(xd,1,&sh)) != exdrOK)
+	if ((result = do_trnheader(xd,1,&sh)) != exdrOK) {
+                xdrfile_close(xd);
 		return result;
+        }
 	xdrfile_close(xd);
 	*natoms = sh.natoms;
 	
@@ -504,16 +506,16 @@ int read_trr_nframes(char *fn, unsigned long *nframes) {
     if (NULL == xd)
         return exdrFILENOTFOUND;
 
-	do {
-		result = read_trr(xd, natoms, &step, &time, &lambda,
-						  box, x, NULL, NULL);
-		if (exdrENDOFFILE != result) {
-			(*nframes)++;
-		}
-	} while (result == exdrOK);
+    do {
+            result = read_trr(xd, natoms, &step, &time, &lambda,
+                                              box, x, NULL, NULL);
+            if (exdrENDOFFILE != result) {
+                    (*nframes)++;
+            }
+    } while (result == exdrOK);
 
-	xdrfile_close(xd);
-	free(x);
+    xdrfile_close(xd);
+    free(x);
     return exdrOK;
 }
 

--- a/tests/test_trr.py
+++ b/tests/test_trr.py
@@ -219,16 +219,17 @@ def test_ragged_2():
             f.write(xyz)
 
 
-def test_malformed_trr():
+def test_malformed():
     with open(temp, 'w') as tmpf:
-        tmpf.write("foo")  # verty badly malformed TRR
+        tmpf.write("foo")  # very badly malformed TRR
 
-    with pytest.raises(OSError):
+    with pytest.raises(IOError):
         TRRTrajectoryFile(temp)
 
     psutil = pytest.importorskip("psutil")
     open_files = psutil.Process().open_files()
-    assert open_files == []
+    paths = [os.path.realpath(f.path) for f in open_files]
+    assert os.path.realpath(temp) not in paths
 
 
 def test_tell(get_fn):

--- a/tests/test_trr.py
+++ b/tests/test_trr.py
@@ -219,6 +219,18 @@ def test_ragged_2():
             f.write(xyz)
 
 
+def test_malformed_trr():
+    with open(temp, 'w') as tmpf:
+        tmpf.write("foo")  # verty badly malformed TRR
+
+    with pytest.raises(OSError):
+        TRRTrajectoryFile(temp)
+
+    psutil = pytest.importorskip("psutil")
+    open_files = psutil.Process().open_files()
+    assert open_files == []
+
+
 def test_tell(get_fn):
     with TRRTrajectoryFile(get_fn('frame0.trr')) as f:
         eq(f.tell(), 0)


### PR DESCRIPTION
Fixes #1481 (at least, once it is done I hope it will).

I'll also check a few other file formats (at least XTC) to see if this repeats elsewhere before calling it ready.

@rmcgibbo : For the moment, I added `psutil` to the testing requirements in the conda recipe (test requires it), but also allowed it to skip with a `pytest.importerskip` if `psutil` isn't available. Other options would be to not include `psutil` in the test reqs and skip it, or to not allow it to be skipped. Let me know if you'd prefer a different approach.