### PR TITLE
Mock-testing dependency absence for netCDF4

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -17,3 +17,4 @@ dependencies:
   - pytest
   - pytest-xdist
   - netCDF4
+  - ambertools

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -16,3 +16,4 @@ dependencies:
   - gsd>=2.8
   - pytest
   - pytest-xdist
+  - netCDF4

--- a/mdtraj/formats/netcdf.py
+++ b/mdtraj/formats/netcdf.py
@@ -158,8 +158,6 @@ class NetCDFTrajectoryFile:
             # for scipy.io.netcdf_file is "version=2"
             input_args = {"version": 2}
 
-        netcdf = import_("scipy.io").netcdf_file  # noqa: F841
-
         if mode not in ["r", "w"]:
             raise ValueError("mode must be one of ['r', 'w']")
 

--- a/mdtraj/testing/testing.py
+++ b/mdtraj/testing/testing.py
@@ -134,8 +134,10 @@ def eq(o1, o2, decimal=6, err_msg=""):
     ------
     AssertionError
         If the tests fail
-    """
-    assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
+    """    
+    # assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
+    assert (isinstance(o1, (np.ndarray, np.ma.MaskedArray)) and 
+            isinstance(o2, (np.ndarray, np.ma.MaskedArray))), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
 
     if isinstance(o1, dict):
         assert_dict_equal(o1, o1, decimal)

--- a/mdtraj/testing/testing.py
+++ b/mdtraj/testing/testing.py
@@ -135,7 +135,11 @@ def eq(o1, o2, decimal=6, err_msg=""):
     AssertionError
         If the tests fail
     """    
-    assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
+    # assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
+    if isinstance(o1, (np.ndarray, np.ma.MaskedArray)) and isinstance(o2, (np.ndarray, np.ma.MaskedArray)):
+        pass
+    else:
+        assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
 
     if isinstance(o1, dict):
         assert_dict_equal(o1, o1, decimal)

--- a/mdtraj/testing/testing.py
+++ b/mdtraj/testing/testing.py
@@ -135,9 +135,7 @@ def eq(o1, o2, decimal=6, err_msg=""):
     AssertionError
         If the tests fail
     """    
-    # assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
-    assert (isinstance(o1, (np.ndarray, np.ma.MaskedArray)) and 
-            isinstance(o2, (np.ndarray, np.ma.MaskedArray))), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
+    assert type(o1) is type(o2), f"o1 and o2 not the same type: {type(o1)} {type(o2)}"
 
     if isinstance(o1, dict):
         assert_dict_equal(o1, o1, decimal)

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ addopts = -vra
 filterwarnings =
     ignore:.*Function restrict_atoms is deprecated;.*:DeprecationWarning
     ignore:.*Using or importing the ABCs from 'collections' instead of.*:DeprecationWarning
