### PR TITLE
Avoid side effects in mdtraj.load

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -416,7 +416,8 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         kwargs.pop('standard_names', None)
 
     trajectories = []
-    tmp_file = filename_or_filenames.pop(0)
+    tmp_file = filename_or_filenames[0]
+    filename_or_filenames = filename_or_filenames[1:]  # ignore first file
     try:
         # this is a little hack that makes calling load() more predictable. since
         # most of the loaders take a kwargs "top" except for load_hdf5, (since


### PR DESCRIPTION
using `filename_or_filenames.pop(0)` leads to a change of the filename list which propagates back into the outer scope and is (in my opinion) quite unexpected, i.e., handing in a list of filenames, that list is suddenly shorter by 1 after a call to `mdtraj.load`. This small change uses slicing rather than `pop` which as an added benefit also supports tuples (which do not possess `pop`).