### PR TITLE
fix bug: resSeq changed when doing trajectory.atom_slice if resSeq==0

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -90,7 +90,7 @@ def _topology_from_subset(topology, atom_indices):
     for chain in topology._chains:
         newChain = newTopology.add_chain()
         for residue in chain._residues:
-            resSeq = getattr(residue, 'resSeq', None) or residue.index
+            resSeq = getattr(residue, 'resSeq', residue.index)
             newResidue = None
             for atom in residue._atoms:
                 if atom.index in atom_indices:


### PR DESCRIPTION
When I was doing trajectory.atom_slice, if a residue's resSeq == 0, the line 93 reassigns resSeq as residue.index because
```python
resSeq = 0 or residue.index # =residue.index
```
As we can assign a default value to the [getattr](https://docs.python.org/3/library/functions.html#getattr) method like
```python
getattr(object, name, default, /)
```
, it would be better to use this instead. 