### PR TITLE
Fix xdrlib for cimports as well.

### DIFF
--- a/mdtraj/formats/xtc/trr.pyx
+++ b/mdtraj/formats/xtc/trr.pyx
@@ -39,7 +39,7 @@ np.import_array()
 from mdtraj.formats.registry import FormatRegistry
 from mdtraj.utils import cast_indices, ensure_type, in_units_of
 
-cimport xdrlib
+cimport mda_xdrlib as xdrlib
 
 cimport trrlib
 from libc.stdio cimport SEEK_CUR, SEEK_SET

--- a/mdtraj/formats/xtc/xtc.pyx
+++ b/mdtraj/formats/xtc/xtc.pyx
@@ -38,7 +38,7 @@ np.import_array()
 from mdtraj.formats.registry import FormatRegistry
 from mdtraj.utils import cast_indices, ensure_type, in_units_of
 
-cimport xdrlib
+cimport mda_xdrlib as xdrlib
 
 from libc.math cimport ceil
 from libc.stdio cimport SEEK_CUR, SEEK_SET


### PR DESCRIPTION
use mda-xdrlib for cimports as well. 

Quoting myself (https://github.com/mdtraj/mdtraj/pull/1919#issuecomment-2318784877).

> Because we're using xdrlib in the "python" context and also "Cython" context, we need to load both. Former for lines like [these](https://github.com/mdtraj/mdtraj/blob/6d77f4eeb398cee2b14460f9ffbc1f263f26c6b7/mdtraj/formats/xtc/trr.pyx#L273), latter for the header files for lines like [these](https://github.com/mdtraj/mdtraj/blob/6d77f4eeb398cee2b14460f9ffbc1f263f26c6b7/mdtraj/formats/xtc/trr.pyx#L560). Convention is to load them [under the same name](https://numpy.org/doc/stable/reference/random/extending.html#cython).
> 
> 
> Easy way to test is:
> In a python 3.13 environment (`conda create -n 313 -c conda-forge/label/python_rc python=3.13.0rc1 mda-xdrlib`), install cython that is compatible with 3.13 (`conda activate 313; python -m pip install cython`)
> 
> In a test file (`test.pyx`) containing the following:
> ```
> import mda_xdrlib as xdrlib
> cimport mda_xdrlib as xdrlib
> 
> xdrlib.xdrtel('abc.txt')
> ```
> 
> Compilation will fail (`cythonize -i test.pyx`) if the first line is commented out.

 