### PR TITLE
bugfix from previous gro file parsing bugfix

### DIFF
--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -295,6 +295,10 @@ class GroTrajectoryFile(object):
         residue = None
         atomReplacements = {}
 
+        # This is needed because sometimes
+        # residue names get replaced and this
+        # brings to wrong residue parsing
+        old_resname = None
         for ln, line in enumerate(self._file):
             if ln == 1:
                 n_atoms = int(line.strip())
@@ -302,9 +306,10 @@ class GroTrajectoryFile(object):
                 (thisresnum, thisresname, thisatomname, thisatomnum) = \
                     [line[i*5:i*5+5].strip() for i in range(4)]
                 thisresnum, thisatomnum = map(int, (thisresnum, thisatomnum))
-                if residue is None or residue.resSeq != thisresnum or residue.name != thisresname:
-                    if residue is not None and residue.name != thisresname:
-                        warnings.warn("WARNING: two consecutive residues with same number (%s, %s)" % (thisresname, residue.name))
+                if residue is None or residue.resSeq != thisresnum or old_resname != thisresname:
+                    if residue is not None and thisresnum == residue.resSeq:
+                        warnings.warn("WARNING: two consecutive residues with same number (%s, %s)" % (thisresname, old_resname))
+                    old_resname = thisresname
                     if thisresname in pdb.PDBTrajectoryFile._residueNameReplacements:
                         thisresname = pdb.PDBTrajectoryFile._residueNameReplacements[thisresname]
                     residue = topology.add_residue(thisresname, chain, resSeq=thisresnum)


### PR DESCRIPTION
in fact the previous bugfix I did didn't take in consideration the residue renaming of pdb.PDBTrajectoryFile._residueNameReplacements and did therefore create a residue per atom in case of residue renaming. For example in the case of SOL -> HOH renaming

It has been noted in #1658 

And I corrected a small thing in the condition to raise a warning for 2 contiguous residues with the same residue number.