### PR TITLE
Fix RMSD externs to be compatible with Cython 3.0.

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # Core
   - python
-  - cython =0.29.36
+  - cython
   - numpy
   - zlib
   - pyparsing

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   # Core
   - python
-  - cython
+  - cython =3
   - numpy
   - zlib
   - pyparsing

--- a/mdtraj/rmsd/_lprmsd.pyx
+++ b/mdtraj/rmsd/_lprmsd.pyx
@@ -42,15 +42,19 @@ assert sizeof(np.int32_t) == sizeof(int)
 ##############################################################################
 # External c/cpp function declarations
 ##############################################################################
+
 cdef extern from "include/fancy_index.hpp":
     cdef extern void fancy_index2d(const float* A, int nx, int ny,
         const int* indx, int nindx, const int* indy, int nindy, float* out) nogil
-cdef extern float msd_atom_major(int nrealatoms, int npaddedatoms,  float* a,
-    float* b, float G_a, float G_b, int computeRot, float rot[9]) nogil
-cdef extern float rot_atom_major(const int n_atoms, float* a, const float rot[9]) nogil
-cdef extern void sgemm33(const float A[9], const float B[9], float out[9]) nogil
-cdef extern void inplace_center_and_trace_atom_major(float* coords, float* traces,
-    const int n_frames, const int n_atoms) nogil
+cdef extern from "include/theobald_rmsd.h":
+    cdef extern float msd_atom_major(int nrealatoms, int npaddedatoms,  float* a,
+        float* b, float G_a, float G_b, int computeRot, float rot[9]) nogil
+cdef extern from "include/rotation.h":
+    cdef extern float rot_atom_major(const int n_atoms, float* a, const float rot[9]) nogil
+    cdef extern void sgemm33(const float A[9], const float B[9], float out[9]) nogil
+cdef extern from "include/center.h":
+    cdef extern void inplace_center_and_trace_atom_major(float* coords, float* traces,
+        const int n_frames, const int n_atoms) nogil
 cdef extern from "include/Munkres.h":
     cdef cppclass Munkres:
         Munkres()

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -38,13 +38,15 @@ from cython.parallel cimport prange
 # External Declarations
 ##############################################################################
 
-cdef extern float msd_axis_major(int nrealatoms, int npaddedatoms, int rowstride,
-    float* aT, float* bT, float G_a, float G_b) nogil
-cdef extern float msd_atom_major(int nrealatoms, int npaddedatoms,  float* a,
-    float* b, float G_a, float G_b, int computeRot, float rot[9]) nogil
-cdef extern float rot_msd_atom_major(const int n_real_atoms,
-    const int n_padded_atoms, const float* a, const float* b, const float rot[9]) nogil
-cdef extern float rot_atom_major(const int n_atoms, float* a, const float rot[9]) nogil
+cdef extern from "theobald_rmsd.h":
+    cdef extern float msd_axis_major(int nrealatoms, int npaddedatoms, int rowstride,
+        float* aT, float* bT, float G_a, float G_b) nogil
+    cdef extern float msd_atom_major(int nrealatoms, int npaddedatoms,  float* a,
+        float* b, float G_a, float G_b, int computeRot, float rot[9]) nogil
+cdef extern from "rotation.h":
+    cdef extern float rot_msd_atom_major(const int n_real_atoms,
+        const int n_padded_atoms, const float* a, const float* b, const float rot[9]) nogil
+    cdef extern float rot_atom_major(const int n_atoms, float* a, const float rot[9]) nogil
 cdef extern from "center.h":
     void inplace_center_and_trace_atom_major(float* coords, float* traces,
     const int n_frames, const int n_atoms) nogil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "versioneer[toml]",
     "wheel",
     "numpy~=1.25",
-    "Cython~=3",
+    "Cython>=3.0.0",
 ]
 
 [tool.versioneer]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "versioneer[toml]",
     "wheel",
     "numpy~=1.25",
-    "Cython>0.29",
+    "Cython=3",
 ]
 
 [tool.versioneer]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "versioneer[toml]",
     "wheel",
     "numpy~=1.25",
-    "Cython~=0.29.36",
+    "Cython>0.29",
 ]
 
 [tool.versioneer]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "versioneer[toml]",
     "wheel",
     "numpy~=1.25",
-    "Cython=3",
+    "Cython~3",
 ]
 
 [tool.versioneer]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "versioneer[toml]",
     "wheel",
     "numpy~=1.25",
-    "Cython~3",
+    "Cython~=3",
 ]
 
 [tool.versioneer]


### PR DESCRIPTION
* We needed this fix internally to make mdtraj work with Cython 3.0.
* This fixed it, however, we build rdkit ourselves using Blaze (Bazel), so this fix might not be applicable upstream.