### PR TITLE
Faster load function and more omogeneus file parser interface

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -439,9 +439,9 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
         t = loader(tmp_file, **kwargs)
 
-    #in case only a part of the atoms where selected
-    #I get the right topology to laret share with the
-    #other frames
+    # In case only a part of the atoms were selected
+    # I get the right topology to later share with the
+    # other frames
     subset_topology = t.topology
     trajectories.append(t)
 

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -435,6 +435,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         if "got an unexpected keyword argument 'top'" not in str(e):
             raise
 
+        warnings.warn('top= kwargs ignored since this file parser does not support it')
+
         kwargs.pop('top', None)
 
         t = loader(tmp_file, **kwargs)

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -418,6 +418,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
 
     trajectories = []
+    tmp_file = filename_or_filenames.pop(0)
     try:
         # this is a little hack that makes calling load() more predictable. since
         # most of the loaders take a kwargs "top" except for load_hdf5, (since
@@ -427,12 +428,12 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         # it.
         #TODO make all the loaders accept a pre parsed topology (top) in order to avoid
         #this part and have a more consistent interface and a faster load function
-        t = loader(filename_or_filenames.pop(0), **kwargs)
+        t = loader(tmp_file, **kwargs)
         
     except TypeError:
         kwargs.pop('top', None)
 
-        t = loader(filename_or_filenames.pop(0), **kwargs)
+        t = loader(tmp_file, **kwargs)
 
     finally:
 

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -454,7 +454,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
     trajectories.append(t)
 
-    # Only do this extra copy and monkey patching if needed
+    # Only do this monkey patching if needed in order not to
+    # modify the output topology
     if ('top' in kwargs) and (
         kwargs.get('atom_indices', None) is not None) and (
         len(filename_or_filenames) > 1):

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -166,7 +166,11 @@ def _parse_topology(top, **kwargs):
     else:
         ext = None  # might not be a string
 
-    if isinstance(top, string_types) and (ext in ['.pdb', '.pdb.gz', '.h5','.lh5']):
+    if isinstance(top, Topology):
+        topology = top
+    elif isinstance(top, Trajectory):
+        topology = top.topology
+    elif isinstance(top, string_types) and (ext in ['.pdb', '.pdb.gz', '.h5','.lh5']):
         _traj = load_frame(top, 0, **kwargs)
         topology = _traj.topology
     elif isinstance(top, string_types) and (ext in ['.prmtop', '.parm7', '.prm7']):
@@ -183,10 +187,6 @@ def _parse_topology(top, **kwargs):
         topology = load_hoomdxml(top, **kwargs).topology
     elif isinstance(top, string_types) and (ext in ['.gsd']):
         topology = load_gsd_topology(top, **kwargs)
-    elif isinstance(top, Trajectory):
-        topology = top.topology
-    elif isinstance(top, Topology):
-        topology = top
     elif isinstance(top, string_types):
         raise IOError('The topology is loaded by filename extension, and the '
                       'detected "%s" format is not supported. Supported topology '

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -359,7 +359,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     >>> print traj2
     <mdtraj.Trajectory with 250 frames, 423 atoms at 0x11136e410>
 
-    >>> traj3 = md.load_hdf5('output.xtc', atom_indices=[0,1] top='topology.pdb')
+    >>> traj3 = md.load_hdf5('output.xtc', atom_indices=[0,1], top='topology.pdb')
     >>> print traj3
     <mdtraj.Trajectory with 500 frames, 2 atoms at 0x18236e4a0>
 
@@ -438,6 +438,17 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         kwargs.pop('top', None)
 
         t = loader(tmp_file, **kwargs)
+
+    except ValueError as e:
+
+        if 'xyz must be shape' in str(e):
+
+            raise ValueError('The topology and the trajectory files might not contain the same atoms\n'
+            'The input topology must contain all atoms even if '
+            'you want to select a subset of them with atom_indices'
+            ) from e
+
+        raise
 
     # In case only a part of the atoms were selected
     # I get the right topology to later share with the

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -458,7 +458,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     # modify the output topology
     if ('top' in kwargs) and (
         kwargs.get('atom_indices', None) is not None) and (
-        len(filename_or_filenames) > 1):
+        len(filename_or_filenames) > 0):
 
         # In case only a part of the atoms were selected
         # I get the right topology that
@@ -467,7 +467,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
         # Little monkey-patch to prevent further subsetting Topologies
         # this modified version of the topology will never exit this function
