### PR TITLE
Add Python 3.11 release candidate 2 to testing

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
            intrinsics: native
          - py: "python310"
            intrinsics: native
-         - py: "python311-dev"
+         - py: "python311-dev" 
            intrinsics: native
          - py: "python311-dev"
            intrinsics: generic

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,9 +19,9 @@ jobs:
            intrinsics: native
          - py: "python310"
            intrinsics: native
-         - py: "python311-dev"
+         - py: "python311"
            intrinsics: native
-         - py: "python311-dev"
+         - py: "python311"
            intrinsics: generic
          - py: "python310"
            intrisics: generic

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,6 +19,8 @@ jobs:
            intrinsics: native
          - py: "python310"
            intrinsics: native
+         - py: "python311-dev"
+           intrinsics: native
          - py: "python310"
            intrisics: generic
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,8 @@ jobs:
            intrinsics: native
          - py: "python311-dev"
            intrinsics: native
+         - py: "python311-dev"
+           intrinsics: generic
          - py: "python310"
            intrisics: generic
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
            intrinsics: native
          - py: "python310"
            intrinsics: native
-         - py: "python311-dev" 
+         - py: "python311-dev"
            intrinsics: native
          - py: "python311-dev"
            intrinsics: generic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     "numpy==1.17.5; python_version=='3.8'",
     "numpy==1.19.5; python_version=='3.9'",
     "numpy==1.21.3; python_version=='3.10'",
-    "numpy; python_version>='3.11'",
-    "Cython>0.28",
+    "numpy==1.23.5; python_version=='3.11'",
+    "numpy; python_version>='3.12'",
+    "Cython>0.29.32",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ requires = [
     "numpy==1.21.3; python_version=='3.10'",
     "numpy==1.23.5; python_version=='3.11'",
     "numpy; python_version>='3.12'",
-    "Cython>0.29.32",
+    "Cython>0.29",
 ]


### PR DESCRIPTION
Related to #1754

Python 3.11 will be on average 22% faster than Python 3.10 so let’s give it a spin...
https://www.python.org/download/pre-releases