### PR TITLE
New OpenMM imports

### DIFF
--- a/mdtraj/reporters/basereporter.py
+++ b/mdtraj/reporters/basereporter.py
@@ -39,14 +39,19 @@ import numpy as np
 
 try:
     # openmm
-    import simtk.unit as units
-    import simtk.openmm as mm
+    import openmm.unit as units
+    import openmm as mm
     OPENMM_IMPORTED = True
 except ImportError:
-    # if someone tries to import all of mdtraj but doesn't
-    # OpenMM installed, we don't want that to choke. It should
-    # only choke if they actually try to USE the reporter
-    OPENMM_IMPORTED = False
+    try:
+        import simtk.unit as units
+        import simtk.openmm as mm
+        OPENMM_IMPORTED = True
+    except ImportError:
+        # if someone tries to import all of mdtraj but doesn't
+        # OpenMM installed, we don't want that to choke. It should
+        # only choke if they actually try to USE the reporter
+        OPENMM_IMPORTED = False
 
 ##############################################################################
 # Classes

--- a/mdtraj/utils/delay_import.py
+++ b/mdtraj/utils/delay_import.py
@@ -146,6 +146,24 @@ MESSAGES = {
 # functions
 ##############################################################################
 
+def _chain_import(modules):
+    """Return the first of ``modules`` that can be imported.
+    """
+    error = None
+    for module in modules:
+        try:
+            return importlib.import_module(module)
+        except ImportError as e:
+            error = e  # keep it in the outer scope
+    # if nothing could be imported, raise the last error generated
+    raise error
+
+_MODULE_SYNONYMS = {
+    'simtk.unit': ['openmm.unit', 'simtk.unit'],
+    'simtk.openmm': ['openmm', 'simtk.openmm'],
+    'simtk.openmm.app': ['openmm.app', 'simtk.openmm.app'],
+}
+
 def import_(module):
     """Import a module, and issue a nice message to stderr if the module isn't installed.
 
@@ -171,8 +189,9 @@ def import_(module):
     >>> import tables
     >>> tables = import_('tables')
     """
+    modules = _MODULE_SYNONYMS.get(module, [module])
     try:
-        return importlib.import_module(module)
+        return _chain_import(modules)
     except ImportError as e:
         try:
             message = MESSAGES[module]

--- a/mdtraj/utils/unit/__init__.py
+++ b/mdtraj/utils/unit/__init__.py
@@ -38,9 +38,12 @@ from mdtraj.utils.unit import unit_definitions
 from mdtraj.utils import import_, six
 UNIT_DEFINITIONS = unit_definitions
 try:
-    import simtk.unit as simtk_unit
+    import openmm.unit as simtk_unit
 except ImportError:
-    pass
+    try:
+        import simtk.unit as simtk_unit
+    except ImportError:
+        pass
 
 __all__ = ['in_units_of']
 


### PR DESCRIPTION
Starting in OpenMM 7.6, currently available as a release candidate, the `simtk` namespace is deprecated. This PR makes it so that the new import names (`openmm`, `openmm.app`, and `openmm.unit`) are the first ones tried, while the old names in the `simtk` namespace are used as backups if the new names fail.

I haven't thoroughly tested the changes to `import_` yet, but I have checked that I can at least import MDTraj in both an OpenMM 7.6 environment and an OpenMM 7.5 environment, and I don't see the warning about the import name changing when I do that import in 7.6.