### PR TITLE
Topology.join updates resSeq of new residues as default now

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -257,13 +257,17 @@ class Topology(object):
 
         return hash_value
 
-    def join(self, other):
+    def join(self, other, keepIds=False):
         """Join two topologies together
 
         Parameters
         ----------
         other : Topology
             Another topology object
+        keepIds : bool, optional, default=False
+            if False (default) the residue numbers (resSeq) of the
+            topology that is joined are updated in order to
+            continue from the last resSeq of this topology
 
         Returns
         -------
@@ -275,11 +279,21 @@ class Topology(object):
             raise ValueError('other must be an instance of Topology to join')
         out = self.copy()
 
+        #I need this in order to have the resSeq of the
+        #new residues to continue from the one of the
+        #las residue of this topology
+        if not keepIds:
+            out_resSeq = out.atom(-1).residue.resSeq
+
         atom_mapping = {}
         for chain in other.chains:
             c = out.add_chain()
             for residue in chain.residues:
-                r = out.add_residue(residue.name, c, residue.resSeq, residue.segment_id)
+                if keepIds:
+                    out_resSeq = residue.resSeq
+                else:
+                    out_resSeq += 1
+                r = out.add_residue(residue.name, c, out_resSeq, residue.segment_id)
                 for atom in residue.atoms:
                     a = out.add_atom(atom.name, atom.element, r,
                                      serial=atom.serial)

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1059,7 +1059,7 @@ class Trajectory(object):
         return self.__class__(xyz, deepcopy(self._topology), time=time,
             unitcell_lengths=lengths, unitcell_angles=angles)
 
-    def stack(self, other):
+    def stack(self, other, keepIds=False):
         """Stack two trajectories along the atom axis
 
         This method joins trajectories along the atom axis, giving a new trajectory
@@ -1087,6 +1087,8 @@ class Trajectory(object):
         ----------
         other : Trajectory
             The other trajectory to join
+        keepIds : bool, optional, default=False
+            see ```mdtraj.core.topology.Topology.join``` method documentation
 
         See Also
         --------
@@ -1098,7 +1100,7 @@ class Trajectory(object):
             raise ValueError('Number of frames in self (%d) is not equal '
                              'to number of frames in other (%d)' % (self.n_frames, other.n_frames))
         if self.topology is not None:
-            topology = self.topology.join(other.topology)
+            topology = self.topology.join(other.topology, keepIds=keepIds)
         else:
             topology = None
 

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -288,3 +288,35 @@ def test_topology_sliced_residue_indices(get_fn):
     assert idx == sliced.top.n_residues-1
     # Now see if this works
     _ = sliced.topology.residue(idx)
+
+def test_topology_join(get_fn):
+    top_1 = md.load(get_fn('2EQQ.pdb')).topology
+    top_2 = md.load(get_fn('4OH9.pdb')).topology
+
+    out_topology = top_1.join(top_2)
+
+    eq(out_topology.n_atoms, top_1.n_atoms + top_2.n_atoms)
+    eq(out_topology.n_residues, top_1.n_residues + top_2.n_residues)
+    eq(top_1.atom(0).residue.name, out_topology.atom(0).residue.name)
+    eq(top_2.atom(-1).residue.name, out_topology.atom(-1).residue.name)
+    eq(top_1.atom(0).element, out_topology.atom(0).element)
+    eq(top_2.atom(-1).element, out_topology.atom(-1).element)
+
+def test_topology_join_keepIds(get_fn):
+    top_1 = md.load(get_fn('2EQQ.pdb')).topology
+    top_2 = md.load(get_fn('4OH9.pdb')).topology
+
+    out_topology_keepId_True = top_1.join(top_2, keepIds=True)
+    out_topology_keepId_False = top_1.join(top_2, keepIds=False)
+
+    out_resSeq_keepId_True = [residue.resSeq for residue in out_topology_keepId_True.residues]
+    out_resSeq_keepId_False = [residue.resSeq for residue in out_topology_keepId_False.residues]
+
+    expected_resSeq_keepId_True = (
+        [residue.resSeq for residue in top_1.residues
+            ] + [
+                residue.resSeq for residue in top_2.residues])
+    expected_resSeq_keepId_False = list(range(1, len(expected_resSeq_keepId_True) + 1))
+
+    eq(out_resSeq_keepId_True, expected_resSeq_keepId_True)
+    eq(out_resSeq_keepId_False, expected_resSeq_keepId_False)


### PR DESCRIPTION
When I first used Trajectory.stack I noticed that the resSeq of the added part restarted from 1, this can be quite annoying especially when you are adding one single residue on the top of a file (pdb, gro, ...) , as example if you add one ligand on the top pf a water box, because you would have 2 residues 1.

So I changed Topology.join in order to renumber the new residues according to the last residue of the other topology as default

both Topology.join and Trajectory.stack now accept a new argument keepIds that if set to True will give the old behavior
