### PR TITLE
[ci] Bump OS versions on github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,20 +13,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-         - py: "python37"
-           nixpkgs: "channel:nixos-20.09"
+         #- py: "python37"
+         #  nixpkgs: "channel:nixos-20.09"
          - py: "python38"
-           nixpkgs: "https://github.com/NixOS/nixpkgs/archive/54c1e44240d8a527a8f4892608c4bce5440c3ecb.tar.gz"
-         #- py: "python39"
-         #  nixpkgs: "https://github.com/NixOS/nixpkgs/archive/54c1e44240d8a527a8f4892608c4bce5440c3ecb.tar.gz"
+           nixpkgs: "channel:nixos-21.05"
+         - py: "python39"
+           nixpkgs: "channel:nixos-21.05"
 
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v14.1
       with:
         nix_path: nixpkgs=${{ matrix.nixpkgs }}
-    - uses: cachix/cachix-action@v8
+    - uses: cachix/cachix-action@v10
       with:
         name: nixpkgs-review-bot
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master'
     steps:
-    - uses: cachix/install-nix-action@v13
+    - uses: cachix/install-nix-action@v14.1
       with:
         nix_path: channel:nixos-20.09
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
Change test matrix to python38 and python39 rather than python37 and python38.