### PR TITLE
Use oldest-supported-numpy instead of numpy version pinning for build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,12 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy==1.11.3; python_version=='3.6'",
-    "numpy==1.14.6; python_version=='3.7'",
-    "numpy==1.17.5; python_version=='3.8'",
-    "numpy==1.19.5; python_version=='3.9'",
-    "numpy==1.21.3; python_version=='3.10'",
+    "numpy; sys_platform=='darwin'",
+    "numpy==1.11.3; python_version=='3.6' and sys_platform=='linux'",
+    "numpy==1.14.6; python_version=='3.7' and sys_platform=='linux'",
+    "numpy==1.17.5; python_version=='3.8' and sys_platform=='linux'",
+    "numpy==1.19.5; python_version=='3.9' and sys_platform=='linux'",
+    "numpy==1.21.3; python_version=='3.10' and sys_platform=='linux'",
     "numpy; python_version>='3.11'",
     "Cython>0.28",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,10 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy; sys_platform=='darwin'",
-    "numpy==1.11.3; python_version=='3.6' and sys_platform=='linux'",
-    "numpy==1.14.6; python_version=='3.7' and sys_platform=='linux'",
-    "numpy==1.17.5; python_version=='3.8' and sys_platform=='linux'",
-    "numpy==1.19.5; python_version=='3.9' and sys_platform=='linux'",
-    "numpy==1.21.3; python_version=='3.10' and sys_platform=='linux'",
-    "numpy; python_version>='3.11'",
+    # Use oldest-supported-numpy which provides the oldest numpy version with
+    # wheels on PyPI
+    #
+    # See: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    "oldest-supported-numpy",
     "Cython>0.28",
 ]


### PR DESCRIPTION
Older numpy versions pinned were causing issues when those numpy versions were not compatible with newer mac platform.

Instead, let's use https://github.com/scipy/oldest-supported-numpy which does the right thing for most known build envs.