### PR TITLE
Sets netCDF4 as default in NetCDFTrajectoryFile, fallback to scipy

### DIFF
--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -125,17 +125,42 @@ class NetCDFTrajectoryFile(object):
         self._closed = True   # is the file currently closed?
         self._mode = mode      # what mode were we opened in
 
-        netcdf = import_('scipy.io').netcdf_file
+        try:
+            # import netcdf4 if it's available
+            netcdf = import_('netCDF4').Dataset
 
-        if mode not in ['r', 'w']:
-            raise ValueError("mode must be one of ['r', 'w']")
+            # mode check for netCDF4
+            if mode not in ['r', 'w', 'a', 'ws', 'as']:
+                raise ValueError(("mode must be one of ['r', 'w', 'a', 'ws', 'as'] if using netCDF4."
+                    " 'r' indicates read, 'w' indicates write, and 'a' indicates"
+                    " append. 'a' and 'w' can be appended with 's', which turns "
+                    " off buffering"))
+            
+            # set input args for netCDF4
+            input_args = {'format': 'NETCDF3_64BIT', 'clobber': force_overwrite}
+
+        except ImportError:
+            netcdf = import_('scipy.io').netcdf_file
+
+            # warn the user, even though the import above also gives
+            # them a big warning. 
+            warnings.warn('Could not find netCDF4 module. Falling back on '
+                              'scipy implementation, which can be significantly'
+                              'slower than the netCDF4 implementation.')
+            
+            # mode check for scipy.io.netcdf_file
+            if mode not in ['r', 'w']:
+                raise ValueError("mode must be one of ['r', 'w'] if using scipy.io.netcdf_file.")
+            
+            # input args for scipy.io.netcdf_file
+            # AMBER uses the NetCDF3 format, with 64 bit encodings, which
+            # for scipy.io.netcdf_file is "version=2"
+            input_args = {'version': 2}
 
         if mode == 'w' and not force_overwrite and os.path.exists(filename):
             raise IOError('"%s" already exists' % filename)
 
-        # AMBER uses the NetCDF3 format, with 64 bit encodings, which
-        # for scipy.io.netcdf_file is "version=2"
-        self._handle = netcdf(filename, mode=mode, version=2)
+        self._handle = netcdf(filename, mode=mode, **input_args)
         self._closed = False
 
         # self._frame_index is the current frame that we're at in the

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -33,7 +33,6 @@ The code is heavily based on amber_netcdf_trajectory_tools.py by John Chodera.
 
 import os
 import socket
-import sys
 import warnings
 from datetime import datetime
 
@@ -141,13 +140,13 @@ class NetCDFTrajectoryFile(object):
             netcdf = scipy.io.netcdf_file
 
             warning_message = (
-                "Warning: The 'netCDF4' Python module is not installed. MDTraj is using the 'scipy' "
+                "Warning: The 'netCDF4' Python package is not installed. MDTraj is using the 'scipy' "
                 "implementation to read and write netCDF files,which can be significantly slower.\n"
-                "For improved performance, consider installing the 'netCDF4' module. See installation instructions at:\n"
+                "For improved performance, consider installing netCDF4. See installation instructions at:\n"
                 "https://unidata.github.io/netcdf4-python/#quick-install"
             )
             
-            print(warning_message, file=sys.stderr)
+            warnings.warn(warning_message)
 
             # input args for scipy.io.netcdf_file
             # AMBER uses the NetCDF3 format, with 64 bit encodings, which

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -33,13 +33,14 @@ The code is heavily based on amber_netcdf_trajectory_tools.py by John Chodera.
 
 import os
 import socket
+import sys
 import warnings
 from datetime import datetime
 
 import numpy as np
 from mdtraj import version
 from mdtraj.formats.registry import FormatRegistry
-from mdtraj.utils import ensure_type, import_, in_units_of, cast_indices
+from mdtraj.utils import ensure_type, in_units_of, cast_indices
 
 __all__ = ['NetCDFTrajectoryFile', 'load_netcdf']
 
@@ -127,21 +128,27 @@ class NetCDFTrajectoryFile(object):
 
         try:
             # import netcdf4 if it's available
-            netcdf = import_('netCDF4').Dataset
+            import netCDF4
+            netcdf = netCDF4.Dataset
             
             # set input args for netCDF4
             input_args = {'format': 'NETCDF3_64BIT', 'clobber': force_overwrite}
 
         except ImportError:
-            netcdf = import_('scipy.io').netcdf_file
-
-            # warn the user, even though the import above also gives
-            # them a big warning. 
-            warnings.warn('Could not find netCDF4 module. Falling back on '
-                              'scipy implementation, which can be significantly'
-                              'slower than the netCDF4 implementation.')
-        
             
