### PR TITLE
Allow appending to HDF5 files using `trajectory.save_hdf5`

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1474,7 +1474,7 @@ class Trajectory:
         # run the saver, and return whatever output it gives
         return saver(filename, **kwargs)
 
-    def save_hdf5(self, filename, force_overwrite=True):
+    def save_hdf5(self, filename, savemode="w", force_overwrite=True):
         """Save trajectory to MDTraj HDF5 format
 
         Parameters
@@ -1483,8 +1483,15 @@ class Trajectory:
             filesystem path in which to save the trajectory
         force_overwrite : bool, default=True
             Overwrite anything that exists at filename, if its already there
+        savemode : str, default='w'
+            The mode in which to save the file. 'w' will overwrite any existing
+            file, 'a' will append to an existing file.
         """
-        with HDF5TrajectoryFile(filename, "w", force_overwrite=force_overwrite) as f:
+        # check if savemode is valid (only "w" or "a" are allowed)
+        if savemode not in ["w", "a"]:
+            raise ValueError("savemode must be either 'w' or 'a'")
+        
+        with HDF5TrajectoryFile(filename, savemode, force_overwrite=force_overwrite) as f:
             f.write(
                 coordinates=in_units_of(
                     self.xyz,


### PR DESCRIPTION
Addressing #1750 (and maybe #1843) - this adds an additional argument in `core/trajectory.save_hdf5()` called `savemode` that allows you to define either "w" or "a" for write or append mode respectively. I've set it to `savemode="w"` by default.

The added docstring reads
```
        savemode : str, default='w'
            The mode in which to save the file. 'w' will overwrite any existing
            file, 'a' will append to an existing file.
```

I've also added a snipped to check that only "w" or "a" are being passed and raise a `ValueError` otherwise.