### PR TITLE
ValueError Addition : Check topology.bonds > 0

### DIFF
--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -353,6 +353,16 @@ def _get_bond_triplets(topology, exclude_water=True, sidechain_only=False):
 
         return indices
 
+    # Check that there are bonds in topology
+    nbonds = 0
+    for _bond in topology.bonds:
+        nbonds += 1
+        break # Only need to find one hit for this check (not robust)
+    if nbonds == 0:
+        raise ValueError('No bonds found in topology. Try using '
+                         'traj._topology.create_standard_bonds() to create bonds '
+                         'using our PDB standard bond definitions.')
+        
     nh_donors = get_donors('N', 'H')
     oh_donors = get_donors('O', 'H')
     xh_donors = np.array(nh_donors + oh_donors)


### PR DESCRIPTION
Check that topology.bonds has a length greater than zero in the "_get_bond_triplets" function; otherwise, raise an error. Having a topology.bonds list is necessary to run the  hydrogen bond commands: baker_hubbard and wernet_nilsson; however, no explicit error message is given and an empty list is returned after running the aforementioned functions. This added check isn't robust as it only checks to see if there is at least one bond in topology.bonds, ... but it gets the job done!