+            import scipy.io
+
+            netcdf = scipy.io.netcdf_file
+
+            warning_message = (
+                "Warning: The 'netCDF4' Python module is not installed. MDTraj is using the 'scipy' "
+                "implementation to read and write netCDF files,which can be significantly slower.\n"
+                "For improved performance, consider installing the 'netCDF4' module. See installation instructions at:\n"
+                "https://unidata.github.io/netcdf4-python/#quick-install"
+            )
+            
+            print(warning_message, file=sys.stderr)
+
             # input args for scipy.io.netcdf_file
             # AMBER uses the NetCDF3 format, with 64 bit encodings, which
             # for scipy.io.netcdf_file is "version=2"

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -128,13 +128,6 @@ class NetCDFTrajectoryFile(object):
         try:
             # import netcdf4 if it's available
             netcdf = import_('netCDF4').Dataset
-
-            # mode check for netCDF4
-            if mode not in ['r', 'w', 'a', 'ws', 'as']:
-                raise ValueError(("mode must be one of ['r', 'w', 'a', 'ws', 'as'] if using netCDF4."
-                    " 'r' indicates read, 'w' indicates write, and 'a' indicates"
-                    " append. 'a' and 'w' can be appended with 's', which turns "
-                    " off buffering"))
             
             # set input args for netCDF4
             input_args = {'format': 'NETCDF3_64BIT', 'clobber': force_overwrite}
@@ -147,15 +140,15 @@ class NetCDFTrajectoryFile(object):
             warnings.warn('Could not find netCDF4 module. Falling back on '
                               'scipy implementation, which can be significantly'
                               'slower than the netCDF4 implementation.')
-            
-            # mode check for scipy.io.netcdf_file
-            if mode not in ['r', 'w']:
-                raise ValueError("mode must be one of ['r', 'w'] if using scipy.io.netcdf_file.")
+        
             
             # input args for scipy.io.netcdf_file
             # AMBER uses the NetCDF3 format, with 64 bit encodings, which
             # for scipy.io.netcdf_file is "version=2"
             input_args = {'version': 2}
+
+        if mode not in ['r', 'w']:
+            raise ValueError("mode must be one of ['r', 'w']")
 
         if mode == 'w' and not force_overwrite and os.path.exists(filename):
             raise IOError('"%s" already exists' % filename)

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -176,7 +176,14 @@ class NetCDFTrajectoryFile(object):
         self._validate_open()
         if self._needs_initialization:
             raise IOError('The file is uninitialized.')
-        return self._handle.dimensions['atom']
+        
+        try:
+            # netCDF4 requires use of .size on dimensions
+            # to get size as integer. 
+            return self._handle.dimensions['atom'].size
+        except AttributeError:
+            # scipy case
+            return self._handle.dimensions['atom']
 
     @property
     def n_frames(self):

--- a/mdtraj/utils/delay_import.py
+++ b/mdtraj/utils/delay_import.py
@@ -78,7 +78,7 @@ MESSAGES = {
     sharing of array-oriented scientific data.
 
     netcdf4-python can be downloaded from https://pypi.python.org/pypi/netCDF,
-    or installed with the python "coonda" or "pip" package managers using:
+    or installed with the python "conda" or "pip" package managers using:
 
     # conda install -c conda-forge netCDF4
     or

--- a/mdtraj/utils/delay_import.py
+++ b/mdtraj/utils/delay_import.py
@@ -77,7 +77,7 @@ MESSAGES = {
     machine-independent data formats that support the creation, access, and
     sharing of array-oriented scientific data.
 
-    netcdf4-python can be downloaded from https://pypi.python.org/pypi/netCDF,
+    netcdf4-python can be downloaded from https://pypi.python.org/pypi/netCDF4,
     or installed with the python "conda" or "pip" package managers using:
 
     # conda install -c conda-forge netCDF4

--- a/mdtraj/utils/delay_import.py
+++ b/mdtraj/utils/delay_import.py
@@ -78,15 +78,15 @@ MESSAGES = {
     sharing of array-oriented scientific data.
 
     netcdf4-python can be downloaded from https://pypi.python.org/pypi/netCDF,
-    or installed with the python "easy_install" or "pip" package managers using:
+    or installed with the python "coonda" or "pip" package managers using:
 
-    # easy_install netCDF4
+    # conda install -c conda-forge netCDF4
     or
     # pip install netCDF4
 
     netcdf4-python also depends on the C-language HDF5 and NetCDF libraries.
     For detailed installation instructions, visit
-    http://netcdf4-python.googlecode.com/svn/trunk/docs/netCDF4-module.html
+    https://unidata.github.io/netcdf4-python/#quick-install
     ''',
 
     'openmm.unit': '''


### PR DESCRIPTION
This PR addresses #1831.

I've adopted the strategy suggested by the Issue author, based on an approach taken in ParmEd and MDAnalysis, to use netCDF4 if installed and fall back to SciPy netCDF if not installed.

I based the code for netCDF4 on the original version in the code base. It used netCDF4 before SciPy netCDF, PR that changed it here - https://github.com/mdtraj/mdtraj/pull/360/files

Here is a small demo notebook that demonstrates both backends being used: https://github.com/janash/mdtraj-netcdf/blob/main/openmm.ipynb

I also updated the message about `netCDF4` to give information about `conda` and have an updated URL

One thing I'm not quite sure about is using `import_`. It gives a very verbose message, but it's not actually causing an Exception with my current use, so may be confusing.