### PR TITLE
CI macos-latest fix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,8 +47,8 @@ jobs:
 
     - name: Environment Information
       run: |
-        mamba info
-        mamba list
+        micromamba info
+        micromamba list
 
     - name: Run tests
       if: always()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,8 @@ jobs:
 
       matrix:
         os:
-          - macOS-latest
+          - macOS-latest  # arm64
+          - macOS-13  # x86-64
           - ubuntu-latest
         python-version:
           - "3.10"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
 
       matrix:
         os:
-          - macOS-latest
+          - macOS-13
           - ubuntu-latest
         python-version:
           - "3.10"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
 
       matrix:
         os:
-          - macOS-13
+          - macOS-latest
           - ubuntu-latest
         python-version:
           - "3.10"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,8 +47,8 @@ jobs:
 
     - name: Environment Information
       run: |
-        conda info
-        conda list
+        mamba info
+        mamba list
 
     - name: Run tests
       if: always()


### PR DESCRIPTION
Just in case any of the maintainers are wondering, GitHub Action runner images for `macos-latest` has shifted to `macos-14-arm64` a few days ago (from `macos-12`, which is x86-64). That's probably causing the fails in the scheduled CI.

Changing from `macos-latest` to `macos-13` should fix this for the time being, until the arm64 workflows are ready. `macos-13` is the last "standard" (i.e., free) x86-64 runner image from GitHub.