### PR TITLE
preseving chain_id on creating subset.

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -96,7 +96,7 @@ def _topology_from_subset(topology, atom_indices):
     old_atom_to_new_atom = {}
 
     for chain in topology._chains:
-        newChain = newTopology.add_chain()
+        newChain = newTopology.add_chain(chain_id=chain.chain_id)
         for residue in chain._residues:
             resSeq = getattr(residue, 'resSeq', None) or residue.index
             newResidue = None

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -327,3 +327,19 @@ def test_topology_join_keep_resSeq(get_fn):
 
     eq(out_resSeq_keepId_True, expected_resSeq_keepId_True)
     eq(out_resSeq_keepId_False, expected_resSeq_keepId_False)
+
+def test_preserve_chain_id(get_fn): 
+    # This pdb has three chains, A, B and C.  
+    traj = md.load(get_fn("1vii_sustiva_water.pdb"))
+    sub_traj = traj.atom_slice(traj.top.select('chainid 1'))
+    eq(sub_traj.top._chains[0].chain_id, 'B')
+
+def test_preserve_resseq(get_fn): 
+    traj = md.load(get_fn("1vii_sustiva_water.pdb"))
+    sub_traj = traj.atom_slice(traj.top.select('chainid 0 and resSeq 2'))
+    eq(sub_traj.top._residues[0].resSeq, 2)
+
+def test_preserve_serial(get_fn): 
+    traj = md.load(get_fn("1vii_sustiva_water.pdb"))
+    sub_traj = traj.atom_slice(traj.top.select('chainid 0 and index 2')) # serial = 3
+    eq(sub_traj.top._atoms[0].serial, 3)


### PR DESCRIPTION
Hi folks, 

This addresses #1853.  When a new topology is created from a subset of atoms, the `chain_id` from the previous chain is carried across.  

Added three new tests in `test_topology.py`
1. `test_preserve_chain_id`
2. `test_preserve_resseq`
3. `test_preserve_serial`

The last two are for completeness - they are already working but not tested. 
