### PR TITLE
Add option for HDF5 openmm reporter to save forces

### DIFF
--- a/mdtraj/reporters/basereporter.py
+++ b/mdtraj/reporters/basereporter.py
@@ -62,6 +62,7 @@ class _BaseReporter:
         velocities=False,
         atomSubset=None,
         enforcePeriodicBox=None,
+        forces=False
     ):
         """Create an OpenMM reporter
 
@@ -89,6 +90,8 @@ class _BaseReporter:
         atomSubset : array_like, default=None
             Only write a subset of the atoms, with these (zero based) indices
             to the file. If None, *all* of the atoms will be written.
+        forces : bool, default=False
+            Whether to write the forces to the file.
 
         Notes
         -----
@@ -112,6 +115,7 @@ class _BaseReporter:
         self._n_particles = None
 
         self._coordinates = bool(coordinates)
+        self._forces = bool(forces)
         self._time = bool(time)
         self._cell = bool(cell)
         self._potentialEnergy = bool(potentialEnergy)
@@ -197,7 +201,7 @@ class _BaseReporter:
             steps,
             self._coordinates,
             self._velocities,
-            False,
+            self._forces,
             self._needEnergy,
             self._enforcePeriodicBox,
         )
@@ -247,6 +251,8 @@ class _BaseReporter:
             kwargs["temperature"] = 2 * state.getKineticEnergy() / (self._dof * units.MOLAR_GAS_CONSTANT_R)
         if self._velocities:
             kwargs["velocities"] = state.getVelocities(asNumpy=True)[self._atomSlice, :]
+        if self._forces:
+            kwargs["forces"] = state.getForces(asNumpy=True)[self._atomSlice, :]
 
         self._traj_file.write(*args, **kwargs)
         # flush the file to disk. it might not be necessary to do this every

--- a/mdtraj/reporters/hdf5reporter.py
+++ b/mdtraj/reporters/hdf5reporter.py
@@ -103,6 +103,7 @@ class HDF5Reporter(_BaseReporter):
         velocities=False,
         atomSubset=None,
         enforcePeriodicBox=None,
+        forces=False
     ):
         """Create a HDF5Reporter."""
         super().__init__(
@@ -117,4 +118,5 @@ class HDF5Reporter(_BaseReporter):
             velocities,
             atomSubset,
             enforcePeriodicBox,
+            forces
         )


### PR DESCRIPTION
I didn't see any way in the [documentation](https://mdtraj.org/development/api/generated/mdtraj.reporters.HDF5Reporter.html) to save the `forces`, which I wanted as training data for a neural net.

I tested the reporter and it seems to work:
```
simulation.reporters.append(mdtraj.reporters.HDF5Reporter('ala2.h5', 1000, forces=True))
```

I'm not sure how the unit conversions are intended to work. I set the units for the forces to be the same as OpenMM which [says](http://docs.openmm.org/latest/userguide/theory/01_introduction.html):
```
For example, a force always has the same units (kJ/mol/nm)
```