### PR TITLE
[Tests] Fix code for running jupyter notebooks to work with latest vesions of jupyter

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -74,10 +74,9 @@ def run_notebook(nb):
     km.start_kernel(stderr=open(os.devnull, 'w'))
     kc = km.client()
     kc.start_channels()
-    shell = kc.shell_channel
     # simple ping:
     kc.execute("pass")
-    shell.get_msg()
+    kc.get_shell_msg()
 
     failures = 0
     for cell in nb.cells:
@@ -86,7 +85,7 @@ def run_notebook(nb):
         kc.execute(cell.source)
         try:
             # wait for finish, w/ timeout
-            reply = shell.get_msg(timeout=TIMEOUT)['content']
+            reply = kc.get_shell_msg(timeout=TIMEOUT)['content']
         except Empty:
             raise Exception(
                 'Timeout (%.1f) when executing the following %s cell: "%s"' %


### PR DESCRIPTION
When looking into #1683 I got hit with a bunch of:
```
________________________________ test_example_notebook[rmsd-drift.ipynb] ________________________________

example_fn = 'rmsd-drift.ipynb'

    def test_example_notebook(example_fn):
        with open(example_fn) as f:
            nb = nbformat.reads(f.read(), nbformat.NO_CONVERT)
>       run_notebook(nb)

/home/sander/github_files/mdtraj/examples/test_examples.py:69: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

nb = {'cells': [{'cell_type': 'code', 'execution_count': None, 'metadata': {}, 'outputs': [], 'source': 'from __future__ im...'nbconvert_exporter': 'python', 'pygments_lexer': 'ipython3', 'version': '3.5.2'}}, 'nbformat': 4, 'nbformat_minor': 1}

    def run_notebook(nb):
        km = KernelManager()
        km.start_kernel(stderr=open(os.devnull, 'w'))
        kc = km.client()
        kc.start_channels()
        shell = kc.shell_channel
        # simple ping:
        kc.execute("pass")
        shell.get_msg()
    
        failures = 0
        for cell in nb.cells:
            if cell.cell_type != 'code':
                continue
            kc.execute(cell.source)
            try:
                # wait for finish, w/ timeout
>               reply = shell.get_msg(timeout=TIMEOUT)['content']
E               TypeError: 'coroutine' object is not subscriptable

/home/sander/github_files/mdtraj/examples/test_examples.py:89: TypeError
```
From the [migration guide to jupyter-client 7.0](https://jupyter-client.readthedocs.io/en/latest/migration.html#zmqsocketchannel)  it seems that this is not the preferred way of interacting with the shell anymore as it has the note:
> Prefer calling e.g. client.get_shell_msg() over client.shell_channel.get_msg().

Which now allows me to run the complete test-suite :D 

I could not quickly find when these functions were introduced, but as jupyter-client 7 is available for all python3 version and only used in testing, I assumed I don't have to write code to catch old versions