### PR TITLE
rsmd atom_indices checks fix

### DIFF
--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -134,8 +134,7 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
     else:
         atom_indices = ensure_type(np.asarray(atom_indices), dtype=np.int, ndim=1, name='atom_indices')
         if not np.all((atom_indices >= 0) *
-                              (atom_indices < target.xyz.shape[1]) *
-                              (atom_indices < reference.xyz.shape[1])):
+                              (atom_indices < target.xyz.shape[1])):
             raise ValueError("atom_indices must be valid positive indices")
 
     if ref_atom_indices is None:
@@ -148,7 +147,6 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
     if not isinstance(ref_atom_indices, slice):
         ref_atom_indices = ensure_type(np.asarray(ref_atom_indices), dtype=np.int, ndim=1, name='ref_atom_indices')
         if not np.all((ref_atom_indices >= 0) *
-                              (ref_atom_indices < target.xyz.shape[1]) *
                               (ref_atom_indices < reference.xyz.shape[1])):
             raise ValueError("ref_atom_indices must be valid positive indices")
 

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -217,3 +217,29 @@ def test_trajectory_rmsf_aligned(get_fn):
         reference = np.sqrt(3*np.mean((t.xyz - avg_xyz)**2, axis=(0, 2)))[rmsf_indices]
         assert np.sum(np.abs(calculated)) > 0 # check trivial error
         eq(calculated, reference, decimal=3)
+
+def test_rmsd_atom_indices_vs_ref_indices():
+    n_frames = 1
+    n_atoms_1 = 1
+    n_atoms_2 = 2
+
+    top_1 = md.Topology()
+    top_1.add_chain()
+    top_1.add_residue('RS2', top_1.chain(0))
+    top_1.add_atom('A2', 'H', top_1.residue(0))
+
+    top_2 = md.Topology()
+    top_2.add_chain()
+    top_2.add_residue('RS1', top_2.chain(0))
+    top_2.add_atom('A1', 'H', top_2.residue(0))
+    top_2.add_chain()
+    top_2.add_residue('RS2', top_2.chain(1))
+    top_2.add_atom('A2', 'H', top_2.residue(1))
+    # here the 2nd chain in the top_2 is rmsd-compatible to the one in the top_1 so we should be able to compute rsmd between them.
+
+    trj_1 = md.Trajectory(np.random.RandomState(0).randn(n_frames, n_atoms_1, 3), top_1)
+    trj_2 = md.Trajectory(np.random.RandomState(0).randn(n_frames, n_atoms_2, 3), top_2)
+
+    md.rmsd(trj_1, trj_2, atom_indices=[0], ref_atom_indices=[1])
+    md.rmsd(trj_2, trj_1, atom_indices=[1], ref_atom_indices=[0])
+    # is this don't fail then it's good no matter the result


### PR DESCRIPTION
As I understand, `atom_indices` are indices of atoms in the `target`, and `ref_atom_indices` are indices in the `reference`.

However [here](https://github.com/mdtraj/mdtraj/blob/master/mdtraj/rmsd/_rmsd.pyx#L138) `atom_indices` are compared to the `reference` size, but they shouldn't be since they index atoms in a different trajectory (topology).

The same applies [here](https://github.com/mdtraj/mdtraj/blob/master/mdtraj/rmsd/_rmsd.pyx#L151) where `ref_atom_indices` are compared to the `target` size.