### PR TITLE
Use raw strings to fix invalid escape sequences

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,3 +54,7 @@ jobs:
       if: always()
       run: |
         pytest --durations=10 tests/
+
+    - name: Lint
+      run: |
+        ruff check mdtraj

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pytables
   - gsd =2
   - pytest
+  - ruff

--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -268,7 +268,7 @@ class AmberRestartFile(object):
                           unitcell_angles=cell_angles)
 
     def read(self, atom_indices=None):
-        """Read data from an AMBER ASCII restart file
+        r"""Read data from an AMBER ASCII restart file
 
         Parameters
         ----------
@@ -531,7 +531,7 @@ class AmberNetCDFRestartFile(object):
                           unitcell_angles=cell_angles)
 
     def read(self, atom_indices=None):
-        """Read data from an AMBER NetCDF restart file
+        r"""Read data from an AMBER NetCDF restart file
 
         Parameters
         ----------

--- a/mdtraj/formats/gro.py
+++ b/mdtraj/formats/gro.py
@@ -391,7 +391,7 @@ class GroTrajectoryFile(object):
         time = None
         if 't=' in comment:
             # title string (free format string, optional time in ps after 't=')
-            time = float(findall('t= *(\d+\.\d+)',comment)[-1])
+            time = float(findall(r't= *(\d+\.\d+)', comment)[-1])
 
         # box vectors (free format, space separated reals), values: v1(x) v2(y)
         # v3(z) v1(y) v1(z) v2(x) v2(z) v3(x) v3(y), the last 6 values may be
@@ -497,7 +497,7 @@ def _isfloat(word):
     @return answer Boolean which specifies whether the string is any number
 
     """
-    return match('^[-+]?[0-9]*\.?[0-9]*([eEdD][-+]?[0-9]+)?$',word)
+    return match(r'^[-+]?[0-9]*\.?[0-9]*([eEdD][-+]?[0-9]+)?$',word)
 
 def _parse_gro_coord(line, firstDecimal, secondDecimal):
     """ Determines whether a line contains GROMACS data or not

--- a/mdtraj/formats/gsd.py
+++ b/mdtraj/formats/gsd.py
@@ -225,7 +225,7 @@ def read_snapshot(frame, snapshot, topology, atom_indices=None):
     return xyz, box_vectors, time
 
 def write_gsd(filename, xyz, top, cell_lengths=None, cell_angles=None):
-    """Write one or more frames of data to a gsd file.
+    r"""Write one or more frames of data to a gsd file.
 
     Parameters
     ----------

--- a/mdtraj/formats/lammpstrj.py
+++ b/mdtraj/formats/lammpstrj.py
@@ -234,7 +234,7 @@ class LAMMPSTrajectoryFile(object):
         return t
 
     def read(self, n_frames=None, stride=None, atom_indices=None):
-        """Read data from a lammpstrj file.
+        r"""Read data from a lammpstrj file.
 
         Parameters
         ----------
@@ -426,7 +426,7 @@ class LAMMPSTrajectoryFile(object):
         return xyz, lengths, angles
 
     def write_box(self, lengths, angles, mins):
-        """Write the box lines in the header of a frame.
+        r"""Write the box lines in the header of a frame.
 
         Parameters
         ----------
@@ -473,7 +473,7 @@ class LAMMPSTrajectoryFile(object):
             self._fh.write('{0} {1} {2}\n'.format(zlo_bound, zhi_bound, yz))
 
     def write(self, xyz, cell_lengths, cell_angles=None, types=None, unit_set='real'):
-        """Write one or more frames of data to a lammpstrj file.
+        r"""Write one or more frames of data to a lammpstrj file.
 
         Parameters
         ----------

--- a/mdtraj/formats/mol2.py
+++ b/mdtraj/formats/mol2.py
@@ -212,14 +212,14 @@ def mol2_to_dataframes(filename):
         csv.writelines(data["@<TRIPOS>BOND\n"][1:])
         csv.seek(0)
         bonds_frame = pd.read_table(csv, names=["bond_id", "id0", "id1", "bond_type"],
-            index_col=0, header=None, sep="\s+", engine='python')
+            index_col=0, header=None, sep=r"\s+", engine='python')
     else:
         bonds_frame = None
 
     csv = StringIO()
     csv.writelines(data["@<TRIPOS>ATOM\n"][1:])
     csv.seek(0)
