### PR TITLE
Thread parallelism for DRID

### DIFF
--- a/mdtraj/geometry/drid.pyx
+++ b/mdtraj/geometry/drid.pyx
@@ -28,7 +28,9 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 from mdtraj.utils import ensure_type
+
 cimport cython
+from cython.parallel import prange
 
 __all__ = ['compute_drid']
 
@@ -122,7 +124,7 @@ cdef _drid(float[:, :, ::1] xyz, int32_t[::1] atom_indices,
     assert n_dims == 3
 
     for i in range(n_frames):
-        for j in range(n_atom_indices):
+        for j in prange(n_atom_indices, nogil=True):
             drid_moments(&xyz[i, 0, 0], atom_indices[j], &partners[j,0],
                          n_partners[j], &result[i, j, 0])
 


### PR DESCRIPTION
As written, DRID calculations were not thread parallelized. Most of the work had already been done to do this, however, since each atom's DRID can be calculated in parallel, and dispatch to the `drid_moments` function is independent by atom.

This PR just adds openmp parallelization of the inner loop of the DRID calculation.