### PR TITLE
Add atom selection via `atom_indices` to SASA computation, tests added

### DIFF
--- a/mdtraj/geometry/include/sasa.h
+++ b/mdtraj/geometry/include/sasa.h
@@ -6,7 +6,7 @@ extern "C" {
 
 void sasa(const int n_frames, const int n_atoms, const float* xyzlist,
           const float* atom_radii, const int n_sphere_points,
-          const int* atom_mapping, const int n_groups, float* out);
+          const int* atom_mapping, const int* atom_selection_mask, const int n_groups, float* out);
 
 
 #ifdef __cplusplus

--- a/mdtraj/geometry/src/_geometry.pyx
+++ b/mdtraj/geometry/src/_geometry.pyx
@@ -86,7 +86,7 @@ cdef extern from "geometry.h" nogil:
 cdef extern from "sasa.h":
     void sasa(const int n_frames, const int n_atoms, const float* xyzlist,
               const float* atom_radii, const int n_sphere_points,
-              const int* atom_mapping, const int n_groups, float* out) nogil
+              const int* atom_mapping, const int* atom_selection, const int n_groups, float* out) nogil
 
 
 ##############################################################################
@@ -228,11 +228,12 @@ def _sasa(float[:, :, ::1] xyz,
           float[::1] atom_radii,
           int n_sphere_points,
           int[::1] atom_outmapping,
+          int[::1] atom_selection_mask,
           float[:, ::1] out):
     cdef int n_frames = xyz.shape[0]
     cdef int n_atoms = xyz.shape[1]
     sasa(n_frames, n_atoms, &xyz[0,0,0], &atom_radii[0], n_sphere_points,
-         &atom_outmapping[0], out.shape[1], &out[0,0])
+         &atom_outmapping[0], &atom_selection_mask[0], out.shape[1], &out[0,0])
 
 
 def _dssp(float[:, :, ::1] xyz,

--- a/tests/test_sasa.py
+++ b/tests/test_sasa.py
@@ -149,3 +149,29 @@ def test_sasa_5():
     np.testing.assert_approx_equal(calc_area_sulfur, true_area_sulfur)
     # Finally, ensure that we are not changing _ATOMIC_RADII
     assert prev_area_chlorine != calc_area_chlorine
+
+def test_sasa_6(get_fn):
+    #Test the atom selection
+    t = md.load(get_fn('frame0.h5'))
+    atoms_resid1 = t.top.select("resid 1").astype(int)
+    atoms_resid0_2 = t.top.select("resid 0 2").astype(int)
+
+    # Mode="atom"
+    sasa_all_atoms = md.geometry.shrake_rupley(t)
+    sasa_all_atoms_w_selection = md.geometry.shrake_rupley(t, atom_indices=atoms_resid1)
+
+    # The computed SASA values are the same as in "normal" mode
+    np.testing.assert_array_almost_equal(sasa_all_atoms[:,atoms_resid1],
+                                         sasa_all_atoms_w_selection[:,atoms_resid1])
+    # The uncomputed SASA values are all NaN
+    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid0_2]),0)
+
+    # Mode="residues"
+    sasa_all_residues = md.geometry.shrake_rupley(t, mode="residue")
+    sasa_all_residues_w_selection = md.geometry.shrake_rupley(t, atom_indices=atoms_resid1, mode="residue")
+
+    # The computed SASA values are the same as in "normal" mode
+    np.testing.assert_array_almost_equal(sasa_all_residues[:,1],
+                                         sasa_all_residues_w_selection[:,1])
+    # The uncomputed SASA values are all NaN
+    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, [0,2]]), 0)


### PR DESCRIPTION
Limit the SASA computation to some atoms of interest via `atom_indices` when calling `md.shrake_rupley`

The excluded atoms are still considered as potential surface accessibility blockers, but their own SASA doesn't get computed and gets set to zero instead. 

This is particularly helpful for membrane-embedded proteins where you want the lipids "there" but you don't really care about their SASA.