### PR TITLE
Handle hex residue numbers in CONECT records

### DIFF
--- a/mdtraj/formats/pdb/pdbstructure.py
+++ b/mdtraj/formats/pdb/pdbstructure.py
@@ -201,13 +201,16 @@ class PdbStructure(object):
                 self._unit_cell_angles = (float(pdb_line[33:40]), float(pdb_line[40:47]), float(pdb_line[47:54]))
 
             elif (pdb_line.find("CONECT") == 0):
-                atoms = [int(pdb_line[6:11])]
-                for pos in (11,16,21,26):
+                atoms = []
+                for pos in (6,11,16,21,26):
                     try:
                         atoms.append(int(pdb_line[pos:pos+5]))
                     except ValueError:
-                        # Optional field, don't worry if it isn't defined
-                        pass
+                        try:
+                            atoms.append(int(pdb_line[pos:pos+5], 16))
+                        except ValueError:
+                            # Optional field, don't worry if it isn't defined
+                            pass
 
                 self._current_model.connects.append(atoms)
         self._finalize()


### PR DESCRIPTION
Adds a small fix to handle hex residue numbers in CONECT records. mdtraj already handles this elsewhere when parsing ATOM records, but the current CONECT logic will raise an error if those residue numbers show up in a CONECT row as well.

Tested this on a PDB file with CONECT records and validated that it successfully sets `self._current_model.connects` and does not raise an error.