### PR TITLE
fix bugs by nix-2.15

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2.3.4
     - uses: cachix/install-nix-action@v16
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v10
       with:
         name: mdtraj


### PR DESCRIPTION
Pinning nix to 2.13.3 (or install-nix-action@v16 to v20)  

See blow for references:
https://github.com/cachix/install-nix-action/issues/161 
https://github.com/cachix/cachix-action/issues/144