### PR TITLE
don't use serials for more than 1 chain

### DIFF
--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -344,7 +344,7 @@ class PDBTrajectoryFile(object):
                         symbol = atom.element.symbol
                     else:
                         symbol = ' '
-                    if atom.serial is not None and len(topology.chains) < 2:
+                    if atom.serial is not None and len(topology._chains) < 2:
                         # We can't do this for more than 1 chain
                         # to prevent issue 1611
                         atomSerial = atom.serial

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -344,7 +344,9 @@ class PDBTrajectoryFile(object):
                         symbol = atom.element.symbol
                     else:
                         symbol = ' '
-                    if atom.serial is not None:
+                    if atom.serial is not None and len(topology.chains) < 2:
+                        # We can't do this for more than 1 chain
+                        # to prevent issue 1611
                         atomSerial = atom.serial
                     else:
                         atomSerial = atomIndex

--- a/tests/data/issue_1611.pdb
+++ b/tests/data/issue_1611.pdb
@@ -1,0 +1,16 @@
+ATOM      1  O1  HOH A   1       4.012   4.851   0.586  1.00  0.00           O
+ATOM      2  H1  HOH A   1       4.826   4.387   0.302  1.00  0.00           H
+ATOM      3  H2  HOH A   1       3.243   4.622   0.021  1.00  0.00           H
+ATOM      4  C1  MOL B   1       3.024   3.160   3.102  1.00  0.00           C
+ATOM      5  O1  MOL B   1       4.131   3.989   3.088  1.00  0.00           O
+ATOM      6  H1  MOL B   1       2.484   3.163   4.060  1.00  0.00           H
+ATOM      7  H2  MOL B   1       3.406   2.119   2.930  1.00  0.00           H
+ATOM      8  H3  MOL B   1       2.305   3.360   2.302  1.00  0.00           H
+ATOM      9  H4  MOL B   1       3.955   4.912   3.354  1.00  0.00           H
+CONECT    4    5    6    7    8
+CONECT    5    4    9
+CONECT    6    4
+CONECT    7    4
+CONECT    8    4
+CONECT    9    5
+END

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -289,3 +289,14 @@ def test_dummy_pdb_box_detection(get_fn, recwarn):
     assert 'Unlikely unit cell' in str(w.message)
     assert traj.unitcell_lengths is None, 'Expected dummy box to be deleted'
 
+
+def test_multichain_load_cycle(get_fn):
+    # Issue 1611, make sure that save/load works for more than 1 chain
+    pdb = load(get_fn('issue_1611.pdb'))
+    bonds = [(bond.atom1.index, bond.atom2.index)
+             for bond in pdb.topology.bonds]
+    pdb.save(temp)
+    pdb2 = load_pdb(temp)
+    bonds2 = [(bond.atom1.index, bond.atom2.index)
+              for bond in pdb2.topology.bonds]
+    assert len(bonds) == len(bonds2)


### PR DESCRIPTION
Should solve #1611 while still allowing for #1583 as long as not more than 1 chain is present in the topology.

adds the test cases of #1611 to catch this regression in the future