### PR TITLE
bugfix _topology_from_subset correct residue indexing

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -91,14 +91,16 @@ def _topology_from_subset(topology, atom_indices):
         newChain = newTopology.add_chain()
         for residue in chain._residues:
             resSeq = getattr(residue, 'resSeq', None) or residue.index
-            newResidue = newTopology.add_residue(residue.name, newChain,
-                                                 resSeq, residue.segment_id)
+            newResidue = None
             for atom in residue._atoms:
                 if atom.index in atom_indices:
                     try:  # OpenMM Topology objects don't have serial attributes, so we have to check first.
                         serial = atom.serial
                     except AttributeError:
                         serial = None
+                    if newResidue is None:
+                        newResidue = newTopology.add_residue(residue.name, newChain,
+                                                             resSeq, residue.segment_id)
                     newAtom = newTopology.add_atom(atom.name, atom.element,
                                                    newResidue, serial=serial)
                     old_atom_to_new_atom[atom] = newAtom

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -252,6 +252,11 @@ def test_subset(get_fn):
     t2 = t1.subset([1, 2, 3])
     assert t2.n_residues == 1
 
+def test_subset_re_index_residues(get_fn):
+    t1 = md.load(get_fn('2EQQ.pdb')).top
+    t2 = t1.subset(t1.select('resid 0 2'))
+    np.testing.assert_array_equal([0, 1], [rr.index for rr in t2.residues])
+
 
 def test_molecules(get_fn):
     top = md.load(get_fn('4OH9.pdb')).topology


### PR DESCRIPTION
The old `_topology_from_subset` was 

- first creating a new residue anyways (increasing residue count)
- then checking whether it would be added or not to the new topology.

This meant the residue count was increased regardless, leading to inconsistent residue indexing.

Now the residue is only created if the atom is going to be added 

This fixes #1577 