### PR TITLE
Add enforcePeriodicBox option for HDF5Reporter

### DIFF
--- a/mdtraj/reporters/basereporter.py
+++ b/mdtraj/reporters/basereporter.py
@@ -62,7 +62,8 @@ class _BaseReporter(object):
 
     def __init__(self, file, reportInterval, coordinates=True, time=True,
                  cell=True, potentialEnergy=True, kineticEnergy=True,
-                 temperature=True, velocities=False, atomSubset=None):
+                 temperature=True, velocities=False, atomSubset=None,
+                 enforcePeriodicBox=None):
         """Create an OpenMM reporter
 
         Parameters
@@ -122,6 +123,7 @@ class _BaseReporter(object):
         self._needEnergy = potentialEnergy or kineticEnergy or temperature
         self._atomSubset = atomSubset
         self._atomSlice = None
+        self._enforcePeriodicBox = enforcePeriodicBox
 
         if not OPENMM_IMPORTED:
             raise ImportError('OpenMM not found.')
@@ -190,7 +192,7 @@ class _BaseReporter(object):
             energies respectively.
         """
         steps = self._reportInterval - simulation.currentStep % self._reportInterval
-        return (steps, self._coordinates, self._velocities, False, self._needEnergy)
+        return (steps, self._coordinates, self._velocities, False, self._needEnergy, self._enforcePeriodicBox)
 
     def report(self, simulation, state):
         """Generate a report.

--- a/mdtraj/reporters/hdf5reporter.py
+++ b/mdtraj/reporters/hdf5reporter.py
@@ -70,7 +70,7 @@ class HDF5Reporter(_BaseReporter):
     atomSubset : array_like, default=None
         Only write a subset of the atoms, with these (zero based) indices
         to the file. If None, *all* of the atoms will be written to disk.
-    enforcePeriodicBox: bool
+    enforcePeriodicBox: bool or None
         Specifies whether particle positions should be translated so the
         center of every molecule lies in the same periodic box. If None
         (the default), it will automatically decide whether to translate

--- a/mdtraj/reporters/hdf5reporter.py
+++ b/mdtraj/reporters/hdf5reporter.py
@@ -70,6 +70,12 @@ class HDF5Reporter(_BaseReporter):
     atomSubset : array_like, default=None
         Only write a subset of the atoms, with these (zero based) indices
         to the file. If None, *all* of the atoms will be written to disk.
+    enforcePeriodicBox: bool
+        Specifies whether particle positions should be translated so the
+        center of every molecule lies in the same periodic box. If None
+        (the default), it will automatically decide whether to translate
+        molecules based on whether the system being simulated uses periodic
+        boundary conditions.
 
     Notes
     -----
@@ -94,9 +100,11 @@ class HDF5Reporter(_BaseReporter):
 
     def __init__(self, file, reportInterval, coordinates=True, time=True,
                  cell=True, potentialEnergy=True, kineticEnergy=True,
-                 temperature=True, velocities=False, atomSubset=None):
+                 temperature=True, velocities=False, atomSubset=None,
+                 enforcePeriodicBox=None):
         """Create a HDF5Reporter.
         """
         super(HDF5Reporter, self).__init__(file, reportInterval,
             coordinates, time, cell, potentialEnergy, kineticEnergy,
-            temperature, velocities, atomSubset)
+            temperature, velocities, atomSubset,
+            enforcePeriodicBox)


### PR DESCRIPTION
To solve issue #1620. Allow HDF5Reporter to save unwrapped coordinates.