### PR TITLE
Add v1.9.9 release notes

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -3,6 +3,14 @@ What's New?
 
 These are new features and improvements of note in each release.
 
+v1.9.9 (July 20, 2023)
+---------------------
+
+- Pin `Cython~=0.29` in `pyproject.toml` (#1801)
+- Remove "stale" bot (#1758)
+- Announce maintainer update (#1795)
+- Use `oldest-supported-numpy` in `pyproject.toml` (#1751)
+
 v1.9.8 (July 2, 2023)
 ---------------------
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -11,6 +11,14 @@ v1.9.9 (July 20, 2023)
 - Announce maintainer update (#1795)
 - Use `oldest-supported-numpy` in `pyproject.toml` (#1751)
 
+A total of 4 people contributed to this release, including three new contributors.
+People with a "+" by their names contributed a patch for the first time.
+
+In-Ho Yi+
+Sukrit Singh+
+Jeremy Leung+
+Matthew W. Thompson
+
 v1.9.8 (July 2, 2023)
 ---------------------
 
@@ -31,7 +39,7 @@ v1.9.8 (July 2, 2023)
 - Test on Python 3.11 (#1758)
 - Constrain GSD to version 2 (#1790)
 
-A total of 10 people contributed to this release.
+A total of 15 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 
 - Robert T. McGibbon


### PR DESCRIPTION
I think we should put out a quick release, mostly to resolve #1800 without folks needing to read up on an issue and add another constraint into their build system. There have only been a couple of other merges since then, only toolkit/docs and no substantive changes to the source code.

I can take care of this, but not until tomorrow or possibly late tonight at the earliest (MDTraj is not my day job).