### PR TITLE
Attempt to fix windows CI

### DIFF
--- a/devtools/azure-pipelines-win.yml
+++ b/devtools/azure-pipelines-win.yml
@@ -9,14 +9,16 @@ jobs:
         CONDA_PY: '3.7'
         
   steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  - powershell: |
+      Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+      Write-Host "##vso[task.prependpath]$env:CONDA\Library\bin"
     displayName: Add conda to PATH
   - script: |
       ECHO ON
-      set PYTHONUNBUFFERED=1
+      set PYTHONUNBUFFERED=1      
       conda.exe config --add channels omnia
       conda.exe config --add channels conda-forge
-      conda.exe install -yq conda=4.4 conda-build=3.17.8 ripgrep=11.0.2
+      conda.exe install -yq conda=4.6.14 conda-build=3.19.2 ripgrep=11.0.2
     displayName: 'Install dependencies'
     continueOnError: false
   - script: |      


### PR DESCRIPTION
Windows CI is currently failing with

```
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... failed
ERROR conda.core.link:_execute(568): An error occurred while installing package 'conda-forge::pkginfo-1.5.0.1-py_0'.
CondaError: Cannot link a source that does not exist. C:\Miniconda\Scripts\conda.exe
Running `conda clean --packages` may resolve your problem.
Attempting to roll back.

Rolling back transaction: ...working... done

CondaError: Cannot link a source that does not exist. C:\Miniconda\Scripts\conda.exe
Running `conda clean --packages` may resolve your problem.
```
(https://dev.azure.com/rmcgibbo/mdtraj/_build/results?buildId=196&view=logs&j=c3584bed-92ea-506a-4dd3-f90b4f6e31cb&t=2138432d-6752-57c8-2564-add6273e64bf)