### PR TITLE
Minor addition: create standard bonds

### DIFF
--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -322,7 +322,7 @@ class GroTrajectoryFile(object):
 
                 topology.add_atom(thisatomname, element=element, residue=residue,
                                   serial=thisatomnum)
-
+        topology.create_standard_bonds()
         return n_atoms, topology
 
     def _read_frame(self):


### PR DESCRIPTION
Not sure if this will work as intended, but I added one line to automatically create the standard bonds list. This is necessary for other commands such as the hydrogen bonding wernet_nilsson() or baker_hubbard() functions. Without this change, an empty list would be returned upon using those functions.