-        kwargs['top'].subset = lambda self, atom_indices : subset_topology
+        kwargs['top'].subset = lambda atom_indices : subset_topology
         
 
 

--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -86,7 +86,7 @@ def load_gro(filename, stride=None, atom_indices=None, frame=None, top=None):
         If frame is None, the default, the entire trajectory will be loaded.
         If supplied, ``stride`` will be ignored.
     top : mdtraj.core.Topology, default=None
-        if you give a topology as input the topology won't be parsed from the pdb file
+        if you give a topology as input the topology won't be parsed from the gro file
         it saves time if you have to parse a big number of files
     """
     from mdtraj.core.trajectory import _parse_topology, Trajectory
@@ -116,7 +116,7 @@ class GroTrajectoryFile(object):
         If opened in write mode, and a file by the name of `filename` already
         exists on disk, should we overwrite it?
     top : mdtraj.core.Topology, default=None
-        if you give a topology as input the topology won't be parsed from the pdb file
+        if you give a topology as input the topology won't be parsed from the gro file
         it saves time if you have to parse a big number of files
 
     Attributes

--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -69,7 +69,7 @@ from mdtraj.formats.registry import FormatRegistry
 ##############################################################################
 
 @FormatRegistry.register_loader('.gro')
-def load_gro(filename, stride=None, atom_indices=None, frame=None):
+def load_gro(filename, stride=None, atom_indices=None, frame=None, top=None):
     """Load a GROMACS GRO file.
 
     Parameters
@@ -85,10 +85,13 @@ def load_gro(filename, stride=None, atom_indices=None, frame=None):
         Use this option to load only a single frame from a trajectory on disk.
         If frame is None, the default, the entire trajectory will be loaded.
         If supplied, ``stride`` will be ignored.
+    top : mdtraj.core.Topology, default=None
+        if you give a topology as input the topology won't be parsed from the pdb file
+        it saves time if you have to parse a big number of files
     """
     from mdtraj.core.trajectory import _parse_topology, Trajectory
 
-    with GroTrajectoryFile(filename, 'r') as f:
+    with GroTrajectoryFile(filename, 'r', top=top) as f:
         topology = f.topology
         if frame is not None:
             f.seek(frame)
@@ -112,6 +115,9 @@ class GroTrajectoryFile(object):
     force_overwrite : bool
         If opened in write mode, and a file by the name of `filename` already
         exists on disk, should we overwrite it?
+    top : mdtraj.core.Topology, default=None
+        if you give a topology as input the topology won't be parsed from the pdb file
+        it saves time if you have to parse a big number of files
 
     Attributes
     ----------
@@ -126,17 +132,22 @@ class GroTrajectoryFile(object):
     """
     distance_unit = 'nanometers'
 
-    def __init__(self, filename, mode='r', force_overwrite=True):
+    def __init__(self, filename, mode='r', force_overwrite=True, top=None):
         self._open = False
         self._file = None
         self._mode = mode
+
+        self.topology = top
 
         if mode == 'r':
             self._open = True
             self._frame_index = 0
             self._file = open(filename, 'r')
             try:
-                self.n_atoms, self.topology = self._read_topology()
+                if self.topology is None:
+                    self.n_atoms, self.topology = self._read_topology()
+                else:
+                    self.n_atoms = self.topology.n_atoms
             finally:
                 self._file.seek(0)
         elif mode == 'w':

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -49,7 +49,7 @@ from datetime import date
 import gzip
 import numpy as np
 import xml.etree.ElementTree as etree
-from copy import copy
+from copy import copy, deepcopy
 from mdtraj.formats.pdb.pdbstructure import PdbStructure
 from mdtraj.core.topology import Topology
 from mdtraj.utils import ilen, cast_indices, in_units_of, open_maybe_zipped
@@ -165,7 +165,7 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
         topology = f.topology
         if atom_indices is not None:
             #to avoid modifying the topology if given as input
-            topology = copy.deepcopy(topology)
+            topology = deepcopy(topology)
             topology = topology.subset(atom_indices)
 
         if f.unitcell_angles is not None and f.unitcell_lengths is not None:

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -125,7 +125,7 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
     standard_names : bool, default=True
         If True, non-standard atomnames and residuenames are standardized to conform
         with the current PDB format version. If set to false, this step is skipped.
-    topology : mdtraj.core.Topology, default=None
+    top : mdtraj.core.Topology, default=None
         if you give a topology as input the topology won't be parsed from the pdb file
         it saves time if you have to parse a big number of files
 

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -544,7 +544,7 @@ class PDBTrajectoryFile(object):
         self._unitcell_angles = pdb.get_unit_cell_angles()
 
 
