### PR TITLE
Add posonlyargs argument for Python 3.8 compatibility

### DIFF
--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -392,8 +392,8 @@ class parse_selection(object):
         else:
             args = [ast.arg(arg='atom', annotation=None)]
             signature = ast.arguments(args=args, vararg=None, kwarg=None,
-                                      kwonlyargs=[], defaults=[],
-                                      kw_defaults=[])
+                                      posonlyargs=[], kwonlyargs=[],
+                                      defaults=[], kw_defaults=[])
 
         func = ast.Expression(body=ast.Lambda(signature, astnode))
         source = code_gen.to_source(astnode, pretty_source=lambda src: ''.join(src[:-1]))

--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -59,7 +59,7 @@ class _RewriteNames(ast.NodeTransformer):
         _safe_names = {'None': None, 'True': True, 'False': False}
         if node.id in _safe_names:
             if sys.version_info >= (3, 4):
-                return ast.NameConstant(value=_safe_names[node.id])
+                return ast.NameConstant(value=_safe_names[node.id], kind=None)
             return node
 
         # all other bare names are taken to be string literals. Thus something


### PR DESCRIPTION
Just seeing if the proposal in https://github.com/mdtraj/mdtraj/issues/1509 passes CI. This passes locally this locally in a 3.7 environment, which is encouraging.