### PR TITLE
fix a numpy 1.20 depr warning

### DIFF
--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -301,7 +301,7 @@ class AmberRestartFile(object):
         coordinates, time, cell_lengths, cell_angles = self._parse(lines)
 
         if atom_indices is not None:
-            atom_slice = ensure_type(atom_indices, dtype=np.int, ndim=1,
+            atom_slice = ensure_type(atom_indices, dtype=int, ndim=1,
                                      name='atom_indices', warn_on_cast=False)
             if not np.all(atom_slice) >= 0:
                 raise ValueError('Entries in atom_slice must be >= 0')
@@ -589,7 +589,7 @@ class AmberNetCDFRestartFile(object):
             raise ValueError('NetCDF restart has ConventionVersion %s. Only '
                              'Version 1.0 is supported.' % convention_version)
         if atom_indices is not None:
-            atom_slice = ensure_type(atom_indices, dtype=np.int, ndim=1,
+            atom_slice = ensure_type(atom_indices, dtype=int, ndim=1,
                                      name='atom_indices', warn_on_cast=False)
             if not np.all(atom_slice) >= 0:
                 raise ValueError('Entries in atom_slice must be >= 0')

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -578,7 +578,7 @@ class HDF5TrajectoryFile(object):
             # get all of the atoms
             atom_slice = slice(None)
         else:
-            atom_slice = ensure_type(atom_indices, dtype=np.int, ndim=1,
+            atom_slice = ensure_type(atom_indices, dtype=int, ndim=1,
                                      name='atom_indices', warn_on_cast=False)
             if not np.all(atom_slice < self._handle.root.coordinates.shape[1]):
                 raise ValueError('As a zero-based index, the entries in '

--- a/mdtraj/formats/lammpstrj.py
+++ b/mdtraj/formats/lammpstrj.py
@@ -512,7 +512,7 @@ class LAMMPSTrajectoryFile(object):
         if not types:
             # Make all particles the same type.
             types = np.ones(shape=(xyz.shape[1]))
-        types = ensure_type(types, np.int, 1, 'types', can_be_none=True,
+        types = ensure_type(types, int, 1, 'types', can_be_none=True,
                 shape=(xyz.shape[1], ), warn_on_cast=False,
                 add_newaxis_on_deficient_ndim=False)
 

--- a/mdtraj/formats/lh5.py
+++ b/mdtraj/formats/lh5.py
@@ -324,7 +324,7 @@ class LH5TrajectoryFile(object):
         if atom_indices is None:
             atom_slice = slice(None)
         else:
-            atom_slice = ensure_type(atom_indices, dtype=np.int, ndim=1,
+            atom_slice = ensure_type(atom_indices, dtype=int, ndim=1,
                                      name='atom_indices', warn_on_cast=False)
 
         total_n_frames = len(self._handle.root.XYZList)

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -263,7 +263,7 @@ class NetCDFTrajectoryFile(object):
             # get all of the atoms
             atom_slice = slice(None)
         else:
-            atom_slice = ensure_type(atom_indices, dtype=np.int, ndim=1,
+            atom_slice = ensure_type(atom_indices, dtype=int, ndim=1,
                                      name='atom_indices', warn_on_cast=False)
             if not np.all(atom_slice < self.n_atoms):
                 raise ValueError('As a zero-based index, the entries in '
@@ -277,7 +277,7 @@ class NetCDFTrajectoryFile(object):
             coordinates = self._handle.variables['coordinates'][frame_slice, atom_slice, :]
         else:
             raise ValueError('No coordinates found in the NetCDF file. The only '
-                             'variables in the file were %s' % 
+                             'variables in the file were %s' %
                              self._handle.variables.keys())
 
         if 'time' in self._handle.variables:

--- a/mdtraj/geometry/contact.py
+++ b/mdtraj/geometry/contact.py
@@ -143,7 +143,7 @@ def compute_contacts(traj, contacts='all', scheme='closest-heavy', ignore_nonpro
             raise ValueError('No acceptable residue pairs found')
 
     else:
-        residue_pairs = ensure_type(np.asarray(contacts), dtype=np.int, ndim=2, name='contacts',
+        residue_pairs = ensure_type(np.asarray(contacts), dtype=int, ndim=2, name='contacts',
                                shape=(None, 2), warn_on_cast=False)
         if not np.all((residue_pairs >= 0) * (residue_pairs < traj.n_residues)):
             raise ValueError('contacts requests a residue that is not in the permitted range')
@@ -257,7 +257,7 @@ def squareform(distances, residue_pairs):
         raise ValueError('distances must be a 2d array')
 
     residue_pairs = ensure_type(
-        residue_pairs, dtype=np.int, ndim=2, name='residue_pars',
+        residue_pairs, dtype=int, ndim=2, name='residue_pars',
         shape=(None, 2), warn_on_cast=False)
 
     if not np.all(residue_pairs >= 0):

--- a/mdtraj/geometry/dihedral.py
+++ b/mdtraj/geometry/dihedral.py
@@ -230,7 +230,7 @@ def _atom_sequence(top, atom_names, residue_offsets=None):
     found_residue_ids = np.array(found_residue_ids)
 
     if len(atom_indices) == 0:
-        atom_indices = np.empty(shape=(0, 4), dtype=np.int)
+        atom_indices = np.empty(shape=(0, 4), dtype=int)
 
     return found_residue_ids, atom_indices
 
@@ -370,7 +370,7 @@ def _indices_chi(top, chi_atoms):
     rids, indices = zip(*(_atom_sequence(top, atoms) for atoms in chi_atoms))
     id_sort = np.argsort(np.concatenate(rids))
     if not any(x.size for x in indices):
-        return np.empty(shape=(0, 4), dtype=np.int)
+        return np.empty(shape=(0, 4), dtype=int)
     indices = np.vstack([x for x in indices if x.size])[id_sort]
     return indices
 

--- a/mdtraj/geometry/neighborlist.pyx
+++ b/mdtraj/geometry/neighborlist.pyx
@@ -93,7 +93,7 @@ def compute_neighborlist(traj, cutoff, frame=0, periodic=True):
     for i in range(n_atoms):
         if atom_neighbors[i].size() > 0:
             atom_neighbors_mview = <int[:atom_neighbors[i].size()]> (<int*> (&atom_neighbors[i][0]))
-            neighbors.append(np.array(atom_neighbors_mview, dtype=np.int, copy=True))
+            neighbors.append(np.array(atom_neighbors_mview, dtype=int, copy=True))
         else:
-            neighbors.append(np.empty(0, dtype=np.int))
+            neighbors.append(np.empty(0, dtype=int))
     return neighbors

--- a/mdtraj/geometry/neighbors.pyx
+++ b/mdtraj/geometry/neighbors.pyx
@@ -122,9 +122,9 @@ def compute_neighbors(traj, cutoff, query_indices, haystack_indices=None,
             frame_neighbors_mview = <int[:frame_neighbors.size()]> (<int*> (&frame_neighbors[0]))
         # so then we can copy it into numpy-managed memory. copy is necessary,
         # because once we exit this scope, C++ will clean up the vector.
-            results.append(np.array(frame_neighbors_mview, dtype=np.int, copy=True))
+            results.append(np.array(frame_neighbors_mview, dtype=int, copy=True))
         else:
-            results.append(np.empty(0, dtype=np.int))
+            results.append(np.empty(0, dtype=int))
 
     return results
 

--- a/mdtraj/rmsd/_lprmsd.pyx
+++ b/mdtraj/rmsd/_lprmsd.pyx
@@ -229,9 +229,9 @@ def lprmsd(target, reference, int frame=0, atom_indices=None, permute_groups=Non
 
 def _validate_atom_indices(atom_indices, n_atoms):
     if atom_indices is None:
-        atom_indices = np.arange(n_atoms, dtype=np.int)
+        atom_indices = np.arange(n_atoms, dtype=int)
     else:
-        atom_indices = ensure_type(np.unique(atom_indices), dtype=np.int,
+        atom_indices = ensure_type(np.unique(atom_indices), dtype=int,
                                    ndim=1, name='atom_indices', warn_on_cast=False)
         if not np.all((atom_indices >= 0) * (atom_indices < n_atoms) * (atom_indices < n_atoms)):
             raise ValueError("atom_indices must be valid positive indices")
@@ -253,7 +253,7 @@ def _validate_permute_groups(permute_groups, atom_indices):
     if permute_groups is None:
         return [atom_indices]
 
-    permute_groups = [ensure_type(np.unique(group), dtype=np.int, ndim=1,
+    permute_groups = [ensure_type(np.unique(group), dtype=int, ndim=1,
                          warn_on_cast=False, name='permute_groups[%d]' % i) for \
                          i, group in enumerate(permute_groups)]
     for pgroup in permute_groups:

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -132,7 +132,7 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         atom_indices_is_none = True
         atom_indices = slice(None)
     else:
-        atom_indices = ensure_type(np.asarray(atom_indices), dtype=np.int, ndim=1, name='atom_indices')
+        atom_indices = ensure_type(np.asarray(atom_indices), dtype=int, ndim=1, name='atom_indices')
         if not np.all((atom_indices >= 0) *
                               (atom_indices < target.xyz.shape[1])):
             raise ValueError("atom_indices must be valid positive indices")
@@ -145,7 +145,7 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
                              "found %d and %d." % (len(atom_indices), len(ref_atom_indices)))
 
     if not isinstance(ref_atom_indices, slice):
-        ref_atom_indices = ensure_type(np.asarray(ref_atom_indices), dtype=np.int, ndim=1, name='ref_atom_indices')
+        ref_atom_indices = ensure_type(np.asarray(ref_atom_indices), dtype=int, ndim=1, name='ref_atom_indices')
         if not np.all((ref_atom_indices >= 0) *
                               (ref_atom_indices < reference.xyz.shape[1])):
             raise ValueError("ref_atom_indices must be valid positive indices")
@@ -293,7 +293,7 @@ def rmsf(target, reference, int frame=0, atom_indices=None,
         atom_indices_is_none = True
         atom_indices = slice(None)
     else:
-        atom_indices = ensure_type(np.asarray(atom_indices), dtype=np.int, ndim=1, name='atom_indices')
+        atom_indices = ensure_type(np.asarray(atom_indices), dtype=int, ndim=1, name='atom_indices')
         if not np.all((atom_indices >= 0) *
                               (atom_indices < target.xyz.shape[1]) *
                               (atom_indices < reference.xyz.shape[1])):
@@ -307,7 +307,7 @@ def rmsf(target, reference, int frame=0, atom_indices=None,
                              "found %d and %d." % (len(atom_indices), len(ref_atom_indices)))
 
     if not isinstance(ref_atom_indices, slice):
-        ref_atom_indices = ensure_type(np.asarray(ref_atom_indices), dtype=np.int, ndim=1, name='ref_atom_indices')
+        ref_atom_indices = ensure_type(np.asarray(ref_atom_indices), dtype=int, ndim=1, name='ref_atom_indices')
         if not np.all((ref_atom_indices >= 0) *
                               (ref_atom_indices < target.xyz.shape[1]) *
                               (ref_atom_indices < reference.xyz.shape[1])):
@@ -370,7 +370,7 @@ def rmsf(target, reference, int frame=0, atom_indices=None,
             for i in range(target_n_frames):
                 msd_atom_major(n_atoms, n_atoms, &target_xyz[i, 0, 0], &ref_xyz_frame[0, 0], ref_g, target_g[i], 1, &rot[i, 0, 0])
                 rot_atom_major(n_atoms, &target_displaced_xyz[i, 0, 0], &rot[i, 0, 0])
-    
+
     if parallel:
         for j in prange(n_atoms, nogil=True):
             for i in range(target_n_frames):

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -162,10 +162,10 @@ def test_closest_contact():
 
 
 def _verify_closest_contact(traj):
-    group1 = np.array([i for i in range(N_ATOMS // 2)], dtype=np.int)
-    group2 = np.array([i for i in range(N_ATOMS // 2, N_ATOMS)], dtype=np.int)
+    group1 = np.array([i for i in range(N_ATOMS // 2)], dtype=int)
+    group2 = np.array([i for i in range(N_ATOMS // 2, N_ATOMS)], dtype=int)
     contact = find_closest_contact(traj, group1, group2)
-    pairs = np.array([(i, j) for i in group1 for j in group2], dtype=np.int)
+    pairs = np.array([(i, j) for i in group1 for j in group2], dtype=int)
     dists = md.compute_distances(traj, pairs, True)[0]
     dists2 = md.compute_distances(traj, pairs, False)[0]
     nearest = np.argmin(dists)


### PR DESCRIPTION
A downstream project of mine directly interfaced with this code and our test surface a:
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

This fixes that instance. ~And I did not see more warnings surface when running `py.test` on this repo, but I might be missing some.~
EDIT: did a `grep -r -n "np.int" --include="*.py*"` and will go to the other ones now
