### PR TITLE
Run tests in parallel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,4 +54,4 @@ jobs:
     - name: Run tests
       if: always()
       run: |
-        pytest -nauto --durations=10 tests/
+        pytest -n auto --durations=10 tests/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,4 +54,4 @@ jobs:
     - name: Run tests
       if: always()
       run: |
-        pytest --durations=10 tests/
+        pytest -nauto --durations=10 tests/

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -16,3 +16,4 @@ dependencies:
   - pytables
   - gsd>=2.8
   - pytest
+  - pytest-xdist


### PR DESCRIPTION
Free runners include two cores these days and tests take a few minutes, so this should speed things up.