### PR TITLE
Remove unused Python xdrlib import

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -8,7 +8,6 @@ dependencies:
   - numpy
   - zlib
   - pyparsing
-  - mda-xdrlib
   - scipy
   - networkx
   - pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ nbsphinx_link
 msmb_theme
 jupyter
 ipython
-mda-xdrlib
 matplotlib
 pandoc
 jinja2

--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -28,7 +28,6 @@
 
 import os
 import warnings
-import mda_xdrlib as xdrlib
 
 import numpy as np
 

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -27,7 +27,6 @@
 ###############################################################################
 import os
 import warnings
-import mda_xdrlib as xdrlib
 
 import numpy as np
 

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,6 @@ metadata = dict(
         "scipy",
         "pyparsing",
         "packaging",
-        "mda-xdrlib",
     ],
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,


### PR DESCRIPTION
Following up the discussion of #1818, this PR removes the unused Python `xdrlib`, as only the internal C `xdrlib` is used. Closes #1818