### PR TITLE
Fixing DSSP Tests

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1545,7 +1545,7 @@ class Trajectory:
                 types=[a.name for a in self.top.atoms],
             )
 
-    def save_pdb(self, filename, force_overwrite=True, bfactors=None, ter=True):
+    def save_pdb(self, filename, force_overwrite=True, bfactors=None, ter=True, header=True):
         """Save trajectory to RCSB PDB format
 
         Parameters
@@ -1561,6 +1561,10 @@ class Trajectory:
         ter : bool, default=True
             Include TER lines in pdb to indicate end of a chain of residues. This is useful
             if you need to keep atom numbers consistent.
+        header : bool, default=True
+            Include header in pdb. Useful if you want the extra output, but sometimes prevent
+            programs from running smoothly.
+
         """
         self._check_valid_unitcell()
 
@@ -1603,6 +1607,7 @@ class Trajectory:
                         ),
                         unitcell_angles=self.unitcell_angles[i],
                         ter=ter,
+                        header=header,
                     )
                 else:
                     f.write(
@@ -1615,6 +1620,7 @@ class Trajectory:
                         modelIndex=i,
                         bfactors=bfactors[i],
                         ter=ter,
+                        header=header,
                     )
 
     def save_xtc(self, filename, force_overwrite=True):

--- a/mdtraj/formats/pdb/pdbfile.py
+++ b/mdtraj/formats/pdb/pdbfile.py
@@ -305,6 +305,7 @@ class PDBTrajectoryFile:
         unitcell_angles=None,
         bfactors=None,
         ter=True,
+        header=True,
     ):
         """Write a PDB file to disk
 
@@ -327,6 +328,9 @@ class PDBTrajectoryFile:
         ter : bool, default=True
             Include TER lines in pdb to indicate end of a chain of residues. This is useful
             if you need to keep atom numbers consistent.
+        header : bool, default=True
+            Include header in pdb. Useful if you want the extra output, but sometimes prevent
+            programs from running smoothly.
         """
         if not self._mode == "w":
             raise ValueError("file not opened for writing")
@@ -358,7 +362,7 @@ class PDBTrajectoryFile:
 
         atomIndex = 1
         posIndex = 0
-        if modelIndex is not None:
+        if header and modelIndex is not None:
             print("MODEL     %4d" % modelIndex, file=self._file)
         for chainIndex, chain in enumerate(topology.chains):
             if not chain.chain_id:
@@ -420,7 +424,7 @@ class PDBTrajectoryFile:
                     )
                     atomIndex += 1
 
-        if modelIndex is not None:
+        if header and modelIndex is not None:
             print("ENDMDL", file=self._file)
 
     def _write_header(self, unitcell_lengths, unitcell_angles, write_metadata=True):

--- a/tests/test_dssp.py
+++ b/tests/test_dssp.py
@@ -15,8 +15,8 @@ needs_dssp = pytest.mark.skipif(not shutil.which("mkdssp"), reason=DSSP_MSG)
 def call_dssp(dirname, traj, frame=0):
     inp = os.path.join(dirname, "temp.pdb")
     out = os.path.join(dirname, "temp.pdb.dssp")
-    traj[frame].save(inp)
-    cmd = ["mkdssp", "-i", inp, "-o", out]
+    traj[frame].save(inp, header=False)
+    cmd = ["mkdssp", inp, out]
     subprocess.check_output(" ".join(cmd), shell=True)
 
     KEY_LINE = (

--- a/tests/test_hbonds.py
+++ b/tests/test_hbonds.py
@@ -48,7 +48,7 @@ def test_hbonds_against_dssp(get_fn, tmpdir):
     dssp = os.path.join(tmpdir, "f.pdb.dssp")
     t.save(pdb)
 
-    cmd = ["mkdssp", "-i", pdb, "-o", dssp]
+    cmd = ["mkdssp", pdb, dssp]
     subprocess.check_output(" ".join(cmd), shell=True)
     energy = scipy.sparse.lil_matrix((t.n_residues, t.n_residues))
 


### PR DESCRIPTION
The DSSP tests are currently not working or running, mostly because of dependencies (dependent on an old version of mkdssp, not easily installable) This modifies the tests so they actually run with a modern version of [dssp](https://github.com/PDB-REDO/dssp), at least locally. 

1. New option/feature to skip outputting PDB header lines (MDL, Remarks etc.), since `mkdssp` apparently won't run with them in the way. Defaults to true (like usual) but if there are problems, you can invoke this with `traj.save('output_file.pdb', header=False)` or `traj.save_pdb('output_file.pdb', header=False)`.
2. There are some discrepancies with secondary structure assignments between [DSSP v4.4.7](https://github.com/PDB-REDO/dssp) and what mdtraj outputs. Pytest results: 
https://gist.github.com/jeremyleung521/3ff52fcc9c44cb5ad18b73d0e6e58931

Will dig deeper on why we're getting 2., but here's some of the work, if anyone wants to build upon that.
