### PR TITLE
Drop distutils usage and add Python 3.12 tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,6 +30,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
   
     steps:
     - uses: actions/checkout@v3

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import os
 import sys
 import socket
-from distutils.spawn import find_executable as _find_executable
+import shutil
 
 import pytest
 
@@ -40,7 +40,7 @@ def is_network_connected():
 
 def find_executable(names):
     for possible in names:
-        result = _find_executable(possible)
+        result = shutil.which(possible)
         if result is not None:
             return result
     return None

--- a/mdtraj/formats/amberrst.py
+++ b/mdtraj/formats/amberrst.py
@@ -30,12 +30,13 @@ removing the functionality that is not needed.
 """
 
 from __future__ import print_function, division
-from distutils.version import StrictVersion
 from math import ceil
 import os
 import warnings
 
 import numpy as np
+from packaging.version import Version
+
 from mdtraj import version
 from mdtraj.formats.registry import FormatRegistry
 from mdtraj.utils import ensure_type, import_, in_units_of, cast_indices, six
@@ -462,7 +463,7 @@ class AmberNetCDFRestartFile(object):
     def __init__(self, filename, mode='r', force_overwrite=False):
         self._closed = True
         self._mode = mode
-        if StrictVersion(import_('scipy.version').short_version) < StrictVersion('0.12.0'):
+        if Version(import_('scipy.version').short_version) < Version('0.12.0'):
             raise ImportError('MDTraj NetCDF support requires scipy>=0.12.0. '
                               'You have %s' % import_('scipy.version').short_version)
         netcdf = import_('scipy.io').netcdf_file

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -37,9 +37,9 @@ import os
 import socket
 import warnings
 from datetime import datetime
-from distutils.version import StrictVersion
 
 import numpy as np
+from packaging.version import Version
 from mdtraj import version
 from mdtraj.formats.registry import FormatRegistry
 from mdtraj.utils import ensure_type, import_, in_units_of, cast_indices
@@ -127,7 +127,7 @@ class NetCDFTrajectoryFile(object):
     def __init__(self, filename, mode='r', force_overwrite=True):
         self._closed = True   # is the file currently closed?
         self._mode = mode      # what mode were we opened in
-        if StrictVersion(import_('scipy.version').short_version) < StrictVersion('0.12.0'):
+        if Version(import_('scipy.version').short_version) < Version('0.12.0'):
             raise ImportError('MDTraj NetCDF support requires scipy>=0.12.0. '
                               'You have %s' % import_('scipy.version').short_version)
         netcdf = import_('scipy.io').netcdf_file

--- a/mdtraj/nmr/shift_wrappers.py
+++ b/mdtraj/nmr/shift_wrappers.py
@@ -23,9 +23,9 @@
 from __future__ import print_function, absolute_import
 
 import os
+import shutil
 import subprocess
-from distutils.spawn import find_executable as _find_executable
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import numpy as np
 
@@ -46,7 +46,7 @@ __all__ = ['chemical_shifts_shiftx2', 'chemical_shifts_ppm', 'chemical_shifts_sp
 
 def find_executable(names):
     for possible in names:
-        result = _find_executable(possible)
+        result = shutil.which(possible)
         if result is not None:
             return result
     return None
@@ -154,7 +154,7 @@ def chemical_shifts_shiftx2(trj, pH=5.0, temperature=298.00):
 
     results = pd.concat(results)
 
-    if LooseVersion(pd.__version__) < LooseVersion('0.14.0'):
+    if Version(pd.__version__) < Version('0.14.0'):
         results = results.pivot_table(rows=["resSeq", "name"], cols="frame", values="SHIFT")
     else:
         results = results.pivot_table(index=["resSeq", "name"], columns="frame", values="SHIFT")
@@ -298,7 +298,7 @@ def chemical_shifts_spartaplus(trj, rename_HN=True):
     if rename_HN:
         results.name[results.name == "HN"] = "H"
 
-    if LooseVersion(pd.__version__) < LooseVersion('0.14.0'):
+    if Version(pd.__version__) < Version('0.14.0'):
         results = results.pivot_table(rows=["resSeq", "name"], cols="frame", values="SHIFT")
     else:
         results = results.pivot_table(index=["resSeq", "name"], columns="frame", values="SHIFT")

--- a/setup.py
+++ b/setup.py
@@ -264,6 +264,7 @@ metadata = \
                         'scipy',
                         'astunparse',
                         'pyparsing',
+                        'packaging',
                         ],
       package_data={'mdtraj.formats.pdb': ['data/*'], },
       zip_safe=False,

--- a/tests/test_dihedral.py
+++ b/tests/test_dihedral.py
@@ -1,6 +1,6 @@
 import itertools
 import os
-from distutils.spawn import find_executable
+import shutil
 
 import mdtraj as md
 import numpy as np
@@ -18,7 +18,7 @@ def traj(get_fn):
 
 @pytest.fixture()
 def pymol():
-    pymol = find_executable('pymol')
+    pymol = shutil.which('pymol')
     if pymol is None:
         try_paths = ['/Applications/MacPyMOL.app/Contents/MacOS/MacPyMOL']
         for path in try_paths:

--- a/tests/test_dssp.py
+++ b/tests/test_dssp.py
@@ -1,14 +1,14 @@
 import itertools
 import os
 import subprocess
-from distutils.spawn import find_executable
+import shutil
 
 import mdtraj as md
 import numpy as np
 import pytest
 
 DSSP_MSG = "This test requires mkdssp to be installed, from http://swift.cmbi.ru.nl/gv/dssp/"
-needs_dssp = pytest.mark.skipif(not find_executable('mkdssp'), reason=DSSP_MSG)
+needs_dssp = pytest.mark.skipif(not shutil.which('mkdssp'), reason=DSSP_MSG)
 
 
 def call_dssp(dirname, traj, frame=0):

--- a/tests/test_hbonds.py
+++ b/tests/test_hbonds.py
@@ -23,7 +23,7 @@
 
 import os
 import subprocess
-from distutils.spawn import find_executable
+import shutil
 
 import mdtraj as md
 import numpy as np
@@ -32,7 +32,7 @@ import scipy.sparse
 from mdtraj.testing import eq
 
 DSSP_MSG = "This test requires mkdssp to be installed, from http://swift.cmbi.ru.nl/gv/dssp/"
-needs_dssp = pytest.mark.skipif(not find_executable('mkdssp'), reason=DSSP_MSG)
+needs_dssp = pytest.mark.skipif(not shutil.which('mkdssp'), reason=DSSP_MSG)
 
 
 def test_hbonds(get_fn):

--- a/tests/test_mol2.py
+++ b/tests/test_mol2.py
@@ -23,7 +23,7 @@
 import mdtraj as md
 from mdtraj.testing import eq
 from mdtraj.formats import mol2
-from distutils.spawn import find_executable
+import shutil
 import tarfile
 import pickle
 import os
@@ -52,7 +52,7 @@ def test_load_mol2(get_fn):
     eq(bonds, ref_bonds)
 
 
-@pytest.mark.skipif(find_executable('obabel') is None, reason='Requires obabel')
+@pytest.mark.skipif(shutil.which('obabel') is None, reason='Requires obabel')
 @pytest.mark.skipif(os.environ.get("TRAVIS", None) == 'true', reason="Skip on Travis.")
 def test_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb(get_fn, tmpdir):
     tar_filename = "freesolve_v0.3.tar.bz2"

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -27,11 +27,10 @@ import mdtraj as md
 import subprocess
 from mdtraj.testing import eq
 import pytest
-
-from distutils.spawn import find_executable
+import shutil
 
 needs_cpptraj = pytest.mark.skipif(
-    find_executable('cpptraj') is None,
+    shutil.which('cpptraj') is None,
     reason="This test requires cpptraj from AmberTools to be installed "
            "(http://ambermd.org)"
 )

--- a/tests/test_psf.py
+++ b/tests/test_psf.py
@@ -22,7 +22,7 @@
 
 import os
 import subprocess
-from distutils.spawn import find_executable
+import shutil
 
 import mdtraj as md
 import pytest
@@ -30,9 +30,9 @@ from mdtraj.formats import psf
 from mdtraj.testing import eq
 from mdtraj.utils import enter_temp_directory
 
-VMD = find_executable('vmd')
+VMD = shutil.which('vmd')
 needs_vmd = pytest.mark.skipif(
-    not find_executable('vmd'),
+    not shutil.which('vmd'),
     reason='This test requires the VMD executable: http://www.ks.uiuc.edu/Research/vmd/'
 )
 


### PR DESCRIPTION
The `distutils` module has been removed from Python 3.12 per [PEP 632](https://peps.python.org/pep-0632/).