### PR TITLE
protect against issue 1699

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ def format_extensions():
         # install of python+zlib or a conda install of python+zlib
         zlib_include_dirs += ["{}/include".format(sys.prefix)]
         zlib_library_dirs += ["{}/lib".format(sys.prefix)]
-    zlib = any([glob(f"{i}/zlib.h") for i in zlib_include_dirs])
+    zlib = any([glob(f"{i}/**/zlib.h", recursive=True)
+                for i in zlib_include_dirs])
     # Protect against Issue 1699
     if zlib:
         def_macros = [("USE_ZLIB", 1)]

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,12 @@ def format_extensions():
         # install of python+zlib or a conda install of python+zlib
         zlib_include_dirs += ["{}/include".format(sys.prefix)]
         zlib_library_dirs += ["{}/lib".format(sys.prefix)]
-
+    zlib = any([glob(f"{i}/zlib.h") for i in zlib_include_dirs])
+    # Protect against Issue 1699
+    if zlib:
+        def_macros = [("USE_ZLIB", 1)]
+    else:
+        def_macros = None
     tng = Extension('mdtraj.formats.tng',
                     sources=glob('mdtraj/formats/tng/src/compression/*.c') +
                                 ['mdtraj/formats/tng/src/lib/tng_io.c',
@@ -109,7 +114,7 @@ def format_extensions():
                                  'mdtraj/formats/tng/tng.pyx'],
                     include_dirs=['mdtraj/formats/tng/include']
                                  + zlib_include_dirs,
-                    define_macros=[('USE_ZLIB', 1)],
+                    define_macros=def_macros,
                     library_dirs=zlib_library_dirs,
                     libraries=['z'],
                     )

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,11 @@ def format_extensions():
     # Protect against Issue 1699
     if zlib:
         def_macros = [("USE_ZLIB", 1)]
+        zlibraries = ['z']
     else:
         def_macros = None
+        zlibraries = None
+
     tng = Extension('mdtraj.formats.tng',
                     sources=glob('mdtraj/formats/tng/src/compression/*.c') +
                                 ['mdtraj/formats/tng/src/lib/tng_io.c',
@@ -117,7 +120,7 @@ def format_extensions():
                                  + zlib_include_dirs,
                     define_macros=def_macros,
                     library_dirs=zlib_library_dirs,
-                    libraries=['z'],
+                    libraries=zlibraries,
                     )
 
     dcd = Extension('mdtraj.formats.dcd',


### PR DESCRIPTION
This should protect against issue #1699 for all future releases. As the `c` code is already wrapped in `ifdef USE_ZLIB` this should work.

I tested setting the value to `("USE_ZLIB", 0)` instead of making `def_macros=None`, but that does still trigger the `ifdef`

I tested this by adding a `#include <potato123.h>` on the problematic line of the issue. This did trigger a similar compile error on regular compilation, and not if I hard-coded `def_macros = None`.