### PR TITLE
Disable intrinsics when SIMD is not available

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -77,7 +77,7 @@ class CompilerDetection(object):
             self.disable_intrinsics = True
             print("Env var MDTRAJ_BUILD_DISABLE_INTRINSICS set")
         else:
-            self.disable_intrinsics = False
+            self.disable_intrinsics = not (self.sse2_enabled or self.neon_enabled)
 
 
         if self.openmp_enabled:


### PR DESCRIPTION
`intrinsics` can only be turned off by an environment variable, but even if a CPU does not support SIMD, it will be enabled and the build will fail if this variable is not defined.
I suggest disabling intrinsics by default if sse2 or neon is not available.