-        #load the topology if none is given
+        # Load the topology if None is given
         if self._topology is None:
             self._topology = Topology()
 

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -94,7 +94,7 @@ def _is_url(url):
 @FormatRegistry.register_loader('.pdb')
 @FormatRegistry.register_loader('.pdb.gz')
 def load_pdb(filename, stride=None, atom_indices=None, frame=None,
-             no_boxchk=False, standard_names=True ):
+             no_boxchk=False, standard_names=True, top=None):
     """Load a RCSB Protein Data Bank file from disk.
 
     Parameters
@@ -125,6 +125,9 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
     standard_names : bool, default=True
         If True, non-standard atomnames and residuenames are standardized to conform
         with the current PDB format version. If set to false, this step is skipped.
+    topology : mdtraj.core.Topology, default=None
+        if you give a topology as input the topology won't be parsed from the pdb file
+        it saves time if you have to parse a big number of files
 
     Returns
     -------
@@ -150,7 +153,7 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
     atom_indices = cast_indices(atom_indices)
 
     filename = str(filename)
-    with PDBTrajectoryFile(filename, standard_names=standard_names) as f:
+    with PDBTrajectoryFile(filename, standard_names=standard_names, top=top) as f:
         atom_slice = slice(None) if atom_indices is None else atom_indices
         if frame is not None:
             coords = f.positions[[frame], atom_slice, :]
@@ -161,6 +164,8 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
 
         topology = f.topology
         if atom_indices is not None:
+            #to avoid modifying the topology if given as input
+            topology = copy.deepcopy(topology)
             topology = topology.subset(atom_indices)
 
         if f.unitcell_angles is not None and f.unitcell_lengths is not None:
@@ -217,6 +222,9 @@ class PDBTrajectoryFile(object):
     standard_names : bool, default=True
         If True, non-standard atomnames and residuenames are standardized to conform
         with the current PDB format version. If set to false, this step is skipped.
+    top : mdtraj.core.Topology, default=None
+        if you give a topology as input the topology won't be parsed from the pdb file
+        it saves time if you have to parse a big number of files
 
     Attributes
     ----------
@@ -241,10 +249,10 @@ class PDBTrajectoryFile(object):
     _atomNameReplacements = {}
     _chain_names = [chr(ord('A') + i) for i in range(26)]
 
-    def __init__(self, filename, mode='r', force_overwrite=True, standard_names=True):
+    def __init__(self, filename, mode='r', force_overwrite=True, standard_names=True, top=None):
         self._open = False
         self._file = None
-        self._topology = None
+        self._topology = top
         self._positions = None
         self._mode = mode
         self._last_topology = None
@@ -513,33 +521,8 @@ class PDBTrajectoryFile(object):
         if not self._mode == 'r':
             raise ValueError('file not opened for reading')
 
-        self._topology = Topology()
-
         pdb = PdbStructure(self._file, load_all_models=True)
 
-        atomByNumber = {}
-        for chain in pdb.iter_chains():
-            c = self._topology.add_chain()
-            for residue in chain.iter_residues():
-                resName = residue.get_name()
-                if resName in PDBTrajectoryFile._residueNameReplacements and self._standard_names:
-                    resName = PDBTrajectoryFile._residueNameReplacements[resName]
-                r = self._topology.add_residue(resName, c, residue.number, residue.segment_id)
-                if resName in PDBTrajectoryFile._atomNameReplacements and self._standard_names:
-                    atomReplacements = PDBTrajectoryFile._atomNameReplacements[resName]
-                else:
-                    atomReplacements = {}
-                for atom in residue.atoms:
-                    atomName = atom.get_name()
-                    if atomName in atomReplacements:
-                        atomName = atomReplacements[atomName]
-                    atomName = atomName.strip()
-                    element = atom.element
-                    if element is None:
-                        element = PDBTrajectoryFile._guess_element(atomName, residue.name, len(residue))
-
-                    newAtom = self._topology.add_atom(atomName, element, r, serial=atom.serial_number)
-                    atomByNumber[atom.serial_number] = newAtom
 
         # load all of the positions (from every model)
         _positions = []
@@ -559,23 +542,54 @@ class PDBTrajectoryFile(object):
         ## The atom positions read from the PDB file
         self._unitcell_lengths = pdb.get_unit_cell_lengths()
         self._unitcell_angles = pdb.get_unit_cell_angles()
-        self._topology.create_standard_bonds()
-        self._topology.create_disulfide_bonds(self.positions[0])
 
-        # Add bonds based on CONECT records.
-        connectBonds = []
-        for connect in pdb.models[-1].connects:
-            i = connect[0]
-            for j in connect[1:]:
-                if i in atomByNumber and j in atomByNumber:
-                    connectBonds.append((atomByNumber[i], atomByNumber[j]))
-        if len(connectBonds) > 0:
-            # Only add bonds that don't already exist.
-            existingBonds = set(self._topology.bonds)
-            for bond in connectBonds:
-                if bond not in existingBonds and (bond[1], bond[0]) not in existingBonds:
-                    self._topology.add_bond(bond[0], bond[1])
-                    existingBonds.add(bond)
+
+        #load the topology if none is given
+        if self._topology is None:
+            self._topology = Topology()
+
+            atomByNumber = {}
+            for chain in pdb.iter_chains():
+                c = self._topology.add_chain()
+                for residue in chain.iter_residues():
+                    resName = residue.get_name()
+                    if resName in PDBTrajectoryFile._residueNameReplacements and self._standard_names:
+                        resName = PDBTrajectoryFile._residueNameReplacements[resName]
+                    r = self._topology.add_residue(resName, c, residue.number, residue.segment_id)
+                    if resName in PDBTrajectoryFile._atomNameReplacements and self._standard_names:
+                        atomReplacements = PDBTrajectoryFile._atomNameReplacements[resName]
+                    else:
+                        atomReplacements = {}
+                    for atom in residue.atoms:
+                        atomName = atom.get_name()
+                        if atomName in atomReplacements:
+                            atomName = atomReplacements[atomName]
+                        atomName = atomName.strip()
+                        element = atom.element
+                        if element is None:
+                            element = PDBTrajectoryFile._guess_element(atomName, residue.name, len(residue))
+
+                        newAtom = self._topology.add_atom(atomName, element, r, serial=atom.serial_number)
+                        atomByNumber[atom.serial_number] = newAtom
+
+        
+            self._topology.create_standard_bonds()
+            self._topology.create_disulfide_bonds(self.positions[0])
+
+            # Add bonds based on CONECT records.
+            connectBonds = []
+            for connect in pdb.models[-1].connects:
+                i = connect[0]
+                for j in connect[1:]:
+                    if i in atomByNumber and j in atomByNumber:
+                        connectBonds.append((atomByNumber[i], atomByNumber[j]))
+            if len(connectBonds) > 0:
+                # Only add bonds that don't already exist.
+                existingBonds = set(self._topology.bonds)
+                for bond in connectBonds:
+                    if bond not in existingBonds and (bond[1], bond[0]) not in existingBonds:
+                        self._topology.add_bond(bond[0], bond[1])
+                        existingBonds.add(bond)
 
     @staticmethod
     def _loadNameReplacementTables():

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -164,8 +164,8 @@ def load_pdb(filename, stride=None, atom_indices=None, frame=None,
 
         topology = f.topology
         if atom_indices is not None:
-            #to avoid modifying the topology if given as input
-            topology = deepcopy(topology)
+            # The input topology shouldn't be modified because
+            # subset makes a copy inside the function
             topology = topology.subset(atom_indices)
 
         if f.unitcell_angles is not None and f.unitcell_lengths is not None:

--- a/tests/test_gro.py
+++ b/tests/test_gro.py
@@ -98,6 +98,18 @@ def test_load(get_fn):
     t = md.load(get_fn('two_residues_same_resnum.gro'))
     eq(t.n_residues, 2)
 
+def test_load_with_given_top(get_fn):
+    gro = get_fn('frame0.gro')
+    t = md.load(gro, top=gro)
+    tref = md.load(gro)
+                 
+    eq(t.xyz, tref.xyz)
+    eq(t.top, tref.top)
+    eq(list(t.top.atoms), list(tref.top.atoms))
+    eq(t.unitcell_vectors, tref.unitcell_vectors)
+
+
+
 
 def test_against_gmx(get_fn, tmpdir):
     t1 = md.load(get_fn('frame0.pdb'))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,5 @@
 from mdtraj import load
+from mdtraj.testing import eq
 
 def test_load_single(get_fn):
     # Just check for any raised errors coming from loading a single file.
@@ -15,3 +16,9 @@ def test_load_many_list(get_fn):
     single = load(get_fn('frame0.pdb'))
     double = load(2 * [get_fn('frame0.pdb')], discard_overlapping_frames=False)
     assert 2 * single.n_frames == double.n_frames
+
+def test_load_atom_indices_multiple_files(get_fn):
+    ref_t = load(get_fn('native.pdb'))
+    t = load([get_fn('native.pdb')]*2, atom_indices=[0])
+
+    eq(t.topology, ref_t.topology.subset([0]))

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -43,6 +43,15 @@ def test_pdbread(get_fn):
     pdb = get_fn('native.pdb')
     p = load(pdb)
 
+def test_pdbread_with_input_top(get_fn):
+    pdb = get_fn('native.pdb')
+    p_1 = load(pdb)
+
+    p_2 = load(pdb, top=pdb)
+
+    eq(p_1.xyz, p_2.xyz)
+    eq(p_1.topology, p_2.topology)
+
 
 def test_pdbwrite(get_fn):
     pdb = get_fn('native.pdb')
@@ -300,3 +309,13 @@ def test_multichain_load_cycle(get_fn):
     bonds2 = [(bond.atom1.index, bond.atom2.index)
               for bond in pdb2.topology.bonds]
     assert len(bonds) == len(bonds2)
+
+def test_load_pdb_input_top(get_fn):
+
+    pdb = get_fn('native.pdb')
+    p_1 = load_pdb(pdb)
+
+    p_2 = load_pdb(pdb, top=p_1.topology)
+
+    eq(p_1.xyz, p_2.xyz)
+    eq(p_1.topology, p_2.topology)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -28,6 +28,7 @@ import mdtraj as md
 import mdtraj.utils
 from mdtraj.utils import six
 from mdtraj.core import element
+import mdtraj.core.trajectory
 import pytest
 import mdtraj.formats
 from collections import namedtuple
@@ -627,7 +628,13 @@ def test_length(get_fn):
 
     for file in files:
         opened = md.open(get_fn(file))
-        loaded = md.load(get_fn(file), top=get_fn('native.pdb'))
+
+        if '.' + file.split('.', 1)[-1] in mdtraj.core.trajectory._TOPOLOGY_EXTS:
+            top = file
+        else:
+            top = 'native.pdb'
+
+        loaded = md.load(get_fn(file), top=get_fn(top))
         assert len(opened) == len(loaded)
 
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -629,7 +629,7 @@ def test_length(get_fn):
     for file in files:
         opened = md.open(get_fn(file))
 
-        if '.' + file.split('.', 1)[-1] in mdtraj.core.trajectory._TOPOLOGY_EXTS:
+        if '.' + file.rsplit('.', 1)[-1] in mdtraj.core.trajectory._TOPOLOGY_EXTS:
             top = file
         else:
             top = 'native.pdb'


### PR DESCRIPTION
Hi, I found myself in the need to load thousands of pdb or gro files all in once and I noticed that the mdtraj.load function can be sped up without losing its high level functionalities

And I also noted that if using pdb or gro files (or in general files in the _TOPOLOGY_EXTS category) the topology gets re-parsed again for each single file.
Therefore I made the PDB and the GRO file parsers able to accept the top argument and therefore re-use the already parsed topology (I would suggest to slowly make the interface more omogeneus by implementing it in all the file parsers in _TOPOLOGY_EXTS, see #1649)

I made the load function able to deal more flexibly with the fact that some parsers may not accept top so if in the future someone implements the top keyword in other parsers it won't be necessary to change load

And changed the if order in _parse_topology in order for it to be faster if a Topology or a Trajecotry is given

The speed up is pretty good for lists of files (12% faster):
```
Before

python -m timeit -n 10 -s 'import mdtraj' -- 'mdtraj.load("tests/data/1am7_protein.pdb", top="tests/data/1am7_protein.pdb")'

10 loops, best of 5: 517 msec per loop



python -m timeit -n 2 -s 'import mdtraj; list=["tests/data/1am7_protein.pdb"]*10' -- 'mdtraj.load(list, top="tests/data/1am7_protein.pdb")'

2 loops, best of 5: 3.17 sec per loop


After

python -m timeit -n 10 -s 'import mdtraj' -- 'mdtraj.load("tests/data/1am7_protein.pdb", top="tests/data/1am7_protein.pdb")'

10 loops, best of 5: 460 msec per loop


python -m timeit -n 2 -s 'import mdtraj; list=["tests/data/1am7_protein.pdb"]*10' -- 'mdtraj.load(list, top="tests/data/1am7_protein.pdb")'

2 loops, best of 5: 2.63 sec per loop
```

ps if the PR is accepted could it be possible to include it in the 1.9.6 release or is it too late?