### PR TITLE
update numpy build pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy",
+    "numpy==1.11.3; python_version=='3.6'",
+    "numpy==1.14.6; python_version=='3.7'",
+    "numpy==1.17.5; python_version=='3.8'",
+    "numpy==1.19.5; python_version=='3.9'",
+    "numpy; python_version>='3.10'",
     "Cython>0.28",
 ]


### PR DESCRIPTION
This implements the solution that was discussed on #1617, found by @rmcgibbo in [this comment](https://github.com/mdtraj/mdtraj/issues/1617#issuecomment-771070431) . It should prevent further issues until python `3.10`

I have only implemented it for python 3.6-3.10 and tested `import mdtraj` for the following installs ( I assume the intermediate numpy installations should also work)

|python| min_numpy| max_numpy| comment
|---|---|---|---|
|3.6|1.14.5|1.19.5| min is bound by scipy, max by pypi
|3.7|1.16.5|1.20.0| min is bound by scipy, import works with scipy warning for numpy==1.14.5
|3.8|1.17.5|1.20.0|
|3.9|1.19.3|1.20.0| 1.19.5 was used for the build but 1.19.3 (absolute minimum numpy for python 3.9) does not complain

Please let me know if you want more python versions supported than this