### PR TITLE
pin numpy in pyproject.toml for python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,6 @@ requires = [
     "numpy==1.17.5; python_version=='3.8'",
     "numpy==1.19.5; python_version=='3.9'",
     "numpy==1.21.3; python_version=='3.10'",
-    "numpy; python_version=='3.11'",
+    "numpy; python_version>='3.11'",
     "Cython>0.28",
 ]


### PR DESCRIPTION
[numpy released a wheel for python 3.10](https://github.com/numpy/numpy/releases/tag/v1.21.3) (v1.21.3)
this pins numpy for python==`3.10` as follow up to #1619  this should now prevent issues until python `3.11` or `4.0`

However, mdtraj currently does not build in python `3.10`, gcc errors with 
```
      133 | #define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))
          |                                                          ^
    mdtraj/geometry/drid.cpp:17366:7: note: in expansion of macro ‘Py_REFCNT’
    17366 |     ++Py_REFCNT(o);
          |       ^~~~~~~~~
    /home/sroet/miniconda3/envs/py310/include/python3.10/object.h:133:58: error: lvalue required as decrement operand
      133 | #define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))
          |                                                          ^
    mdtraj/geometry/drid.cpp:17368:7: note: in expansion of macro ‘Py_REFCNT’
    17368 |     --Py_REFCNT(o);
          |       ^~~~~~~~~
    mdtraj/geometry/drid.cpp: In function ‘void __pyx_tp_dealloc__memoryviewslice(PyObject*)’:
    /home/sroet/miniconda3/envs/py310/include/python3.10/object.h:133:58: error: lvalue required as increment operand
      133 | #define Py_REFCNT(ob) _Py_REFCNT(_PyObject_CAST_CONST(ob))
          |                                                          ^
    mdtraj/geometry/drid.cpp:17616:7: note: in expansion of macro ‘Py_REFCNT’
    17616 |     ++Py_REFCNT(o);
          |       ^~~~~~~~~
    /home/sroet/miniconda3/envs/py310/include/python3.10/object.h:133:58: error: lvalue required as decrement operand
```

It also warns about using deprecated cpython from unicodeobject.h
```
   /home/sroet/miniconda3/envs/py310/include/python3.10/cpython/unicodeobject.h:451:75: warning: ‘Py_ssize_t _PyUnicode_get_wstr_length(PyObject*)’ is deprecated [-Wdeprecated-declarations]
      451 | #define PyUnicode_WSTR_LENGTH(op) _PyUnicode_get_wstr_length((PyObject*)op)
          |                                                                           ^
    /home/sroet/miniconda3/envs/py310/include/python3.10/cpython/unicodeobject.h:261:7: note: in expansion of macro ‘PyUnicode_WSTR_LENGTH’
      261 |       PyUnicode_WSTR_LENGTH(op) :                    \
          |       ^~~~~~~~~~~~~~~~~~~~~
    mdtraj/geometry/drid.cpp:18967:26: note: in expansion of macro ‘PyUnicode_GET_SIZE’
    18967 |                         (PyUnicode_GET_SIZE(**argname) != PyUnicode_GET_SIZE(key)) ? 1 :
          |                          ^~~~~~~~~~~~~~~~~~
    /home/sroet/miniconda3/envs/py310/include/python3.10/cpython/unicodeobject.h:446:26: note: declared here
      446 | static inline Py_ssize_t _PyUnicode_get_wstr_length(PyObject *op) {
          |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
```

I will open an issue to keep track of those