### PR TITLE
Fix netCDF file loading to no longer import scipy (and add netCDF to CI reqs)

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -16,3 +16,4 @@ dependencies:
   - gsd>=2.8
   - pytest
   - pytest-xdist
+  - netCDF4

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -158,8 +158,6 @@ class NetCDFTrajectoryFile:
             # for scipy.io.netcdf_file is "version=2"
             input_args = {"version": 2}
 
-        netcdf = import_("scipy.io").netcdf_file  # noqa: F841
-
         if mode not in ["r", "w"]:
             raise ValueError("mode must be one of ['r', 'w']")
 


### PR DESCRIPTION
A quick PR to address #1893 - changes below: 

1. Removes the line 

` netcdf = import_("scipy.io").netcdf_file `

from `formats/netcdf.py` which should fix netCDF4 loading issues.

2. Updated the `conda-envs/test.yaml` file to include netCDF4 in the requirements. This should ensure netCDF4 is in the CI env.

Let me know if I'm missing something! 