### PR TITLE
Update azure-pipelines-linux to python 3.8

### DIFF
--- a/devtools/azure-pipelines-linux.yml
+++ b/devtools/azure-pipelines-linux.yml
@@ -34,3 +34,4 @@ jobs:
   - bash: conda build devtools/conda-recipe
     displayName: 'Build and test'
     continueOnError: false
+

--- a/devtools/azure-pipelines-linux.yml
+++ b/devtools/azure-pipelines-linux.yml
@@ -8,10 +8,10 @@ jobs:
     matrix:
       Python36:
         CONDA_PY: '3.7'
-        CONDA_NPY: '1.17'
-      Python37:
+        CONDA_NPY: '1.14'
+      Python38:
         CONDA_PY: '3.8'
-        CONDA_NPY: '1.18'
+        CONDA_NPY: '1.17'
     maxParallel: 10
 
   steps:

--- a/devtools/azure-pipelines-linux.yml
+++ b/devtools/azure-pipelines-linux.yml
@@ -7,11 +7,11 @@ jobs:
   strategy:
     matrix:
       Python36:
-        CONDA_PY: '3.6'
-        CONDA_NPY: '1.11'
-      Python37:
         CONDA_PY: '3.7'
         CONDA_NPY: '1.17'
+      Python37:
+        CONDA_PY: '3.8'
+        CONDA_NPY: '1.18'
     maxParallel: 10
 
   steps:

--- a/devtools/azure-pipelines-linux.yml
+++ b/devtools/azure-pipelines-linux.yml
@@ -6,7 +6,7 @@ jobs:
 
   strategy:
     matrix:
-      Python36:
+      Python37:
         CONDA_PY: '3.7'
         CONDA_NPY: '1.14'
       Python38:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - cython
     - numpy
     - zlib
-    - msinttypes  # [win and py27]
     - pip >=19
 
   run:
@@ -39,7 +38,6 @@ test:
     - pytest
     - networkx
     - matplotlib
-    - openmm >=7.1  # [not (win32 or (win and py2k) or py37)]
     - shiftx2  # [linux and py2k]
     # 1. do not install cpptraj on osx, because the current version from omnia is linked against an old runtime.
     #    and not avail on win


### PR DESCRIPTION
We generally support the 2 most recently released minor versions of python, so this drops testing of 3.6 and adds 3.8. If it works I'll expand the PR to the other OSes.