### PR TITLE
don't allow non-sorted or non-unique indices in atom_slice

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -373,8 +373,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     #order to have an easier function later on
     if isinstance(filename_or_filenames, string_types):
         filename_or_filenames = [filename_or_filenames]
-    
-    
+
+
     extensions = [_get_extension(f) for f in filename_or_filenames]
     extension = extensions[0]
     #Make the needed checks
@@ -427,7 +427,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         #TODO make all the loaders accept a pre parsed topology (top) in order to avoid
         #this part and have a more consistent interface and a faster load function
         t = loader(tmp_file, **kwargs)
-        
+
     except TypeError as e:
 
         #Don't want to intercept legit
@@ -468,7 +468,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         # Little monkey-patch to prevent further subsetting Topologies
         # this modified version of the topology will never exit this function
         kwargs['top'].subset = lambda atom_indices : subset_topology
-        
+
 
 
     # We know the topology is equal because we send the same topology
@@ -479,7 +479,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     # files to be read in without using ridiculous amounts of memory.
     for f in filename_or_filenames:
         t = loader(f, **kwargs)
-        
+
         t.topology = None
         trajectories.append(t)
 
@@ -1800,7 +1800,12 @@ class Trajectory(object):
         --------
         stack : stack multiple trajectories along the atom axis
         """
-        xyz = np.array(self.xyz[:, atom_indices], order='C')
+        indices = np.unique(np.array(atom_indices))
+        if (len(indices) != len(atom_indices) or
+            np.not_equal(indices, atom_indices).any()):
+            s = "Atom indices were made unique and sorted before atom slicing"
+            warnings.warn(s, UserWarning)
+        xyz = np.array(self.xyz[:, indices], order='C')
         topology = None
         if self._topology is not None:
             topology = self._topology.subset(atom_indices)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -563,10 +563,10 @@ def test_iterload_chunk_dcd(get_fn):
 
     full = md.load(file, top=top, stride=skip_frames)
     length = len(full)
-    
+
 
     chunks = []
-    for traj_chunk in md.iterload(file, top=top, stride=skip_frames, chunk=frames_chunk):        
+    for traj_chunk in md.iterload(file, top=top, stride=skip_frames, chunk=frames_chunk):
         chunks.append(traj_chunk)
     joined = md.join(chunks)
     assert len(full) == len(joined)
@@ -756,3 +756,13 @@ def test_add_remove_atoms(get_fn):
     roundtrip_atoms = list(top.atoms)[:]
     # Ensure the atoms are the same after a round trip of adding / deleting
     assert old_atoms == roundtrip_atoms
+
+
+@pytest.mark.parametrize("indices", [[2, 1, 0], [0, 1, 2, 2]])
+def test_non_continious_atom_slice(indices, get_fn):
+    pdb = md.load(get_fn('native2.pdb'), no_boxchk=True)
+    pdb_slice0 = pdb.atom_slice([0, 1, 2])
+    with pytest.warns(UserWarning, match="Atom indices"):
+        pdb_slice1 = pdb.atom_slice(indices)
+    assert (pdb_slice0.xyz == pdb_slice1.xyz).all()
+    assert list(pdb_slice0.topology.atoms) == list(pdb_slice1.topology.atoms)


### PR DESCRIPTION
closes #1664 

I could not think of a trivial to fix on the `topology` side. A couple things that needed to be taken into account:

1. What happens if atom [0,1] belong to residue 0 and atom [2] to residue 1? Should the residue order also be changed? (This can lead to broken protein chains, and what to do if [0,1] are residue 0, [2,3] are residue 1 and a user ask for a [0,2,1,3] slice?)
2. Same as 1. but with different chains

I don't have the bandwidth to carefully fix this on the topology side, but I did implement a quick fix by not allowing `non-sorted` slicing of the `xyz`. This is now fixed auto-magically with a warning ( by using `np.unique(np.array(indices)`).  It also fixes and warns if you try to slice with a non-unique set of indices `pdb.atom_slice([0,1,2,2])` (which used to raise an error form deep inside the code due to a mismatch in expected xyz shape and the real one) . 

I also added the issue as a test

@mizimmer90 would this behavior (fixing the xyz instead of the topology) be enough to solve your issue? 
