### PR TITLE
let compute_displacements handle empty atom_pairs

### DIFF
--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -113,6 +113,8 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
     pairs = ensure_type(np.asarray(atom_pairs), dtype=np.int32, ndim=2, name='atom_pairs', shape=(None, 2), warn_on_cast=False)
     if not np.all(np.logical_and(pairs < traj.n_atoms, pairs >= 0)):
         raise ValueError('atom_pairs must be between 0 and %d' % traj.n_atoms)
+    if len(pairs) == 0:  # If pairs is an empty slice of an array
+        return np.zeros((len(xyz), 0, 3), dtype=np.float32)
 
     if periodic and traj._have_unitcell:
         box = ensure_type(traj.unitcell_vectors, dtype=np.float32, ndim=3, name='unitcell_vectors', shape=(len(xyz), 3, 3),
@@ -174,7 +176,7 @@ def compute_center_of_geometry(traj):
     centers = np.zeros((traj.n_frames, 3))
 
     for i, x in enumerate(traj.xyz):
-        centers[i, :] = x.astype('float64').T.mean(axis=1) 
+        centers[i, :] = x.astype('float64').T.mean(axis=1)
     return centers
 
 


### PR DESCRIPTION
This makes `mdtraj.compute_displacements` behave similar to  `compute_distances` when provided with an empty slice as `atom_pairs` (returning an empty slice as well)
current code returns a crytpic error:
```python
>>> import mdtraj as md
>>> import numpy as np
>>> traj = md.load('test.xtc', top='test.pdb')
>>> c = np.array([[3000, -1]])
>>> d = c[0:0]
>>> d
array([], shape=(0, 2), dtype=int64)
>>> md.compute_distances(traj, d) # Expected behaviour
array([], shape=(101, 0), dtype=float32)
>>> md.compute_displacements(traj, d)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/sroet/miniconda3/envs/dask-traj/lib/python3.7/site-packages/mdtraj/geometry/distance.py", line 123, in compute_displacements
    _geometry._dist_mic_displacement(xyz, pairs, box.transpose(0, 2, 1).copy(), out, orthogonal)
  File "mdtraj/geometry/src/_geometry.pyx", line 120, in mdtraj.geometry._geometry._dist_mic_displacement
ValueError: Buffer and memoryview are not contiguous in the same dimension.
```
This PR, makes it:
```python
>>> md.compute_displacements(traj, d)
array([], shape=(101, 0, 3), dtype=float32)
```