### PR TITLE
now Topology.from_dataframe methon can manage residues with same resSeq

### DIFF
--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -83,6 +83,14 @@ def test_topology_pandas_TIP4PEW(get_fn):
     eq(topology, topology2)
 
 
+def test_topology_pandas_2residues_same_resSeq(get_fn):
+    topology = md.load(get_fn('two_residues_same_resnum.gro')).topology
+    atoms, bonds = topology.to_dataframe()
+
+    topology2 = md.Topology.from_dataframe(atoms, bonds)
+    eq(topology, topology2)
+
+
 def test_topology_numbers(get_fn):
     topology = md.load(get_fn('1bpi.pdb')).topology
     assert len(list(topology.atoms)) == topology.n_atoms


### PR DESCRIPTION
closes #1646

Now the Topology.from_dataframe methon in topology.py is able to deal with a structure that has many residues with the same resSeq respecting their input order, the function in fact now is much similar to the pdb parser (maybe give a quick check if there is something I haven't considered on how dataframes need to be handled)

I have also added a test

ps if the PR is accepted could it be possible to include it in the 1.9.6 release or is it too late?