-    atoms_frame = pd.read_csv(csv, sep="\s+", engine='python',  header=None)
+    atoms_frame = pd.read_csv(csv, sep=r"\s+", engine='python',  header=None)
     ncols = atoms_frame.shape[1]
     names=["serial", "name", "x", "y", "z", "atype", "code", "resName", "charge", "status"]
     atoms_frame.columns = names[:ncols]

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -214,7 +214,7 @@ class NetCDFTrajectoryFile(object):
                           unitcell_angles=cell_angles)
 
     def read(self, n_frames=None, stride=None, atom_indices=None):
-        """Read data from a molecular dynamics trajectory in the AMBER NetCDF
+        r"""Read data from a molecular dynamics trajectory in the AMBER NetCDF
         format.
 
         Parameters
@@ -320,7 +320,7 @@ class NetCDFTrajectoryFile(object):
         return coordinates, time, cell_lengths, cell_angles
 
     def write(self, coordinates, time=None, cell_lengths=None, cell_angles=None):
-        """Write one or more frames of a molecular dynamics trajectory to disk
+        r"""Write one or more frames of a molecular dynamics trajectory to disk
         in the AMBER NetCDF format.
 
         Parameters

--- a/mdtraj/formats/prmtop.py
+++ b/mdtraj/formats/prmtop.py
@@ -60,7 +60,7 @@ from mdtraj.core import topology
 from mdtraj.formats import pdb
 from mdtraj.core import element as elem
 
-FORMAT_RE_PATTERN = re.compile("([0-9]+)([a-zA-Z]+)([0-9]+)\.?([0-9]*)")
+FORMAT_RE_PATTERN = re.compile(r"([0-9]+)([a-zA-Z]+)([0-9]+)\.?([0-9]*)")
 
 __all__ = ['load_prmtop']
 

--- a/mdtraj/geometry/contact.py
+++ b/mdtraj/geometry/contact.py
@@ -41,7 +41,7 @@ __all__ = ['compute_contacts', 'squareform']
 
 def compute_contacts(traj, contacts='all', scheme='closest-heavy', ignore_nonprotein=True, periodic=True,
                      soft_min=False, soft_min_beta=20):
-    """Compute the distance between pairs of residues in a trajectory.
+    r"""Compute the distance between pairs of residues in a trajectory.
 
     Parameters
     ----------

