### PR TITLE
port openmm.unit 

### DIFF
--- a/mdtraj/utils/unit/__init__.py
+++ b/mdtraj/utils/unit/__init__.py
@@ -37,13 +37,11 @@ from mdtraj.utils.unit.quantity import Quantity
 from mdtraj.utils.unit import unit_definitions
 from mdtraj.utils import import_, six
 UNIT_DEFINITIONS = unit_definitions
+
 try:
-    import openmm.unit as simtk_unit
+    import openmm.unit as openmm_unit
 except ImportError:
-    try:
-        import simtk.unit as simtk_unit
-    except ImportError:
-        pass
+    pass
 
 __all__ = ['in_units_of']
 
@@ -79,7 +77,7 @@ class _UnitContext(ast.NodeTransformer):
 _unit_context = _UnitContext()  # global instance of the visitor
 
 
-def _str_to_unit(unit_string, simtk=False):
+def _str_to_unit(unit_string, openmm=False):
     """eval() based transformer that extracts a openmm.unit object
     from a string description.
 
@@ -104,8 +102,8 @@ def _str_to_unit(unit_string, simtk=False):
 
     assert isinstance(unit_string, six.string_types)
     unit_definitions = UNIT_DEFINITIONS
-    if simtk:
-        unit_definitions = import_('simtk.unit').unit_definitions
+    if openmm:
+        unit_definitions = openmm_unit.unit_definitions
     parsed = ast.parse(unit_string, mode='eval')
     node = _unit_context.visit(parsed)
     fixed_node = ast.fix_missing_locations(node)
@@ -150,10 +148,10 @@ def in_units_of(quantity, units_in, units_out, inplace=False):
     if quantity is None:
         return quantity
 
-    if (('simtk.unit' in sys.modules or 'openmm.unit' in sys.modules) and
-        isinstance(quantity, simtk_unit.Quantity)):
+    if ('openmm.unit' in sys.modules and
+        isinstance(quantity, openmm_unit.Quantity)):
         units_in = quantity.unit
-        units_out = _str_to_unit(units_out, simtk=True)
+        units_out = _str_to_unit(units_out, openmm=True)
         quantity = quantity._value
     elif isinstance(quantity, Quantity):
         units_in = quantity.unit

--- a/mdtraj/utils/unit/__init__.py
+++ b/mdtraj/utils/unit/__init__.py
@@ -21,8 +21,8 @@
 ##############################################################################
 """
 
-Unit processing for MDTraj. This subpackage is a port of simtk.unit from
-OpenMM. Unlike in simtk.openmm, the MDTraj library **does not pass around
+Unit processing for MDTraj. This subpackage is a port of openmm.unit from
+OpenMM. Unlike in openmm, the MDTraj library **does not pass around
 "united quantities"**
 
 The only publicly facing API from this package, for the purpose of MDTraj,
@@ -71,7 +71,7 @@ class _UnitContext(ast.NodeTransformer):
         if not hasattr(unit_definitions, node.id):
             # also, let's take this opporunity to check that the node.id
             # (which supposed to be the name of the unit, like "nanometers")
