### PR TITLE
remove deprecated oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "numpy<2",
+    "numpy~=1.25",
     "Cython~=0.29.36",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,6 @@ requires = [
     "setuptools",
     "wheel",
     "numpy<2",
-    # provides the oldest numpy version with wheels on PyPI
-    "oldest-supported-numpy",
     "Cython~=0.29.36",
 ]
 


### PR DESCRIPTION
I was a bit surprised to see this dependency still in the build-system part as it also defines `numpy>2`.

It is officially [deprecated](https://github.com/scipy/oldest-supported-numpy?tab=readme-ov-file#deprecation-notice-for-numpy-20) and the backwards compatibility issue has been solved by numpy since version `1.25` (before that oldest-supported-numpy was needed for build stability).

This is what the [current numpy docs](https://numpy.org/devdocs/dev/depending_on_numpy.html#build-time-dependency) say:
> By default, NumPy will expose an API that is backwards compatible with the oldest NumPy version that supports the currently oldest compatible Python version. NumPy 1.25.0 supports Python 3.9 and higher and NumPy 1.19 is the first version to support Python 3.9. Thus, we guarantee that, when using defaults, NumPy 1.25 will expose a C-API compatible with NumPy 1.19. (the exact version is set within NumPy-internal header files).