+    ignore:.*The 'netCDF4' Python package.*:UserWarning

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -41,7 +41,6 @@ needs_cpptraj = pytest.mark.skipif(
 fd, temp = tempfile.mkstemp(suffix=".nc")
 fd2, temp2 = tempfile.mkstemp(suffix=".nc")
 
-
 def teardown_module(module):
     """remove the temporary file created by tests in this file
     this gets automatically called by pytest"""
@@ -114,6 +113,7 @@ def test_read_chunk_3(get_fn):
     eq(a[0], b[0])
 
 def test_read_write_1():
+    """Default test using netCDF4"""
     xyz = np.random.randn(100, 3, 3)
     time = np.random.randn(100)
     boxlengths = np.random.randn(100, 3)
@@ -130,10 +130,12 @@ def test_read_write_1():
         assert eq(d, boxangles)
 
 def test_read_write_1_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
     monkeypatch.setitem(sys.modules, 'netCDF4', None)
     test_read_write_1()
 
 def test_read_write_2(get_fn):
+    """Default test using netCDF4"""
     xyz = np.random.randn(5, 22, 3)
     time = np.random.randn(5)
 
@@ -152,6 +154,7 @@ def test_read_write_2(get_fn):
     eq(t.unitcell_lengths, None)
 
 def test_read_write_2_scipy(get_fn, monkeypatch):
+    """Test fallback scipy implementation"""
     monkeypatch.setitem(sys.modules, 'netCDF4', None)
     test_read_write_2(get_fn)
 
@@ -167,6 +170,11 @@ def test_ragged_1():
         with pytest.raises(ValueError):
             f.write(xyz, time, cell_lengths, cell_angles)
 
+def test_ragged_1_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_ragged_1()
+
 
 def test_ragged_2():
     # try first writing no cell angles/lengths, and then adding some
@@ -181,6 +189,10 @@ def test_ragged_2():
         with pytest.raises(ValueError):
             f.write(xyz, time)
 
+def test_ragged_2_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_ragged_2()
 
 def test_read_write_25():
     xyz = np.random.randn(100, 3, 3)
@@ -202,6 +214,10 @@ def test_read_write_25():
         assert eq(c, None)
         assert eq(d, None)
 
+def test_read_write_25_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_read_write_25()
 
 def test_write_3():
     with NetCDFTrajectoryFile(temp, "w", force_overwrite=True) as f:
@@ -212,6 +228,10 @@ def test_write_3():
         with pytest.raises(ValueError):
             f.write(np.random.randn(100, 3, 3), cell_angles=np.random.randn(100, 3))
 
+def test_write_3_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_write_3()
 
 def test_n_atoms():
     with NetCDFTrajectoryFile(temp, "w", force_overwrite=True) as f:
@@ -219,6 +239,10 @@ def test_n_atoms():
     with NetCDFTrajectoryFile(temp) as f:
         eq(f.n_atoms, 11)
 
+def test_n_atoms_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_n_atoms()
 
 def test_do_overwrite():
     with open(temp, "w") as f:
@@ -227,6 +251,10 @@ def test_do_overwrite():
     with NetCDFTrajectoryFile(temp, "w", force_overwrite=True) as f:
         f.write(np.random.randn(10, 5, 3))
 
+def test_do_overwrite_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_do_overwrite()
 
 def test_do_not_overwrite():
     with open(temp, "w") as f:
@@ -236,6 +264,10 @@ def test_do_not_overwrite():
         with NetCDFTrajectoryFile(temp, "w", force_overwrite=False) as f:
             f.write(np.random.randn(10, 5, 3))
 
+def test_do_not_overwrite_scipy(monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_do_not_overwrite()
 
 def test_trajectory_save_load(get_fn):
     t = md.load(get_fn("native.pdb"))
@@ -248,6 +280,10 @@ def test_trajectory_save_load(get_fn):
     eq(t.xyz, t2.xyz)
     eq(t.unitcell_lengths, t2.unitcell_lengths)
 
+def test_do_overwrite_scipy(get_fn, monkeypatch):
+    """Test fallback scipy implementation"""
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_trajectory_save_load(get_fn)
 
 @needs_cpptraj
 def test_cpptraj(get_fn):

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -133,9 +133,6 @@ def test_read_write_1_scipy(monkeypatch):
     monkeypatch.setitem(sys.modules, 'netCDF4', None)
     test_read_write_1()
 
-def test_read_write_1_netcdf(monkeypatch):
-    test_read_write_1()
-
 def test_read_write_2(get_fn):
     xyz = np.random.randn(5, 22, 3)
     time = np.random.randn(5)
@@ -156,9 +153,6 @@ def test_read_write_2(get_fn):
 
 def test_read_write_2_scipy(get_fn, monkeypatch):
     monkeypatch.setitem(sys.modules, 'netCDF4', None)
-    test_read_write_2(get_fn)
-
-def test_read_write_2_netcdf(get_fn, monkeypatch):
     test_read_write_2(get_fn)
 
 def test_ragged_1():

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -130,13 +130,11 @@ def test_read_write_1():
         assert eq(d, boxangles)
 
 def test_read_write_1_scipy(monkeypatch):
-    with monkeypatch.context() as m:
-        monkeypatch.setitem(sys.modules, 'netCDF4', None)
-        test_read_write_1()
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_read_write_1()
 
 def test_read_write_1_netcdf(monkeypatch):
-    with monkeypatch.context() as m:
-        test_read_write_1()
+    test_read_write_1()
 
 def test_read_write_2(get_fn):
     xyz = np.random.randn(5, 22, 3)
@@ -157,13 +155,11 @@ def test_read_write_2(get_fn):
     eq(t.unitcell_lengths, None)
 
 def test_read_write_2_scipy(get_fn, monkeypatch):
-    with monkeypatch.context() as m:
-        monkeypatch.setitem(sys.modules, 'netCDF4', None)
-        test_read_write_2(get_fn)
+    monkeypatch.setitem(sys.modules, 'netCDF4', None)
+    test_read_write_2(get_fn)
 
 def test_read_write_2_netcdf(get_fn, monkeypatch):
-    with monkeypatch.context() as m:
-        test_read_write_2(get_fn)
+    test_read_write_2(get_fn)
 
 def test_ragged_1():
     # try first writing no cell angles/lengths, and then adding some

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -21,6 +21,7 @@
 ##############################################################################
 
 import os
+import sys
 import subprocess
 import tempfile
 from distutils.spawn import find_executable
@@ -112,7 +113,6 @@ def test_read_chunk_3(get_fn):
 
     eq(a[0], b[0])
 
-
 def test_read_write_1():
     xyz = np.random.randn(100, 3, 3)
     time = np.random.randn(100)
@@ -129,6 +129,14 @@ def test_read_write_1():
         assert eq(c, boxlengths)
         assert eq(d, boxangles)
 
+def test_read_write_1_scipy(monkeypatch):
+    with monkeypatch.context() as m:
+        monkeypatch.setitem(sys.modules, 'netCDF4', None)
+        test_read_write_1()
+
+def test_read_write_1_netcdf(monkeypatch):
+    with monkeypatch.context() as m:
+        test_read_write_1()
 
 def test_read_write_2(get_fn):
     xyz = np.random.randn(5, 22, 3)

--- a/tests/test_netcdf.py
+++ b/tests/test_netcdf.py
@@ -156,6 +156,14 @@ def test_read_write_2(get_fn):
     eq(t.unitcell_angles, None)
     eq(t.unitcell_lengths, None)
 
+def test_read_write_2_scipy(get_fn, monkeypatch):
+    with monkeypatch.context() as m:
+        monkeypatch.setitem(sys.modules, 'netCDF4', None)
+        test_read_write_2(get_fn)
+
+def test_read_write_2_netcdf(get_fn, monkeypatch):
+    with monkeypatch.context() as m:
+        test_read_write_2(get_fn)
 
 def test_ragged_1():
     # try first writing no cell angles/lengths, and then adding some


### PR DESCRIPTION
As discussed in #1893 and #1894, I mocked patched netcdf4 off. I used ``pytest`` instead of ``unittest.mock`` since I'm more familiar with that.

Also added ambertools into the dev env to run the cpptraj test.  I believe it was added to conda-forge 1-2 years ago.


Following this:
https://stackoverflow.com/questions/5386194/simulating-lack-of-a-dependency-when-testing-a-python-script


NOTE: #1894 should be merged in first.