### PR TITLE
Constrain `cython=0.29`

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Core
   - python
-  - cython
+  - cython =0.29
   - numpy
   - zlib
   - pyparsing

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Core
   - python
-  - cython =0.29
+  - cython =0.29.36
   - numpy
   - zlib
   - pyparsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    # Use oldest-supported-numpy which provides the oldest numpy version with
-    # wheels on PyPI
-    #
-    # See: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+    # provides the oldest numpy version with wheels on PyPI
     "oldest-supported-numpy",
-    "Cython=0.29",
+    "Cython==0.29",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = [
     "wheel",
     # provides the oldest numpy version with wheels on PyPI
     "oldest-supported-numpy",
-    "Cython==0.29.36",
+    "Cython~=0.29.36",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,5 @@ requires = [
     #
     # See: https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
     "oldest-supported-numpy",
-    "Cython>0.28",
+    "Cython=0.29",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = [
     "wheel",
     # provides the oldest numpy version with wheels on PyPI
     "oldest-supported-numpy",
-    "Cython==0.29",
+    "Cython==0.29.36",
 ]


### PR DESCRIPTION
Band-aid for #1800, which should be followed-up by a proper fix.

Version 3.0 (!) was released, but the current source code is only compatible with versions 0.29.x