### PR TITLE
bump conda pins

### DIFF
--- a/devtools/azure-pipelines-linux.yml
+++ b/devtools/azure-pipelines-linux.yml
@@ -27,7 +27,7 @@ jobs:
       source devtools/travis-ci/install_ppm.sh
       conda config --add channels omnia
       conda config --add channels conda-forge # hightest priority
-      conda install -y conda=4.7.12 conda-build=3.18.9
+      conda install -y conda=4.8.5 conda-build=3.20.4
     displayName: 'Install dependencies'
     continueOnError: false
 

--- a/devtools/azure-pipelines-osx.yml
+++ b/devtools/azure-pipelines-osx.yml
@@ -19,7 +19,7 @@ jobs:
   - bash: |
       conda config --add channels omnia
       conda config --add channels conda-forge # hightest priority
-      conda install -y conda=4.7.12 conda-build=3.18.9
+      conda install -y conda=4.8.5 conda-build=3.20.4
     displayName: 'Install dependencies'
     continueOnError: false
 


### PR DESCRIPTION
As all new development pipelines are failing, this bumps the `conda` and `conda_build` versions based on [this comment](https://github.com/mdtraj/mdtraj/pull/1586#issuecomment-708903049) from @dwhswenson .

I will cherry pick these over into #1586  and #1584 if this fixes the pipelines