--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -248,7 +248,7 @@ def baker_hubbard(traj, freq=0.1, exclude_water=True, periodic=True, sidechain_o
 
 
 def kabsch_sander(traj):
-    """Compute the Kabsch-Sander hydrogen bond energy between each pair
+    r"""Compute the Kabsch-Sander hydrogen bond energy between each pair
     of residues in every frame.
 
     Hydrogen bonds are defined using an electrostatic definition, assuming
@@ -259,7 +259,7 @@ def kabsch_sander(traj):
 
     .. math::
 
-        E = 0.42 \cdot 0.2 \cdot 33.2 kcal/(mol \cdot nm) * \\
+        E = 0.42 \cdot 0.2 \cdot 33.2 kcal/(mol \cdot nm) * \
             (1/r_{ON} + 1/r_{CH} - 1/r_{OH} - 1/r_{CN})
 
     Parameters

--- a/mdtraj/geometry/internal.py
+++ b/mdtraj/geometry/internal.py
@@ -367,7 +367,7 @@ def get_dihedral_connectivity(ibonds):
 ################################################################################
 
 def get_wilson_B(conformation, **kwargs):
-    """Calculate the Wilson B matrix, which collects the derivatives of the
+    r"""Calculate the Wilson B matrix, which collects the derivatives of the
     redundant internal coordinates w/r/t the cartesian coordinates.
 
     .. math::

--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -77,7 +77,7 @@ def principal_moments(traj):
     return np.linalg.eigvalsh(gyration_tensor)
 
 def asphericity(traj):
-    """Compute the asphericity of a trajectory.
+    r"""Compute the asphericity of a trajectory.
 
     For each frame compute the principal moments then,
 
@@ -102,7 +102,7 @@ def asphericity(traj):
     return b
 
 def acylindricity(traj):
-    """Compute the acylindricity of a trajectory.
+    r"""Compute the acylindricity of a trajectory.
 
     For each frame compute the principal moments then,
 
@@ -127,7 +127,7 @@ def acylindricity(traj):
     return c
 
 def relative_shape_anisotropy(traj):
-    """Compute the relative shape anisotropy of a trajectory.
+    r"""Compute the relative shape anisotropy of a trajectory.
 
     For each frame compute the principal moments then,
 

--- a/mdtraj/nmr/shift_wrappers.py
+++ b/mdtraj/nmr/shift_wrappers.py
@@ -211,7 +211,7 @@ def chemical_shifts_ppm(trj):
         if return_flag != 0:
             raise(IOError("Could not successfully execute command '%s', check your PPM installation or your input trajectory." % cmd))
 
-        d = pd.read_table("./bb_details.dat", index_col=False, header=None, sep="\s+").drop([3], axis=1)
+        d = pd.read_table("./bb_details.dat", index_col=False, header=None, sep=r"\s+").drop([3], axis=1)
 
         d = d.rename(columns={0: "resSeq", 1: "resName", 2: "name"})
         d["resSeq"] += first_resSeq - 1  # Fix bug in PPM that reindexes to 1
@@ -289,7 +289,7 @@ def chemical_shifts_spartaplus(trj, rename_HN=True):
 
         results = []
         for i in range(trj.n_frames):
-            d = pd.read_table("./trj%d_pred.tab" % i, names=names, header=None, sep="\s+", skiprows=lines_to_skip)
+            d = pd.read_table("./trj%d_pred.tab" % i, names=names, header=None, sep=r"\s+", skiprows=lines_to_skip)
             d["frame"] = i
             results.append(d)
 

--- a/mdtraj/testing/docscrape.py
+++ b/mdtraj/testing/docscrape.py
@@ -302,7 +302,7 @@ class NumpyDocString(object):
 
         summary = self._doc.read_to_next_empty_line()
         summary_str = " ".join([s.strip() for s in summary]).strip()
-        if re.compile('^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
+        if re.compile(r'^([\w., ]+=)?\s*[\w\.]+\(.*\)$').match(summary_str):
             self['Signature'] = summary_str
             if not self._is_at_section():
                 self['Summary'] = self._doc.read_to_next_empty_line()
@@ -342,7 +342,7 @@ class NumpyDocString(object):
 
     def _str_signature(self):
         if self['Signature']:
-            return [self['Signature'].replace('*','\*')] + ['']
+            return [self['Signature'].replace('*', r'\*')] + ['']
         else:
             return ['']
 
@@ -461,7 +461,7 @@ class FunctionDoc(NumpyDocString):
                 # try to read signature
                 argspec = inspect.getargspec(func)
                 argspec = inspect.formatargspec(*argspec)
-                argspec = argspec.replace('*','\*')
+                argspec = argspec.replace('*', r'\*')
                 signature = '%s%s' % (func_name, argspec)
             except TypeError as e:
                 signature = '%s()' % func_name
@@ -479,7 +479,7 @@ class FunctionDoc(NumpyDocString):
         out = ''
 
         func, func_name = self.get_func()
-        signature = self['Signature'].replace('*', '\*')
+        signature = self['Signature'].replace('*', r'\*')
 
         roles = {'func': 'function',
                  'meth': 'method'}

--- a/mdtraj/testing/docstrings.py
+++ b/mdtraj/testing/docstrings.py
@@ -123,7 +123,7 @@ def docstring_verifiers(module, error_on_none=False):
                 try:
                     f(*list(range(100)))
                 except TypeError as e:
-                    m = re.search('takes at most (\d+) positional arguments', str(e))
+                    m = re.search(r'takes at most (\d+) positional arguments', str(e))
                     if not m:
                         return
                     n_args = int(m.group(1))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ requires = [
     "oldest-supported-numpy",
     "Cython~=0.29.36",
 ]
+
+[tool.ruff]
+select = [
+    "W605",  # invalid-escape-sequence
+]


### PR DESCRIPTION
Add [ruff](https://beta.ruff.rs/) check of [invalid-escape-sequence (W605)](https://beta.ruff.rs/docs/rules/invalid-escape-sequence/) linter rule to CI pipeline.

Fixes https://github.com/mdtraj/mdtraj/issues/1806