### PR TITLE
[core.Topology.from_dataframe] BUGFIX: force new residue when creating new chain

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -529,7 +529,7 @@ class Topology(object):
 
                 c = out.add_chain()
 
-            if atom['resSeq'] != previous_resSeq or atom['resName'] != previous_resName:
+            if atom['resSeq'] != previous_resSeq or atom['resName'] != previous_resName or c.n_atoms==0:
                 previous_resSeq = atom['resSeq']
                 previous_resName = atom['resName']
 


### PR DESCRIPTION
[Disclaimer: @rmcgibbo I'm well aware of your note on current project status. Thanks so much for mdtraj! I'm posting this because I think it's the best place to do it, even if you can't do anything with it at the moment. Just hoping it makes it into whatever next release you can do, if you plan such a thing at all.]

The previous logic didn't detect a new residue unless resSeq or resname had changed. 

This left out a situation I just came across: a pdb where two subsequent chains, consisting of one residue each, have the same resname and resSeq. Using from_dataframe on them, the second chain gets correctly created, but its atoms get assigned to the previous residue (of the previous chain) since the residue hadn't been updated. 

The PDB in question is [3E8D](https://www.rcsb.org/structure/3E8D), and the residue is G98, which appears two times. Here's some relevant snippets:
```
REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE G98 A 1
...
REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE G98 B 1
```
The chain change between second and third line goes undetected
and the atoms 5392... keep being added to the previous G98
```
HETATM 5390  O1  G98 A   1      34.061 -22.082 -12.759  1.00 27.34           O
HETATM 5391  N4  G98 A   1      32.957 -22.764 -12.136  1.00 27.36           N
HETATM 5392  N1  G98 B   1      -5.324 -37.802   1.514  1.00 29.96           N
HETATM 5393  N3  G98 B   1      -3.082 -39.245  -1.024  1.00 29.99           N
```
Easiest way to reproduce:
```
import mdtraj as md
geom = md.load_pdb("https://files.rcsb.org/download/3E8D.pdb")
df, bonds = geom.top.to_dataframe()
md.Topology.from_dataframe(df, bonds=bonds)==geom.top
```
yields False with current version and True with this bugfix.