-            # is actually an attribute in simtk.unit
+            # is actually an attribute in openmm.unit
             raise ValueError('%s is not a valid unit' % node.id)
 
         return ast.Attribute(value=ast.Name(id='unit_definitions', ctx=ast.Load()),
@@ -80,7 +80,7 @@ _unit_context = _UnitContext()  # global instance of the visitor
 
 
 def _str_to_unit(unit_string, simtk=False):
-    """eval() based transformer that extracts a simtk.unit object
+    """eval() based transformer that extracts a openmm.unit object
     from a string description.
 
     Parameters
@@ -92,7 +92,7 @@ def _str_to_unit(unit_string, simtk=False):
     Examples
     --------
     >>> type(_str_to_unit('nanometers**2/meters*gigajoules'))
-    <class 'simtk.unit.unit.Unit'>
+    <class 'openmm.unit.unit.Unit'>
     >>> str(_str_to_unit('nanometers**2/meters*gigajoules'))
     'nanometer**2*gigajoule/meter'
 
@@ -118,11 +118,11 @@ def in_units_of(quantity, units_in, units_out, inplace=False):
 
     Parameters
     ----------
-    quantity : {number, np.ndarray, simtk.unit.Quantity}
+    quantity : {number, np.ndarray, openmm.unit.Quantity}
         quantity can either be a unitted quantity -- i.e. instance of
-        simtk.unit.Quantity, or just a bare number or numpy array
+        openmm.unit.Quantity, or just a bare number or numpy array
     units_in : str
-        If you supply a quantity that's not a simtk.unit.Quantity, you should
+        If you supply a quantity that's not a openmm.unit.Quantity, you should
         tell me what units it is in. If you don't, i'm just going to echo you
         back your quantity without doing any unit checking.
     units_out : str
@@ -150,7 +150,8 @@ def in_units_of(quantity, units_in, units_out, inplace=False):
     if quantity is None:
         return quantity
 
-    if 'simtk.unit' in sys.modules and isinstance(quantity, simtk_unit.Quantity):
+    if (('simtk.unit' in sys.modules or 'openmm.unit' in sys.modules) and
+        isinstance(quantity, simtk_unit.Quantity):
         units_in = quantity.unit
         units_out = _str_to_unit(units_out, simtk=True)
         quantity = quantity._value

--- a/mdtraj/utils/unit/__init__.py
+++ b/mdtraj/utils/unit/__init__.py
@@ -151,7 +151,7 @@ def in_units_of(quantity, units_in, units_out, inplace=False):
         return quantity
 
     if (('simtk.unit' in sys.modules or 'openmm.unit' in sys.modules) and
-        isinstance(quantity, simtk_unit.Quantity):
+        isinstance(quantity, simtk_unit.Quantity)):
         units_in = quantity.unit
         units_out = _str_to_unit(units_out, simtk=True)
         quantity = quantity._value

--- a/mdtraj/utils/unit/basedimension.py
+++ b/mdtraj/utils/unit/basedimension.py
@@ -1,5 +1,6 @@
+#!/bin/env python
 """
-Module simtk.unit.basedimension
+Module openmm.unit.basedimension
 
 BaseDimension class for use by units and quantities.
 BaseDimensions are things like "length" and "mass".
@@ -13,7 +14,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -31,6 +32,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import print_function, division
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"
@@ -39,7 +41,7 @@ __version__ = "0.6"
 class BaseDimension(object):
     '''
     A physical dimension such as length, mass, or temperature.
-    
+
     It is unlikely the user will need to create new ones.
     '''
     # Keep deterministic order of dimensions
@@ -54,30 +56,38 @@ class BaseDimension(object):
         'angle': 8,
     }
     _next_unused_index = 9
-    
+
     def __init__(self, name):
         """Create a new BaseDimension.
 
         Each new BaseDimension is assumed to be independent of all other BaseDimensions.
-        Use the existing BaseDimensions in simtk.dimension instead of creating
-        new ones.
+        Use the existing BaseDimensions instead of creating new ones.
         """
         self.name = name
         if not self.name in BaseDimension._index_by_name.keys():
             BaseDimension._index_by_name[name] = BaseDimension._next_unused_index
             BaseDimension._next_unused_index += 1
         self._index = BaseDimension._index_by_name[name]
-        
+
     def __lt__(self, other):
         """
         The implicit order of BaseDimensions is the order in which they were created.
         This method is used for using BaseDimensions as hash keys, and also affects
         the order in which units appear in multi-dimensional Quantities.
-        
+
         Returns True if self < other, False otherwise.
         """
         return self._index < other._index
-        
+
+    def __le__(self, other):
+        return self._index <= other._index
+
+    def __gt__(self, other):
+        return self._index > other._index
+
+    def __ge__(self, other):
+        return self._index >= other._index
+
     def __hash__(self):
         """
         Needed for using BaseDimensions as hash keys.
@@ -86,8 +96,19 @@ class BaseDimension(object):
 
     def __repr__(self):
         return 'BaseDimension("%s")' % self.name
+    
+    def __eq__(self, other):
+        if isinstance(other, BaseDimension):
+            return self._index == other._index
+        return False
+    
+    def __ne__(self, other):
+        if isinstance(other, BaseDimension):
+            return self._index != other._index
+        return False
 
 
+# run module directly for testing
 if __name__=='__main__':
     # Test the examples in the docstrings
     import doctest, sys

--- a/mdtraj/utils/unit/baseunit.py
+++ b/mdtraj/utils/unit/baseunit.py
@@ -1,5 +1,8 @@
+#!/bin/env python
+
+
 """
-Module simtk.unit.baseunit
+Module openmm.unit.baseunit
 
 Contains BaseUnit class, which is a component of the Unit class.
 
@@ -12,7 +15,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -30,6 +33,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import print_function, division, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"
@@ -37,14 +41,15 @@ __version__ = "0.6"
 class BaseUnit(object):
     '''
     Physical unit expressed in exactly one BaseDimension.
-    
+
     For example, meter_base_unit could be a BaseUnit for the length dimension.
     The BaseUnit class is used internally in the more general Unit class.
     '''
+    __array_priority__ = 100
 
     def __init__(self, base_dim, name, symbol):
         """Creates a new BaseUnit.
-        
+
         Parameters
          - self: The newly created BaseUnit.
          - base_dim: (BaseDimension) The dimension of the new unit, e.g. 'mass'
@@ -59,7 +64,7 @@ class BaseUnit(object):
         self._conversion_factor_to[self] = 1.0
         self._conversion_factor_to_by_name = {}
         self._conversion_factor_to_by_name[self.name] = 1.0
-    
+
     def __lt__(self, other):
         """
         Comparison function that sorts BaseUnits by BaseDimension
@@ -75,10 +80,10 @@ class BaseUnit(object):
         Returns a dictionary of BaseDimension:exponent pairs, describing the dimension of this unit.
         """
         yield (self.dimension, 1)
-        
+
     def iter_base_units(self):
         yield (self, 1)
-        
+
     def get_dimension_tuple(self):
         """
         Returns a sorted tuple of (BaseDimension, exponent) pairs, that can be used as a dictionary key.
@@ -86,7 +91,7 @@ class BaseUnit(object):
         l = list(self.iter_base_dimensions())
         l.sort()
         return tuple(l)
-        
+
     def __str__(self):
         """Returns a string with the name of this BaseUnit
         """
@@ -94,52 +99,48 @@ class BaseUnit(object):
 
     def __repr__(self):
         return 'BaseUnit(base_dim=%s, name="%s", symbol="%s")' % (self.dimension, self.name, self.symbol)
-        
+
     def define_conversion_factor_to(self, other, factor):
         """
         Defines a conversion factor between two BaseUnits.
-        
+
         self * factor = other
-        
+
         Parameters:
          - self: (BaseUnit) 'From' unit in conversion.
          - other: (BaseUnit) 'To' unit in conversion.
          - factor: (float) Conversion factor.
-        
+
         After calling this method, both self and other will have stored
         conversion factors for one another, plus all other BaseUnits which
         self and other have previously defined.
-        
+
         Both self and other must have the same dimension, otherwise a TypeError
         will be raised.
-        
+
         Returns None.
         """
         if self.dimension != other.dimension:
             raise TypeError('Cannot define conversion for BaseUnits with different dimensions.')
         assert(factor != 0)
-        assert(not self is other)        
+        assert(not self is other)
         # import all transitive conversions
         self._conversion_factor_to[other] = factor
         self._conversion_factor_to_by_name[other.name] = factor
         for (unit, cfac) in other._conversion_factor_to.items():
-            if unit is self:
-                continue
-            if unit in self._conversion_factor_to:
-                continue
-            self._conversion_factor_to[unit] = factor * cfac                
+            if unit is self: continue
+            if unit in self._conversion_factor_to: continue
+            self._conversion_factor_to[unit] = factor * cfac
             unit._conversion_factor_to[self] = pow(factor * cfac, -1)
-            self._conversion_factor_to_by_name[unit.name] = factor * cfac                
+            self._conversion_factor_to_by_name[unit.name] = factor * cfac
             unit._conversion_factor_to_by_name[self.name] = pow(factor * cfac, -1)
         # and for the other guy
         invFac = pow(factor, -1.0)
         other._conversion_factor_to[self] = invFac
         other._conversion_factor_to_by_name[self.name] = invFac
         for (unit, cfac) in self._conversion_factor_to.items():
-            if unit is other:
-                continue
-            if unit in other._conversion_factor_to:
-                continue
+            if unit is other: continue
+            if unit in other._conversion_factor_to: continue
             other._conversion_factor_to[unit] = invFac * cfac
             unit._conversion_factor_to[other] = pow(invFac * cfac, -1)
             other._conversion_factor_to_by_name[unit.name] = invFac * cfac
@@ -147,13 +148,13 @@ class BaseUnit(object):
 
     def conversion_factor_to(self, other):
         """Returns a conversion factor from this BaseUnit to another BaseUnit.
-        
+
         It does not matter which existing BaseUnit you define the conversion factor to.
         Conversions for all other known BaseUnits will be computed at the same time.
-        
+
         Raises TypeError if dimension does not match.
         Raises LookupError if no conversion has been defined. (see define_conversion_factor_to).
-        
+
         """
         if self is other: return 1.0
         if self.dimension != other.dimension:

--- a/mdtraj/utils/unit/constants.py
+++ b/mdtraj/utils/unit/constants.py
@@ -1,17 +1,17 @@
 #!/bin/env python
 """
-Module simtk.unit.constants
+Module openmm.unit.constants
 
 This is part of the OpenMM molecular simulation toolkit originating from
 Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2012 Stanford University and the Authors.
+Portions copyright (c) 2012-2020 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -29,8 +29,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-
-from __future__ import division
+from __future__ import print_function, division, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.5"
@@ -41,14 +40,12 @@ from .unit_definitions import *
 ### CONSTANTS ###
 #################
 
-# codata 2006
-AVOGADRO_CONSTANT_NA = 6.02214179e23 / mole
-BOLTZMANN_CONSTANT_kB = 1.3806504e-23 * joule / kelvin
+# codata 2018
+AVOGADRO_CONSTANT_NA = 6.02214076e23 / mole
+BOLTZMANN_CONSTANT_kB = 1.380649e-23 * joule / kelvin
 MOLAR_GAS_CONSTANT_R = AVOGADRO_CONSTANT_NA * BOLTZMANN_CONSTANT_kB
-
-# From simtkcommon
 SPEED_OF_LIGHT_C = 2.99792458e8 * meter / second
-GRAVITATIONAL_CONSTANT_G = 6.6742e-11 * newton * meter**2 / kilogram**2
+GRAVITATIONAL_CONSTANT_G = 6.6743e-11 * newton * meter**2 / kilogram**2
 
 # run module directly for testing
 if __name__=='__main__':

--- a/mdtraj/utils/unit/doctests.py
+++ b/mdtraj/utils/unit/doctests.py
@@ -1,5 +1,7 @@
+#!/bin/env python
+
 """
-Module simtk.unit.doctests
+Module openmm.unit.doctests
 
 Lots of in-place doctests would no longer work after I rearranged
 so that specific unit definitions are defined late.  So those tests
@@ -15,7 +17,7 @@ Examples
 >>> furlong_base_unit.define_conversion_factor_to(meter_base_unit, 201.16800)
 >>> furlong_base_unit.conversion_factor_to(angstrom_base_unit)
 2011680000000.0
-        
+
 Examples
 
 >>> furlong_base_unit = BaseUnit(length_dimension, "furlong", "fur")
@@ -30,7 +32,7 @@ from unit.is_unit
 True
 >>> is_unit(5*meter)
 False
-    
+
 >>> c = 1.0*calories
 >>> c
 Quantity(value=1.0, unit=calorie)
@@ -39,12 +41,12 @@ Quantity(value=1.0, unit=calorie)
 >>> print(joule.conversion_factor_to(calorie))
 0.239005736138
 >>> c.in_units_of(joules)
-Quantity(value=4.1840000000000002, unit=joule)
+Quantity(value=4.184, unit=joule)
 >>> j = 1.0*joules
 >>> j
 Quantity(value=1.0, unit=joule)
 >>> j.in_units_of(calories)
-Quantity(value=0.23900573613766729, unit=calorie)
+Quantity(value=0.2390057361376673, unit=calorie)
 >>> j/joules
 1.0
 >>> print(j/calories)
@@ -56,7 +58,7 @@ Quantity(value=0.23900573613766729, unit=calorie)
 >>> c**2
 Quantity(value=1.0, unit=calorie**2)
 >>> (c**2).in_units_of(joule*joule)
-Quantity(value=17.505856000000001, unit=joule**2)
+Quantity(value=17.505856, unit=joule**2)
 
 >>> ScaledUnit(1000.0, kelvin, "kilokelvin", "kK")
 ScaledUnit(factor=1000.0, master=kelvin, name='kilokelvin', symbol='kK')
@@ -164,7 +166,7 @@ Examples
 
 >>> meter.is_compatible(centimeter)
 True
->>> meter.is_compatible(meter)     
+>>> meter.is_compatible(meter)
 True
 >>> meter.is_compatible(kelvin)
 False
@@ -250,29 +252,29 @@ Collections of numbers can also be used as values.
 >>> print(s4)
 ((1, 2, 3), (4, 5, 6)) cm
 >>> print(s4 / millimeters)
-[(10.0, 20.0, 30.0), (40.0, 50.0, 60.0)]
+((10.0, 20.0, 30.0), (40.0, 50.0, 60.0))
 >>> t = (1,2,3) * centimeters
 >>> print(t)
 (1, 2, 3) cm
 >>> print(t / millimeters)
-[10.0, 20.0, 30.0]
+(10.0, 20.0, 30.0)
 
 Numpy examples are commented out because not all systems have numpy installed
 # >>> import numpy
-# >>> 
+# >>>
 # >>> a = Quantity(numpy.array([1,2,3]), centimeters)
 # >>> print(a)
 # [1 2 3] cm
 # >>> print(a / millimeters)
 # [ 10.  20.  30.]
-# >>> 
+# >>>
 # >>> a2 = Quantity(numpy.array([[1,2,3],[4,5,6]]), centimeters)
 # >>> print(a2)
 # [[1 2 3]
 #  [4 5 6]] cm
 # >>> print(a2 / millimeters)
 # [[ 10.  20.  30.]
-#  [ 40.  50.  60.]]     
+#  [ 40.  50.  60.]]
 
 Addition, subtraction, multiplication, division, and powers of Quantities
 exhibit correct dimensional analysis and unit conversion.
@@ -291,12 +293,12 @@ The following examples are derived from the C++ Boost.Units examples at
 http://www.boost.org/doc/libs/1_37_0/doc/html/boost_units/Examples.html
 >>>
 >>> l = 2.0 * meters
->>> 
+>>>
 >>> print(l + 2.0 * nanometers)
 2.000000002 m
 >>> print(2.0 * nanometers + l)
 2000000002.0 nm
->>> 
+>>>
 >>> print(l)
 2.0 m
 >>> print(l+l)
@@ -408,25 +410,25 @@ True
 False
 >>> print(l1 > l2)
 False
->>> 
+>>>
 >>> def work(f, dx):
 ...   return f * dx
-... 
+...
 >>> F = 1.0 * kilogram * meter / second**2
 >>> dx = 1.0 * meter
 >>> E = work(F, dx)
->>> 
+>>>
 >>> print("F = ", F)
 F =  1.0 kg m/(s**2)
 >>> print("dx = ", dx)
 dx =  1.0 m
->>> 
+>>>
 >>> def idealGasLaw(P, V, T):
 ...     R = MOLAR_GAS_CONSTANT_R
 ...     print("P * V = ", P * V)
 ...     print("R * T = ", R * T)
 ...     return (P * V / (R * T)).in_units_of(mole)
-... 
+...
 >>> T = (273.0 + 37.0) * kelvin
 >>> P = 1.01325e5 * pascals
 >>> r = 0.5e-6 * meters
@@ -435,7 +437,7 @@ dx =  1.0 m
 P * V =  5.3053601125e-14 m**3 Pa
 R * T =  2577.48646608 J/mol
 >>> R = MOLAR_GAS_CONSTANT_R
->>> 
+>>>
 >>> print("r = ", r)
 r =  5e-07 m
 >>> print("P = ", P)
@@ -458,7 +460,7 @@ is_quantity(V) =  True
 57.2957795131 deg
 >>> print((1.0*angstroms).in_units_of(nanometers))
 0.1 nm
->>> 
+>>>
 >>> print((90*degrees)/radians)
 1.57079632679
 >>> print(sin(90*degrees))
@@ -473,7 +475,7 @@ True
 Traceback (most recent call last):
    ...
 TypeError: Unit "degree" is not compatible with Unit "nanometer".
->>> 
+>>>
 >>> x = 1.5 * nanometers
 >>> print(x / meters)
 1.5e-09
@@ -501,7 +503,7 @@ Examples
 10.0
 >>> print(x.value_in_unit_system(md_unit_system))
 100000000.0
->>> 
+>>>
 >>> y = 20 * millimeters / millisecond**2
 >>> print(y.value_in_unit_system(si_unit_system))
 20000.0
@@ -517,7 +519,7 @@ Examples
 Dimensionless quantities return their unmodified values.
 >>> Quantity(5, dimensionless).value_in_unit_system(md_unit_system)
 5
-        
+
 Examples
 
 >>> x = 2.3*meters
@@ -579,9 +581,9 @@ Examples
 >>> print(8.4 / x)
 2.0 /cm
 
-        
+
         Examples
-        
+
         >>> x = 4.3 * meters
         >>> print(x/centimeters)
         430.0
@@ -591,15 +593,15 @@ Examples
         >>> x/millimeter
         [10.0, 20.0, 30.0]
 
-        
+
         Examples
-        
+
         >>> x = 1.2*meters
         >>> print(5*x)
         6.0 m
-        
+
         Examples
-        
+
         >>> x = 1.2*meters
         >>> y = 72*centimeters
         >>> print(x*y)
@@ -618,42 +620,42 @@ Examples
         Quantity(value=2.0, unit=nanometer**2/(angstrom**2))
         >>> "%.1f" % q.reduce_unit()
         '200.0'
-        
+
         Examples
-        
+
         >>> 1.2*meters < 72*centimeters
         False
-        >>> meter != None
+        >>> meter is not None
         True
-        >>> meter == None
+        >>> meter is None
         False
-        
+
         Examples
-        
+
         >>> print(1.2 * meters - 72 * centimeters)
         0.48 m
-        
+
         Examples
-        
+
         >>> print(1.2 * meters + 72 * centimeters)
         1.92 m
-        
+
         Examples
-        
+
         >>> print(repr(1.2*meter))
         Quantity(value=1.2, unit=meter)
 
-        
+
         Examples
-        
+
         >>> print(5.0 * nanometers)
         5.0 nm
-        
+
         Examples
-        
+
         >>> Quantity(5.0, meters)
         Quantity(value=5.0, unit=meter)
-        
+
         >>> Quantity([1*angstrom,2*nanometer,3*angstrom])
         Quantity(value=[1, 20.0, 3], unit=angstrom)
         >>> Quantity((1,2,3))
@@ -682,14 +684,14 @@ Examples
         >>> Quantity(value=5.0, unit=100.0*meters)
         Quantity(value=500.0, unit=meter)
 
-        
+
         Examples
-        
+
         >>> x = 2.3*meters
         >>> y = x.in_units_of(centimeters)
         >>> print(y)
         230.0 cm
-        
+
         >>> x = 2.3*meters
         >>> print(x.in_units_of(centimeters))
         230.0 cm
@@ -697,9 +699,9 @@ Examples
         Traceback (most recent call last):
            ...
         TypeError: Unit "meter" is not compatible with Unit "second".
-        
+
         Examples
-        
+
         >>> x = 100.0 * millimeter
         >>> print(x)
         100.0 mm
@@ -723,22 +725,22 @@ Examples
         >>> q = 1.0 * md_kilocalorie/mole/angstrom
         >>> print(q.in_units_of(md_kilojoule/mole/nanometer))
         41.84 kJ/(nm mol)
-        
+
         Examples
-        
+
         >>> class Foo:
         ...     def bar(self):
         ...         print("bar")
-        ... 
+        ...
         >>> x = Foo()
         >>> x.bar()
         bar
         >>> y = x * nanometers
         >>> y.bar()
         bar
-    
+
     Examples
-    
+
     >>> print(meters * centimeters)
     centimeter*meter
     >>> print(meters * meters)
@@ -746,43 +748,43 @@ Examples
     >>> print(meter * meter )
     meter**2
 
-    
+
     Examples
-    
+
     >>> print(meter / 2)
     0.5 m
-     
+
     Examples
-     
+
     >>> define_prefixed_units(kelvin_base_unit, sys.modules["__main__"])
     >>> from __main__ import millikelvin
     >>> print(5.0 * millikelvin)
     5.0 mK
-    
-        
+
+
         Creating a new BaseUnit:
         >>> ms = milli * second_base_unit
         >>> ms
         BaseUnit(base_dim=BaseDimension("time"), name="millisecond", symbol="ms")
         >>> ms.conversion_factor_to(second_base_unit)
         0.001
-        
+
         Creating a new ScaledUnit:
         >>> mC = milli * ScaledUnit(4.184, joule, "calorie", "cal")
         >>> mC
-        ScaledUnit(factor=0.0041840000000000002, master=joule, name='millicalorie', symbol='mcal')
-        
+        ScaledUnit(factor=0.004184, master=joule, name='millicalorie', symbol='mcal')
+
         Creating a new Unit:
         >>> ms = milli * second
         >>> ms
         Unit({BaseUnit(base_dim=BaseDimension("time"), name="millisecond", symbol="ms"): 1.0})
-        
+
         Don't try a Quantity though:
         >>> ms = milli * (1.0 * second)
         Traceback (most recent call last):
            ...
         TypeError: Unit prefix "milli" can only be applied to a Unit, BaseUnit, or ScaledUnit.
-        
+
     Comparison of dimensionless quantities issue (fixed in svn 513)
     >>> x = Quantity(1.0, dimensionless)
     >>> y = Quantity(1.0, dimensionless)
@@ -793,7 +795,7 @@ Examples
     Formatting of Quantities
     >>> x = 5.439999999 * picosecond
     >>> x
-    Quantity(value=5.4399999990000003, unit=picosecond)
+    Quantity(value=5.439999999, unit=picosecond)
     >>> x.format("%.3f")
     '5.440 ps'
 
@@ -837,7 +839,7 @@ Examples
 # April 2010, thanks to John Chodera for reporting
     >>> try:
     ...     import numpy
-    ...     x = Quantity(numpy.array([1.,2.]), nanometer)            
+    ...     x = Quantity(numpy.array([1.,2.]), nanometer)
     ...     y = Quantity(numpy.array([3.,4.]), picosecond)
     ...     assert str(x/y) == '[ 0.33333333  0.5       ] nm/ps'
     ... except ImportError:
@@ -848,7 +850,7 @@ Examples
 # Thanks to Kyle Beauchamp July 2010
     >>> try:
     ...    import numpy
-    ...    from simtk.unit.quantity import _is_string
+    ...    from openmm.unit.quantity import _is_string
     ...    a = numpy.array([[1,2,3],[4,5,6]])
     ...    assert isinstance("", str)
     ...    assert _is_string("")

--- a/mdtraj/utils/unit/mymatrix.py
+++ b/mdtraj/utils/unit/mymatrix.py
@@ -10,7 +10,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -28,44 +28,45 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import print_function, division, absolute_import
 
 import sys
 
 def eye(size):
     """
     Returns identity matrix.
-    
+
     >>> print(eye(3))
     [[1, 0, 0]
      [0, 1, 0]
      [0, 0, 1]]
     """
     result = []
-    for row in range(0, size):
+    for row in range(size):
         r = []
-        for col in range(0, size):
+        for col in range(size):
             if row == col:
                 r.append(1)
             else:
                 r.append(0)
         result.append(r)
     return MyMatrix(result)
-    
+
 def zeros(m, n=None):
     """
     Returns matrix of zeroes
-    
+
     >>> print(zeros(3))
     [[0, 0, 0]
      [0, 0, 0]
      [0, 0, 0]]
     """
-    if n == None:
+    if n is None:
         n = m
     result = []
-    for row in range(0, m):
+    for row in range(m):
         r = []
-        for col in range(0, n):
+        for col in range(n):
             r.append(0)
         result.append(r)
     return MyMatrix(result)
@@ -82,7 +83,7 @@ class MyVector(object):
 
     def __str__(self):
         return str(self.data)
-        
+
     def __repr__(self):
         return self.__class__.__name__ + "(" + repr(self.data) + ")"
 
@@ -91,20 +92,20 @@ class MyVector(object):
 
     def __contains__(self, item):
         return item in self.data
-        
+
     def __delitem__(self, key):
         del self.data[key]
-        
+
     def __iter__(self):
         for item in self.data:
             yield item
 
     def __len__(self):
         return len(self.data)
-    
+
     def __setitem__(self, key, value):
         self.data[key] = value
-        
+
     def __rmul__(self, lhs):
         try:
             len(lhs)
@@ -119,7 +120,7 @@ class MyVector(object):
 class MyMatrix(MyVector):
     """
     Pure python linear algebra matrix for internal matrix inversion in UnitSystem.
-    
+
     >>> m = MyMatrix([[1,0,],[0,1,]])
     >>> print(m)
     [[1, 0]
@@ -158,7 +159,7 @@ class MyMatrix(MyVector):
     """
     def numRows(self):
         return len(self.data)
-        
+
     def numCols(self):
         if len(self.data) == 0:
             return 0
@@ -171,7 +172,7 @@ class MyMatrix(MyVector):
     def __str__(self):
         result = ""
         start_char = "["
-        for m in range(0, self.numRows()):
+        for m in range(self.numRows()):
             result += start_char
             result += str(self[m])
             if m < self.numRows() - 1:
@@ -179,13 +180,13 @@ class MyMatrix(MyVector):
             start_char = " "
         result += "]"
         return result
-        
+
     def __repr__(self):
         return 'MyMatrix(' + MyVector.__repr__(self) + ')'
 
     def is_square(self):
         return self.numRows() == self.numCols()
-    
+
     def __iter__(self):
         for item in self.data:
             yield MyVector(item)
@@ -206,7 +207,7 @@ class MyMatrix(MyVector):
     def __mul__(self, rhs):
         """
         Matrix multiplication.
-        
+
         >>> a = MyMatrix([[1,2],[3,4]])
         >>> b = MyMatrix([[5,6],[7,8]])
         >>> print(a)
@@ -218,7 +219,7 @@ class MyMatrix(MyVector):
         >>> print(a*b)
         [[19, 22]
          [43, 50]]
-        
+
         """
         m = self.numRows()
         n = len(rhs[0])
@@ -226,16 +227,16 @@ class MyMatrix(MyVector):
         if self.numCols() != r:
             raise ArithmeticError("Matrix multplication size mismatch (%d vs %d)" % (self.numCols(), r))
         result = zeros(m, n)
-        for i in range(0, m):
-            for j in range(0, n):
-                for k in range(0, r):
+        for i in range(m):
+            for j in range(n):
+                for k in range(r):
                     result[i][j] += self[i][k]*rhs[k][j]
         return result
 
     def __add__(self, rhs):
         """
         Matrix addition.
-        
+
         >>> print(MyMatrix([[1, 2],[3, 4]]) + MyMatrix([[5, 6],[7, 8]]))
         [[6, 8]
          [10, 12]]
@@ -245,15 +246,15 @@ class MyMatrix(MyVector):
         assert len(rhs) == m
         assert len(rhs[0]) == n
         result = zeros(m,n)
-        for i in range(0,m):
-            for j in range(0,n):
+        for i in range(m):
+            for j in range(n):
                 result[i][j] = self[i][j] + rhs[i][j]
         return result
 
     def __sub__(self, rhs):
         """
         Matrix subtraction.
-        
+
         >>> print(MyMatrix([[1, 2],[3, 4]]) - MyMatrix([[5, 6],[7, 8]]))
         [[-4, -4]
          [-4, -4]]
@@ -263,20 +264,20 @@ class MyMatrix(MyVector):
         assert len(rhs) == m
         assert len(rhs[0]) == n
         result = zeros(m,n)
-        for i in range(0,m):
-            for j in range(0,n):
+        for i in range(m):
+            for j in range(n):
                 result[i][j] = self[i][j] - rhs[i][j]
         return result
 
     def __pos__(self):
         return self
-        
+
     def __neg__(self):
         m = self.numRows()
         n = self.numCols()
         result = zeros(m, n)
-        for i in range(0,m):
-            for j in range(0,n):
+        for i in range(m):
+            for j in range(n):
                 result[i][j] = -self[i][j]
         return result
 
@@ -358,7 +359,7 @@ class MyMatrix(MyVector):
                 ipiv[icol] += 1
                 # We now have the pivot element, so we interchange rows...
                 if irow != icol:
-                    for l in range(0,n):
+                    for l in range(n):
                         temp = a[irow][l]
                         a[irow][l] = a[icol][l]
                         a[icol][l] = temp
@@ -368,23 +369,23 @@ class MyMatrix(MyVector):
                     raise ArithmeticError("Cannot invert singular matrix")
                 pivinv = 1.0/a[icol][icol]
                 a[icol][icol] = 1.0
-                for l in range(0,n):
+                for l in range(n):
                     a[icol][l] *= pivinv
-                for ll in range(0,n): # next we reduce the rows
+                for ll in range(n): # next we reduce the rows
                     if ll == icol:
                         continue # except the pivot one, of course
                     dum = a[ll][icol]
                     a[ll][icol] = 0.0
-                    for l in range(0,n):
+                    for l in range(n):
                         a[ll][l] -= a[icol][l]*dum
             # Unscramble the permuted columns
             for l in range(n-1, -1, -1):
                 if indxr[l] == indxc[l]:
                     continue
-                for k in range(0,n):
+                for k in range(n):
                     temp = a[k][indxr[l]]
                     a[k][indxr[l]] = a[k][indxc[l]]
-                    a[k][indxc[l]] = temp                
+                    a[k][indxc[l]] = temp
             return a
 
     def transpose(self):
@@ -395,13 +396,13 @@ class MyMatrixTranspose(MyMatrix):
 
     def transpose(self):
         return MyMatrix(self.data)
-        
+
     def numRows(self):
         if len(self.data) == 0:
             return 0
         else:
             return len(self.data[0])
-        
+
     def numCols(self):
         return len(self.data)
 
@@ -415,7 +416,7 @@ class MyMatrixTranspose(MyMatrix):
             return MyVector(result)
 
     def __setitem__(self, key, rhs):
-        for n in range(0, len(self.data)):
+        for n in range(len(self.data)):
             self.data[n][key] = rhs[n]
 
     def __str__(self):
@@ -423,11 +424,11 @@ class MyMatrixTranspose(MyMatrix):
             return "[[]]"
         start_char = "["
         result = ""
-        for m in range(0, len(self.data[0])):
+        for m in range(len(self.data[0])):
             result += start_char
             result += "["
             sep_char = ""
-            for n in range(0, len(self.data)):
+            for n in range(len(self.data)):
                 result += sep_char
                 result += str(self.data[n][m])
                 sep_char = ", "
@@ -443,11 +444,11 @@ class MyMatrixTranspose(MyMatrix):
             return "MyMatrixTranspose([[]])"
         start_char = "["
         result = 'MyMatrixTranspose('
-        for m in range(0, len(self.data[0])):
+        for m in range(len(self.data[0])):
             result += start_char
             result += "["
             sep_char = ""
-            for n in range(0, len(self.data)):
+            for n in range(len(self.data)):
                 result += sep_char
                 result += repr(self.data[n][m])
                 sep_char = ", "
@@ -461,7 +462,7 @@ class MyMatrixTranspose(MyMatrix):
 
 # run module directly for testing
 if __name__=='__main__':
-    
+
     # Test the examples in the docstrings
     import doctest, sys
     doctest.testmod(sys.modules[__name__])

--- a/mdtraj/utils/unit/prefix.py
+++ b/mdtraj/utils/unit/prefix.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 """
-Module simtk.unit.prefix
+Module openmm.unit.prefix
 
 This is part of the OpenMM molecular simulation toolkit originating from
 Simbios, the NIH National Center for Physics-Based Simulation of
@@ -11,7 +11,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -29,6 +29,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import print_function, division, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"
@@ -44,14 +45,14 @@ import sys
 class SiPrefix(object):
     """
     Unit prefix that can be multiplied by a unit to yield a new unit.
-    
+
     e.g. millimeter = milli*meter
     """
     def __init__(self, prefix, factor, symbol):
         self.prefix = prefix
         self.factor = factor
         self.symbol = symbol
-        
+
     def __mul__(self, unit):
         """
         SiPrefix * BaseUnit yields new BaseUnit
@@ -136,17 +137,17 @@ si_prefixes = (   yotto
 def define_prefixed_units(base_unit, module = sys.modules[__name__]):
     """
     Create attributes for prefixed units derived from a particular BaseUnit, e.g. "kilometer" from "meter_base_unit"
-    
+
     Parameters
      - base_unit (BaseUnit) existing base unit to use as a basis for prefixed units
-     - module (Module) module which will contain the new attributes.  Defaults to simtk.unit module.
+     - module (Module) module which will contain the new attributes.  Defaults to openmm.unit module.
     """
     for prefix in si_prefixes:
         new_base_unit = prefix * base_unit
         name = new_base_unit.name
         new_unit = Unit({new_base_unit: 1.0})
         # Create base_unit attribute, needed for creating UnitSystems
-        module.__dict__[name + '_base_unit'] = new_base_unit # e.g. "kilometer_base_unit"        
+        module.__dict__[name + '_base_unit'] = new_base_unit # e.g. "kilometer_base_unit"
         # Create attribue in this module
         module.__dict__[name] = new_unit # e.g. "kilometer"
         # And plural version

--- a/mdtraj/utils/unit/standard_dimensions.py
+++ b/mdtraj/utils/unit/standard_dimensions.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 """
-Module simtk.unit.standard_dimensions
+Module openmm.unit.standard_dimensions
 
 Definition of principal dimensions: mass, length, time, etc.
 
@@ -13,7 +13,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -31,6 +31,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"

--- a/mdtraj/utils/unit/unit_definitions.py
+++ b/mdtraj/utils/unit/unit_definitions.py
@@ -1,17 +1,17 @@
 #!/bin/env python
 """
-Module simtk.unit.unit_definitions
+Module openmm.unit.unit_definitions
 
 This is part of the OpenMM molecular simulation toolkit originating from
 Simbios, the NIH National Center for Physics-Based Simulation of
 Biological Structures at Stanford, funded under the NIH Roadmap for
 Medical Research, grant U54 GM072970. See https://simtk.org.
 
-Portions copyright (c) 2012 Stanford University and the Authors.
+Portions copyright (c) 2012-2020 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -30,7 +30,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.6"
@@ -42,6 +42,8 @@ from .unit_operators import * ; # needed for manipulation of units
 from .prefix import *
 import math
 import sys
+
+# Physical constants in this file are CODATA 2018 values from https://pml.nist.gov/cuu/Constants
 
 #####################
 ### DIMENSIONLESS ###
@@ -62,7 +64,7 @@ angstrom_base_unit.define_conversion_factor_to(meter_base_unit, 1e-10)
 angstroms = angstrom = Unit({angstrom_base_unit: 1.0})
 
 planck_length_base_unit = BaseUnit(length_dimension, "Planck length", "l_P")
-planck_length_base_unit.define_conversion_factor_to(meter_base_unit, 1.61625281e-35)
+planck_length_base_unit.define_conversion_factor_to(meter_base_unit, 1.616255e-35)
 
 inch_base_unit = BaseUnit(length_dimension, "inch", "in")
 inch_base_unit.define_conversion_factor_to(centimeter_base_unit, 2.5400)
@@ -79,6 +81,8 @@ yard = yards = Unit({yard_base_unit: 1.0})
 furlongs = furlong = yard.create_unit(scale=220.0, name="furlong", symbol="furlong")
 miles = mile = furlong.create_unit(scale=8.0, name="mile", symbol="mi")
 
+bohrs = bohr = angstrom.create_unit(scale=0.529177210903, name='bohr', symbol='r_0')
+
 ############
 ### MASS ###
 ############
@@ -89,7 +93,7 @@ grams = gram = Unit({gram_base_unit: 1.0})
 define_prefixed_units(gram_base_unit, module = sys.modules[__name__])
 
 planck_mass_base_unit = BaseUnit(mass_dimension, "Planck mass", "m_P")
-planck_mass_base_unit.define_conversion_factor_to(kilogram_base_unit, 2.1764411e-8)
+planck_mass_base_unit.define_conversion_factor_to(kilogram_base_unit, 2.176434e-8)
 
 # pound can be mass, force, or currency
 pound_mass_base_unit = BaseUnit(mass_dimension, "pound", "lb")
@@ -110,7 +114,7 @@ seconds = second = Unit({second_base_unit: 1.0})
 define_prefixed_units(second_base_unit, module = sys.modules[__name__])
 
 planck_time_base_unit = BaseUnit(time_dimension, "Planck time", "t_P")
-planck_time_base_unit.define_conversion_factor_to(second_base_unit, 5.3912427e-44)
+planck_time_base_unit.define_conversion_factor_to(second_base_unit, 5.391247e-44)
 
 minutes = minute = second.create_unit(scale=60.0, name="minute", symbol="min")
 hours = hour = minute.create_unit(scale=60.0, name="hour", symbol="hr")
@@ -130,7 +134,7 @@ kelvin_base_unit = BaseUnit(temperature_dimension, "kelvin", "K")
 kelvins = kelvin = Unit({kelvin_base_unit: 1.0})
 
 planck_temperature_base_unit = BaseUnit(temperature_dimension, "Planck temperature", "T_p")
-planck_temperature_base_unit.define_conversion_factor_to(kelvin_base_unit, 1.41678571e32)
+planck_temperature_base_unit.define_conversion_factor_to(kelvin_base_unit, 1.416784e32)
 
 ##############
 ### CHARGE ###
@@ -141,11 +145,11 @@ elementary_charges = elementary_charge = Unit({elementary_charge_base_unit: 1.0}
 
 coulomb_base_unit = BaseUnit(charge_dimension, "coulomb", "C")
 # Exact conversion factor
-coulomb_base_unit.define_conversion_factor_to(elementary_charge_base_unit, 6.24150962915265e18)
+coulomb_base_unit.define_conversion_factor_to(elementary_charge_base_unit, 6.241509074460763e18)
 coulombs = coulomb = Unit({coulomb_base_unit: 1.0})
 
 planck_charge_base_unit = BaseUnit(charge_dimension, "Planck charge", "q_P")
-planck_charge_base_unit.define_conversion_factor_to(elementary_charge_base_unit, 11.706237639840)
+planck_charge_base_unit.define_conversion_factor_to(elementary_charge_base_unit, 1/math.sqrt(7.2973525693e-3)) # Calculated from fine structure constant
 
 ##############
 ### AMOUNT ###
@@ -155,7 +159,7 @@ mole_base_unit = BaseUnit(amount_dimension, "mole", "mol")
 moles = mole = Unit({mole_base_unit: 1.0})
 
 single_item_amount_base_unit = BaseUnit(amount_dimension, "item", "")
-mole_base_unit.define_conversion_factor_to(single_item_amount_base_unit, 6.0221417930e23)
+mole_base_unit.define_conversion_factor_to(single_item_amount_base_unit, 6.02214076e23)
 items = item = Unit({single_item_amount_base_unit: 1.0})
 
 ##########################
@@ -235,6 +239,8 @@ joules = joule = Unit({joule_base_unit: 1.0})
 define_prefixed_units(joule_base_unit, module = sys.modules[__name__])
 erg_base_unit = ScaledUnit(1.0, dyne * centimeter, "erg", "erg")
 erg = ergs = Unit({erg_base_unit: 1.0})
+hartree_base_unit = ScaledUnit(4.3597447222071e-18, joule, "hartree", "Ha")
+hartree = hartrees = Unit({hartree_base_unit: 1.0})
 
 # In molecular simulations, "kilojoules" are in microscopic units
 # And you really only want to use kilojoules/mole.
@@ -303,20 +309,20 @@ mmHg = Unit({mmHg_base_unit: 1.0})
 
 ampere_base_unit = ScaledUnit(1.0, coulomb/second, "ampere", "A")
 
-si_unit_system = UnitSystem([\
-        meter_base_unit,\
-        kilogram_base_unit,\
-        second_base_unit,\
+si_unit_system = UnitSystem([
+        meter_base_unit,
+        kilogram_base_unit,
+        second_base_unit,
         ampere_base_unit,
         kelvin_base_unit,
         mole_base_unit,
         candela_base_unit,
         radian_base_unit])
 
-cgs_unit_system = UnitSystem([\
-        centimeter_base_unit,\
-        gram_base_unit,\
-        second_base_unit,\
+cgs_unit_system = UnitSystem([
+        centimeter_base_unit,
+        gram_base_unit,
+        second_base_unit,
         ampere_base_unit,
         kelvin_base_unit,
         mole_base_unit,
@@ -324,10 +330,10 @@ cgs_unit_system = UnitSystem([\
 
 dalton_base_unit = ScaledUnit(1.0, gram/mole, "dalton", "Da")
 
-md_unit_system = UnitSystem([\
-        nanometer_base_unit,\
+md_unit_system = UnitSystem([
+        nanometer_base_unit,
         dalton_base_unit,
-        picosecond_base_unit,\
+        picosecond_base_unit,
         elementary_charge_base_unit,
         kelvin_base_unit,
         mole_base_unit,

--- a/mdtraj/utils/unit/unit_math.py
+++ b/mdtraj/utils/unit/unit_math.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 """
-Module simtk.unit.math
+Module openmm.unit.math
 
 Arithmetic methods on Quantities and Units
 
@@ -13,7 +13,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -31,8 +31,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-
-from __future__ import division
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.5"
@@ -49,7 +48,7 @@ from .unit_definitions import *
 def sin(angle):
     """
     Examples
-    
+
     >>> sin(90*degrees)
     1.0
     """
@@ -67,7 +66,7 @@ def sinh(angle):
 def cos(angle):
     """
     Examples
-    
+
     >>> cos(180*degrees)
     -1.0
     """
@@ -102,10 +101,10 @@ def acos(x):
     0.0 rad
     """
     return math.acos(x) * radians
-    
+
 def acosh(x):
     return math.acosh(x) * radians
-    
+
 def asin(x):
     return math.asin(x) * radians
 
@@ -114,10 +113,10 @@ def asinh(x):
 
 def atan(x):
     return math.atan(x) * radians
-    
+
 def atanh(x):
     return math.atanh(x) * radians
-    
+
 def atan2(x, y):
     return math.atan2(x, y) * radians
 
@@ -156,6 +155,10 @@ def sum(val):
     >>> sum((2.0*meter, 30.0*centimeter))
     Quantity(value=2.3, unit=meter)
     """
+    try:
+        return val.sum()
+    except AttributeError:
+        pass
     if len(val) == 0:
         return 0
     result = val[0]

--- a/mdtraj/utils/unit/unit_operators.py
+++ b/mdtraj/utils/unit/unit_operators.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 """
-Module simtk.unit.unit_operators
+Module openmm.unit.unit_operators
 
 Physical quantities with units, intended to produce similar functionality
 to Boost.Units package in C++ (but with a runtime cost).
@@ -9,8 +9,8 @@ but different internals to satisfy our local requirements.
 In particular, there is no underlying set of 'canonical' base
 units, whereas in Scientific.Physics.PhysicalQuantities all
 units are secretly in terms of SI units.  Also, it is easier
-to add new fundamental dimensions to simtk.dimensions.  You
-might want to make new dimensions for, say, "currency" or 
+to add new fundamental dimensions to basedimension.  You
+might want to make new dimensions for, say, "currency" or
 "information".
 
 Two possible enhancements that have not been implemented are
@@ -28,7 +28,7 @@ Portions copyright (c) 2012 Stanford University and the Authors.
 Authors: Christopher M. Bruns
 Contributors: Peter Eastman
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -46,6 +46,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from __future__ import print_function, absolute_import, division
 
 __author__ = "Christopher M. Bruns"
 __version__ = "0.5"
@@ -60,7 +61,7 @@ from .quantity import Quantity, is_quantity
 def _unit_class_rdiv(self, other):
     """
     Divide another object type by a Unit.
-    
+
     Returns a new Quantity with a value of other and units
     of the inverse of self.
     """
@@ -78,14 +79,14 @@ Unit.__rdiv__ = _unit_class_rdiv
 
 def _unit_class_mul(self, other):
     """Multiply a Unit by an object.
-    
-    If other is another Unit, returns a new composite Unit.  
-    Exponents of similar dimensions are added.  If self and 
+
+    If other is another Unit, returns a new composite Unit.
+    Exponents of similar dimensions are added.  If self and
     other share similar BaseDimension, but
     with different BaseUnits, the resulting BaseUnit for that
     BaseDimension will be that used in self.
-    
-    If other is a not another Unit, this method returns a 
+
+    If other is a not another Unit, this method returns a
     new Quantity...  UNLESS other is a Quantity and the resulting
     unit is dimensionless, in which case the underlying value type
     of the Quantity is returned.
@@ -128,12 +129,10 @@ def _unit_class_mul(self, other):
         return Quantity(value, unit).reduce_unit(self)
     else:
         # print "scalar * unit"
-        value = other
-        unit = self
         # Is reduce_unit needed here?  I hope not, there is a performance issue...
         # return Quantity(other, self).reduce_unit(self)
         return Quantity(other, self)
-        
+
 Unit.__mul__ = _unit_class_mul
 Unit.__rmul__ = Unit.__mul__
 Unit._multiplication_cache = {}


### PR DESCRIPTION
## THIS DROPS OpenMM < 7.6


While looking at #1695 by doing 
```grep -r -n "simtk" --include="*.py"``` 

I saw that the `mdtraj/utils/unit` had a bunch of references to it (in docstrings). I figured that the easy solution for that is to re-export the current `openmm.unit` files. I also updated the `__init__.py` to search for `openmm.unit` in `sys.modules`

[edit] after [this comment](https://github.com/mdtraj/mdtraj/pull/1698#issuecomment-969341160) I decided to not increase the maintenance burden and drop support for the `simtk` namespace