### PR TITLE
[WIP] enable py310 tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
          - py: "python39"
            nixpkgs: "channel:nixos-21.05"
          - py: "python310"
-           nixpkgs: "channel:nixos-21.05"
+           nixpkgs: "channel:nixos-unstable"
 
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,9 @@ jobs:
            nixpkgs: "channel:nixos-21.05"
          - py: "python39"
            nixpkgs: "channel:nixos-21.05"
+         - py: "python310"
+           nixpkgs: "channel:nixos-21.05"
+
 
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This will be my attempt to enable python 3.10 tests, never dealt with nixos before, but seems like a fun thing to try. 

The only package that is not pip installable at the moment is `tables`