### PR TITLE
added select option to compute_center_of_mass

### DIFF
--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -163,7 +163,7 @@ def compute_center_of_mass(traj, select=None):
     else:
         atoms_of_interest = traj.topology.select(select)
 
-        masses = np.array([traj.top.atom[i].element.mass for i in atoms_of_interest])
+        masses = np.array([traj.top.atom(i).element.mass for i in atoms_of_interest])
         masses /= masses.sum()
 
         xyz = traj.xyz[:, atoms_of_interest]

--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -163,10 +163,10 @@ def compute_center_of_mass(traj, select=None):
     else:
         atoms_of_interest = traj.topology.select(select)
 
-        masses = np.array([a.element.mass for a in traj.top.atoms if a.index in atoms_of_interest])
+        masses = np.array([traj.top.atom[i].element.mass for i in atoms_of_interest])
         masses /= masses.sum()
 
-        xyz = np.array(traj.xyz[:, atoms_of_interest], order='C')
+        xyz = traj.xyz[:, atoms_of_interest]
 
     for i, x in enumerate(xyz):
         com[i, :] = x.astype('float64').T.dot(masses)

--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -135,13 +135,17 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
     return _displacement(xyz, pairs)
 
 
-def compute_center_of_mass(traj):
+def compute_center_of_mass(traj, select='all'):
     """Compute the center of mass for each frame.
 
     Parameters
     ----------
     traj : Trajectory
         Trajectory to compute center of mass for
+    select : str, optional, default=all
+        a mdtraj.Topology selection string that
+        defines the set of atoms of which to calculate
+        the center of mass, the default is all atoms
 
     Returns
     -------
@@ -149,7 +153,10 @@ def compute_center_of_mass(traj):
          Coordinates of the center of mass for each frame
     """
 
-    com = np.zeros((traj.n_frames, 3))
+    atoms_of_interest = traj.topology.select(select)
+    traj = traj.atom_slice(atoms_of_interest)
+
+    com = np.empty((traj.n_frames, 3))
     masses = np.array([a.element.mass for a in traj.top.atoms])
     masses /= masses.sum()
 

--- a/mdtraj/geometry/distance.py
+++ b/mdtraj/geometry/distance.py
@@ -135,7 +135,7 @@ def compute_displacements(traj, atom_pairs, periodic=True, opt=True):
     return _displacement(xyz, pairs)
 
 
-def compute_center_of_mass(traj, select='all'):
+def compute_center_of_mass(traj, select=None):
     """Compute the center of mass for each frame.
 
     Parameters
@@ -152,15 +152,23 @@ def compute_center_of_mass(traj, select='all'):
     com : np.ndarray, shape=(n_frames, 3)
          Coordinates of the center of mass for each frame
     """
-
-    atoms_of_interest = traj.topology.select(select)
-    traj = traj.atom_slice(atoms_of_interest)
-
     com = np.empty((traj.n_frames, 3))
-    masses = np.array([a.element.mass for a in traj.top.atoms])
-    masses /= masses.sum()
 
-    for i, x in enumerate(traj.xyz):
+    if select is None:
+        masses = np.array([a.element.mass for a in traj.top.atoms])
+        masses /= masses.sum()
+
+        xyz = traj.xyz
+
+    else:
+        atoms_of_interest = traj.topology.select(select)
+
+        masses = np.array([a.element.mass for a in traj.top.atoms if a.index in atoms_of_interest])
+        masses /= masses.sum()
+
+        xyz = np.array(traj.xyz[:, atoms_of_interest], order='C')
+
+    for i, x in enumerate(xyz):
         com[i, :] = x.astype('float64').T.dot(masses)
     return com
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -75,6 +75,16 @@ def test_center_of_mass():
 
     eq(com_actual, com_test, decimal=4)
 
+    #test with selection string
+    com_test = mdtraj.geometry.distance.compute_center_of_mass(traj, select='index 0')
+
+    com_actual = np.array([
+        [1.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+    ])
+
+    eq(com_actual, com_test, decimal=4)
+
 
 def test_center_of_geometry():
     top = md.Topology()


### PR DESCRIPTION
added select option to compute_center_of_mass to make thing easier and less error prone, the default will act exactly as the older version

I also added it to the  unit test

have also substituted a np.zeros with a np.empty in the same function because it should be faster and doesn't change the result

We were talking about it in the closed issue #1598 