### PR TITLE
Add mda-xdrlib to setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -311,6 +311,7 @@ metadata = dict(
         "scipy",
         "pyparsing",
         "packaging",
+        "mda-xdrlib",
     ],
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,


### PR DESCRIPTION
I was getting the following error:

```bash
conda create -yq -n mdtraj-missing-xdr python=3.11 pip
conda activate mdtraj-missing-xdr
python -m pip install git+https://github.com/mdtraj/mdtraj.git
python -c "import mdtraj"
```

```pytb
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/dwhs/miniforge3/envs/mdtraj-missing-xdr/lib/python3.11/site-packages/mdtraj/__init__.py", line 33, in <module>
    from mdtraj.core.trajectory import (
  File "/Users/dwhs/miniforge3/envs/mdtraj-missing-xdr/lib/python3.11/site-packages/mdtraj/core/trajectory.py", line 34, in <module>
    from mdtraj.formats import (
  File "/Users/dwhs/miniforge3/envs/mdtraj-missing-xdr/lib/python3.11/site-packages/mdtraj/formats/__init__.py", line 13, in <module>
    from mdtraj.formats.trr import TRRTrajectoryFile
  File "mdtraj/formats/xtc/trr.pyx", line 31, in init mdtraj.formats.trr
ModuleNotFoundError: No module named 'mda_xdrlib'
```

Looks to me like this PR will fix it. (Tested by using `python -m pip install -e .` on the local install instead of the pip+git install.) I think this was left out of #1911.

(Caught this in CI for [Contact Map Explorer](https://github.com/dwhswenson/contact_map), which tests against MDTraj dev. [Here](https://github.com/dwhswenson/contact_map/actions/runs/10003104319/job/27649462623) is a test failing against dev MDTraj on older Python versions; [here](https://github.com/dwhswenson/contact_map/actions/runs/10003461729/job/27650417199) is the same failing against newer versions.)
