### PR TITLE
chain_id field when using to/from_dataframe

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -449,7 +449,8 @@ class Topology(object):
         pd = import_('pandas')
         data = [(atom.serial, atom.name, atom.element.symbol,
                  atom.residue.resSeq, atom.residue.name,
-                 atom.residue.chain.index,atom.segment_id) for atom in self.atoms]
+                 [atom.residue.chain.index if atom.residue.chain.chain_id is None else atom.residue.chain.chain_id][0],
+                 atom.segment_id) for atom in self.atoms]
 
         atoms = pd.DataFrame(data, columns=["serial", "name", "element",
                                             "resSeq", "resName", "chainID","segmentID"])
@@ -532,7 +533,7 @@ class Topology(object):
             if atom['chainID'] != previous_chainID:
                 previous_chainID = atom['chainID']
 
-                c = out.add_chain()
+                c = out.add_chain(previous_chainID)
 
             if atom['resSeq'] != previous_resSeq or atom['resName'] != previous_resName or c.n_atoms==0:
                 previous_resSeq = atom['resSeq']

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -533,7 +533,7 @@ class Topology(object):
             if atom['chainID'] != previous_chainID:
                 previous_chainID = atom['chainID']
 
-                c = out.add_chain(previous_chainID)
+                c = out.add_chain(previous_chainID, chain_id=previous_chainID)
 
             if atom['resSeq'] != previous_resSeq or atom['resName'] != previous_resName or c.n_atoms==0:
                 previous_resSeq = atom['resSeq']


### PR DESCRIPTION
ChainID/chain_id attribute was recently (#1715) implemented for pdbfiles, it would be nice if the attribute survives  the to_dataframe/from_dataframe cycle.

Previous behavior:
* `to_dataframe` had a  `chainID` column in the DataFrame, but placed the `atom.residue.chain.index` attribute in it.
* `from_dataframe` read the `chainID` but used it only to detect new chains, it did not get passed to `add_chain`.

New behavior:
* Try to store the actual `chain_id` attribute in the `chainID` column (else fallback to `index`)  when using `top.to_dataframe`
* Add the `chainID` column as `chain_id` when using `from_dataframe`.