### PR TITLE
fix editable mode, add packaging as dependency

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -307,6 +307,15 @@ release = {release}
         )
 
 
+def copy_same_file_pass(source, destination):
+    try:
+        # Try to copy
+        shutil.copy(source, destination)
+    except shutil.SameFileError:
+        # Ignore the error
+        pass
+
+
 class StaticLibrary(Extension):
     def __init__(self, *args, **kwargs):
         self.export_include = kwargs.pop("export_include", [])
@@ -376,12 +385,18 @@ class build_ext(_build_ext):
 
         # 1. copy to build directory
         # 1. copy to src tree for develop mode
+        # 1. catch errors because we're running in editable mode
         import re
 
-        src_tree_output_dir = re.match("build.*(mdtraj.*)", output_dir).group(1)
+        src_tree_output_dir = re.match("build.*(mdtraj.*)", output_dir)
 
-        if not os.path.exists(src_tree_output_dir):
-            os.makedirs(src_tree_output_dir)
+        try:
+            # This might fail if no match in editable mode.
+            src_tree_output_dir.group(1)
+            if not os.path.exists(src_tree_output_dir):
+                os.makedirs(src_tree_output_dir)
+        except AttributeError:
+            src_tree_output_dir = output_dir
 
         if not os.path.exists(output_dir):
             # necessary for windows
@@ -398,11 +413,11 @@ class build_ext(_build_ext):
 
         lib_path = self.compiler.library_filename(libname, output_dir=output_dir)
 
-        shutil.copy(lib_path, src_tree_output_dir)
+        copy_same_file_pass(lib_path, src_tree_output_dir)
 
         for item in ext.export_include:
-            shutil.copy(item, src_tree_output_dir)
-            shutil.copy(item, output_dir)
+            copy_same_file_pass(item, src_tree_output_dir)
+            copy_same_file_pass(item, output_dir)
 
     def get_ext_filename(self, ext_name):
         filename = _build_ext.get_ext_filename(self, ext_name)

--- a/setup.py
+++ b/setup.py
@@ -310,6 +310,7 @@ metadata = dict(
         "scipy",
         "astunparse",
         "pyparsing",
+        "packaging",
     ],
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,


### PR DESCRIPTION
#1876 #1850 

Added some try/except blocks during file copy/file name matching in `base_setup.py` as these steps are unnecessary (and fails) during editable mode install.

Also added 'packaging' as an install dependency because it's no longer default as of python 3.12, but needed in `mdtraj/formats/amberrst.py`
