### PR TITLE
fix collections.abc deprecation warnings

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -29,7 +29,7 @@ from __future__ import print_function, division
 import os
 import warnings
 from copy import deepcopy
-from collections import Iterable
+from collections.abc import Iterable
 import numpy as np
 import functools
 
@@ -1667,9 +1667,9 @@ class Trajectory(object):
         """
         if os.path.exists(filename) and not force_overwrite:
             raise IOError('"%s" already exists' % filename)
-        
+
         self._check_valid_unitcell()
-        write_gsd(filename, self.xyz, self.topology, 
+        write_gsd(filename, self.xyz, self.topology,
                 cell_lengths=self.unitcell_lengths,
                 cell_angles=self.unitcell_angles)
 

--- a/mdtraj/utils/validation.py
+++ b/mdtraj/utils/validation.py
@@ -94,9 +94,9 @@ def ensure_type(val, dtype, ndim, name, length=None, can_be_none=False, shape=No
         return None
 
     if not isinstance(val, np.ndarray):
-        if isinstance(val, collections.Iterable):
+        if isinstance(val, collections.abc.Iterable):
             # If they give us an iterator, let's try...
-            if isinstance(val, collections.Sequence):
+            if isinstance(val, collections.abc.Sequence):
                 # sequences are easy. these are like lists and stuff
                 val = np.array(val, dtype=dtype)
             else:
@@ -170,7 +170,7 @@ def cast_indices(indices):
 
     if not len(indices) == len(set(indices)):
         raise ValueError("indices must be unique.")
-        
+
     out = np.asarray(indices)
     if not issubclass(out.dtype.type, np.integer):
         raise ValueError('indices must be of an integer type. %s is not an integer type' % out.dtype)


### PR DESCRIPTION
I am getting some `DeprecationWarning`s in some package that I manage, that bubble up from mdtraj.
Like:
```
~/miniconda3/envs/test/lib/python3.8/site-packages/mdtraj/core/trajectory.py:32: 

DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable
```

Apparently the [Abstract Base Classes](https://docs.python.org/3.8/library/collections.abc.html#collections-abstract-base-classes) have been moved to `collections.abc` since python `3.3`. mdtraj uses the ABCs `Iterable` and `Sequence`.

This PR fixes that deprecation warning.