### PR TITLE
Add atom selection via atom_indices to SASA computation (try #2, three years after)

### DIFF
--- a/mdtraj/geometry/include/sasa.h
+++ b/mdtraj/geometry/include/sasa.h
@@ -6,7 +6,7 @@ extern "C" {
 
 void sasa(const int n_frames, const int n_atoms, const float* xyzlist,
           const float* atom_radii, const int n_sphere_points,
-          const int* atom_mapping, const int n_groups, float* out);
+          const int* atom_mapping, const int* atom_selection_mask, const int n_groups, float* out);
 
 
 #ifdef __cplusplus

--- a/mdtraj/geometry/sasa.py
+++ b/mdtraj/geometry/sasa.py
@@ -216,7 +216,7 @@ def shrake_rupley(
         for what atoms the SASA is computed. E.g. you can pass a lipid-embedded
         protein (s.t. the lipids are considered blockers) but only compute
         SASA for the protein using atom_selection = traj.top.select("protein").
-        The excluded atoms/residues get a SASA value 0
+        The excluded atoms/residues get a SASA value -1.
 
     Returns
     -------
@@ -287,9 +287,11 @@ def shrake_rupley(
 
     if atom_indices is None:
         atom_selection_mask = np.ones(traj.n_atoms, dtype=np.int32)
+        out = np.zeros((xyz.shape[0], dim1), dtype=np.float32)
     else:
-
         atom_selection_mask = np.array([[1 if ii in atom_indices else 0][0] for ii in range(traj.n_atoms)], dtype=np.int32)
+        out = np.full((xyz.shape[0], dim1), -1, dtype=np.float32)
+        out[:,atom_mapping[atom_indices]]=0
 
     modified_radii = {}
     if change_radii is not None:
@@ -299,7 +301,6 @@ def shrake_rupley(
         for k, v in change_radii.items():
             modified_radii[k] = v
 
-    out = np.zeros((xyz.shape[0], dim1), dtype=np.float32)
     if bool(modified_radii):
         atom_radii = [modified_radii[atom.element.symbol] for atom in traj.topology.atoms]
     else:

--- a/mdtraj/geometry/sasa.py
+++ b/mdtraj/geometry/sasa.py
@@ -183,6 +183,7 @@ def shrake_rupley(
     mode="atom",
     change_radii=None,
     get_mapping=False,
+    atom_indices=None
 ):
     """Compute the solvent accessible surface area of each atom or residue in each simulation frame.
 
@@ -207,6 +208,15 @@ def shrake_rupley(
         Instead of returning only the areas, also return the indices of the
         atoms or the residue-to-atom mapping. If True, will return a tuple
         that contains the areas and the mapping (np.array, shape=(n_atoms)).
+    atom_indices : iterable, optional
+        Selection of atoms indices for which the SASA will be computed.
+        Default is all atoms, but a sub-selection of atoms can be
+        passed here. This selection doesn't affect what
+        atoms are considered accessibility blockers, it only affects
+        for what atoms the SASA is computed. E.g. you can pass a lipid-embedded
+        protein (s.t. the lipids are considered blockers) but only compute
+        SASA for the protein using atom_selection = traj.top.select("protein").
+        The excluded atoms/residues get a SASA value 0
 
     Returns
     -------
@@ -272,9 +282,14 @@ def shrake_rupley(
                 "residues must have contiguous integer indices " "starting from zero",
             )
     else:
-        raise ValueError(
-            'mode must be one of "residue", "atom". "%s" supplied' % mode,
-        )
+        raise ValueError('mode must be one of "residue", "atom". "%s" supplied' %
+                         mode)
+
+    if atom_indices is None:
+        atom_selection_mask = np.ones(traj.n_atoms, dtype=np.int32)
+    else:
+
+        atom_selection_mask = np.array([[1 if ii in atom_indices else 0][0] for ii in range(traj.n_atoms)], dtype=np.int32)
 
     modified_radii = {}
     if change_radii is not None:
@@ -291,7 +306,7 @@ def shrake_rupley(
         atom_radii = [_ATOMIC_RADII[atom.element.symbol] for atom in traj.topology.atoms]
     radii = np.array(atom_radii, np.float32) + probe_radius
 
-    _geometry._sasa(xyz, radii, int(n_sphere_points), atom_mapping, out)
+    _geometry._sasa(xyz, radii, int(n_sphere_points), atom_mapping, atom_selection_mask, out)
 
     if get_mapping is True:
         return out, atom_mapping

--- a/mdtraj/geometry/src/_geometry.pyx
+++ b/mdtraj/geometry/src/_geometry.pyx
@@ -86,7 +86,7 @@ cdef extern from "geometry.h" nogil:
 cdef extern from "sasa.h":
     void sasa(const int n_frames, const int n_atoms, const float* xyzlist,
               const float* atom_radii, const int n_sphere_points,
-              const int* atom_mapping, const int n_groups, float* out) nogil
+              const int* atom_mapping, const int* atom_selection, const int n_groups, float* out) nogil
 
 
 ##############################################################################
@@ -228,11 +228,12 @@ def _sasa(float[:, :, ::1] xyz,
           float[::1] atom_radii,
           int n_sphere_points,
           int[::1] atom_outmapping,
+          int[::1] atom_selection_mask,
           float[:, ::1] out):
     cdef int n_frames = xyz.shape[0]
     cdef int n_atoms = xyz.shape[1]
     sasa(n_frames, n_atoms, &xyz[0,0,0], &atom_radii[0], n_sphere_points,
-         &atom_outmapping[0], out.shape[1], &out[0,0])
+         &atom_outmapping[0], &atom_selection_mask[0], out.shape[1], &out[0,0])
 
 
 def _dssp(float[:, :, ::1] xyz,

--- a/tests/test_sasa.py
+++ b/tests/test_sasa.py
@@ -184,8 +184,8 @@ def test_sasa_6(get_fn):
     # The computed SASA values are the same as in "normal" mode
     np.testing.assert_array_almost_equal(sasa_all_atoms[:,atoms_resid1],
                                          sasa_all_atoms_w_selection[:,atoms_resid1])
-    # The uncomputed SASA values are all 0
-    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid0_2]),0)
+    # The uncomputed SASA values are all -1
+    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid0_2]),-1)
 
     # Mode="residues"
     sasa_all_residues = md.geometry.shrake_rupley(t, mode="residue")
@@ -194,8 +194,8 @@ def test_sasa_6(get_fn):
     # The computed SASA values are the same as in "normal" mode
     np.testing.assert_array_almost_equal(sasa_all_residues[:,1],
                                          sasa_all_residues_w_selection[:,1])
-    # The uncomputed SASA values are all 0
-    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, [0,2]]), 0)
+    # The uncomputed SASA values are all -1
+    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, [0,2]]), -1)
 
     #Test the non sequential selection
     # Mode="atom"
@@ -205,8 +205,8 @@ def test_sasa_6(get_fn):
     np.testing.assert_array_almost_equal(sasa_all_atoms[:, atoms_resid0_2],
                                          sasa_all_atoms_w_selection[:, atoms_resid0_2])
 
-    # The uncomputed SASA values are all 0
-    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid1]),0)
+    # The uncomputed SASA values are all -1
+    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid1]),-1)
 
     # Mode="residues"
     sasa_all_residues_w_selection = md.geometry.shrake_rupley(t, atom_indices=atoms_resid0_2, mode="residue")
@@ -214,8 +214,8 @@ def test_sasa_6(get_fn):
     # The computed SASA values are the same as in "normal" mode
     np.testing.assert_array_almost_equal(sasa_all_residues[:, [0,2]],
                                          sasa_all_residues_w_selection[:, [0,2]])
-    # The uncomputed SASA values are all 0
-    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, 1]), 0)
+    # The uncomputed SASA values are all -1
+    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, 1]), -1)
 
 def test_sasa_7(get_fn):
     #Test the atom selection with specific atoms within residues
@@ -228,7 +228,7 @@ def test_sasa_7(get_fn):
     sasa_all_atoms = md.geometry.shrake_rupley(t)
     np.testing.assert_equal(sasa_all_atoms[:,atoms_resid1_HB3], SASA_resid1_HB3_per_atom[:,atoms_resid1_HB3])
     assert all(SASA_resid1_HB3_per_atom[:,atoms_resid1_HB3]>0)
-    np.testing.assert_equal(SASA_resid1_HB3_per_atom[:,atoms_not_resid1_HB3], 0)
+    np.testing.assert_equal(SASA_resid1_HB3_per_atom[:,atoms_not_resid1_HB3], -1)
 
     # Nothing changes if you do "residue" mode bc only one atom is contributing
     SASA_resid1_HB3_per_residue = md.geometry.shrake_rupley(t, atom_indices=atoms_resid1_HB3, mode="residue")

--- a/tests/test_sasa.py
+++ b/tests/test_sasa.py
@@ -170,3 +170,29 @@ def test_sasa_5():
     np.testing.assert_approx_equal(calc_area_sulfur, true_area_sulfur)
     # Finally, ensure that we are not changing _ATOMIC_RADII
     assert prev_area_chlorine != calc_area_chlorine
+
+def test_sasa_6(get_fn):
+    #Test the atom selection
+    t = md.load(get_fn('frame0.h5'))
+    atoms_resid1 = t.top.select("resid 1").astype(int)
+    atoms_resid0_2 = t.top.select("resid 0 2").astype(int)
+
+    # Mode="atom"
+    sasa_all_atoms = md.geometry.shrake_rupley(t)
+    sasa_all_atoms_w_selection = md.geometry.shrake_rupley(t, atom_indices=atoms_resid1)
+
+    # The computed SASA values are the same as in "normal" mode
+    np.testing.assert_array_almost_equal(sasa_all_atoms[:,atoms_resid1],
+                                         sasa_all_atoms_w_selection[:,atoms_resid1])
+    # The uncomputed SASA values are all NaN
+    np.testing.assert_equal(np.unique(sasa_all_atoms_w_selection[:,atoms_resid0_2]),0)
+
+    # Mode="residues"
+    sasa_all_residues = md.geometry.shrake_rupley(t, mode="residue")
+    sasa_all_residues_w_selection = md.geometry.shrake_rupley(t, atom_indices=atoms_resid1, mode="residue")
+
+    # The computed SASA values are the same as in "normal" mode
+    np.testing.assert_array_almost_equal(sasa_all_residues[:,1],
+                                         sasa_all_residues_w_selection[:,1])
+    # The uncomputed SASA values are all NaN
+    np.testing.assert_equal(np.unique(sasa_all_residues_w_selection[:, [0,2]]), 0)


### PR DESCRIPTION
A little holiday coding for something I had working locally for 3 years and never pushed (#[PR1671](https://github.com/mdtraj/mdtraj/pull/1671) was closed as stale/wontfix). It's been crucial for all my projects all this time.

Here's the original PR message:
> Limit the SASA computation to some atoms of interest via atom_indices when calling md.shrake_rupley
> 
> The excluded atoms are still considered as potential surface accessibility blockers, but their own SASA doesn't get computed and gets set to zero instead.
> 
> This is particularly helpful for membrane-embedded proteins where you want the lipids "there" but you don't really care about their SASA.
>  

I followed @rmcgibbo 's suggestion for the c++ implementation. 

The return SASA-value for 'excluded' atoms/residues is set to np.nan in 9b0d5b81021e0eabb42958462281073d5caf77d0. I can revert that if you prefer a 0 value.