### PR TITLE
Replace `xdrlib` with `mda_xdrlib`

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -8,6 +8,7 @@ dependencies:
   - numpy
   - zlib
   - pyparsing
+  - mda-xdrlib
   - scipy
   - networkx
   - pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,7 @@ nbsphinx_link
 msmb_theme
 jupyter
 ipython
+mda-xdrlib
 matplotlib
 pandoc
 jinja2

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -28,7 +28,7 @@
 
 import os
 import warnings
-import xdrlib
+import mda_xdrlib as xdrlib
 
 import numpy as np
 

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -27,7 +27,7 @@
 ###############################################################################
 import os
 import warnings
-import xdrlib
+import mda_xdrlib as xdrlib
 
 import numpy as np
 


### PR DESCRIPTION
I'm trying to reduce some of the deprecation warnings we get in the mosdef packages, and one of them was from mdtraj's use of `xdrlib`.  https://github.com/mdtraj/mdtraj/issues/1818 mentions using the `mda_xdrlib` package as a replacement, which this PR does. 