### PR TITLE
TRRTrajectoryFile offset fix (mdtraj#1533)

### DIFF
--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -758,8 +758,8 @@ cdef class TRRTrajectoryFile(object):
 
     def _calc_len_and_offsets(self):
         """read byte offsets from TRR file directly"""
-        cdef int status, i, frame_size, frame_offset, header_size
-        cdef int64_t file_size
+        cdef int status, i, frame_size, header_size
+        cdef int64_t file_size, frame_offset
         cdef unsigned long n_frames
         cdef np.ndarray[ndim=1, dtype=np.npy_int64] offsets
         cdef trrlib.t_trnheader header


### PR DESCRIPTION

Fixed declaration of frame_offset that lead to offsets wrap at 2.1E9 when loading large trajectories