### PR TITLE
Possible fix for #1458

### DIFF
--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -403,7 +403,7 @@ cdef class XTCTrajectoryFile(object):
         while status == _EXDROK:
             # guess the size of the chunk to read, based on how many frames we
             # think are in the file and how many we've currently read
-            chunk = max(abs(int((self.approx_n_frames - self.frame_counter) * self.chunk_size_multiplier)),
+            chunk = max(abs(int((self.approx_n_frames - self.frame_counter) * self.chunk_size_multiplier / stride)),
                         self.min_chunk_size)
             xyz, time, step, box, status = self._read(chunk, atom_indices, stride)
 


### PR DESCRIPTION
When n_frames is guessed from the xtc file size, we should take into account the stride when estimating how many frames we're going to read (used to malloc buffer sizes).

@danijoo, could you see if this fixes your test case?