### PR TITLE
Make 1.10.1 release notes

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -22,7 +22,7 @@ v1.10.1 (October 17, 2024)
 - Remove unused `xdrlib` import from Python layer (#1919)
 - Fix PDB "vmd convention" false-positive (#1904)
 
-A total of 15 people contributed to this release.
+A total of 11 people contributed to this release.
 People with a "+" by their names contributed a patch for the first time.
 
 - Charlie Laughton

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -3,8 +3,42 @@ What's New?
 
 These are new features and improvements of note in each release.
 
-v1.10.0rc1 (May 17, 2024)
--------------------------
+v1.10.1 (October 17, 2024)
+--------------------------
+
+- Update RMSD module for Cython 3.0 (#1917)
+- Fix edge case with float rounding in angle computation (#1841)
+- Add atom selection via atom_indices to SASA computation (#1844)
+- ReadTheDocs migration (#1888)
+- Fix netCDF import (#1894)
+- Use standard library `ast.unparse` instead of third-party `astunparse` (#1898)
+- Allow appending to HDF5 files (#1899)
+- Remove deprecated `oldest-supported-numpy` (#1902)
+- Remove remaining uses of `six` (#1908)
+- Replace `xdrlib` with `mda_xdrlib` (#1911)
+- Add `mda-xdrlib` to `setup.py` (#1913)
+- Set up `versioneer` (#1909)
+- Remove `distutils` from tests (#1916)
+- Remove unused `xdrlib` import from Python layer (#1919)
+- Fix PDB "vmd convention" false-positive (#1904)
+
+A total of 15 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+
+- Charlie Laughton
+- Guillermo Pérez-Hernández
+- Sukrit Singh
+- Jeremy Leung
+- Sander Roet
+- Chris Jones+
+- David W.H. Swenson
+- Matthew W. Thompson
+- Robert Schütz+
+- Patrick Kunzmann
+- Augustin Zidek+
+
+v1.10.0 (May 30, 2024)
+----------------------
 
 - Remove TNG support (#1875)
 - Drop support for long-unsupported upstreams (#1838)
@@ -14,10 +48,13 @@ v1.10.0rc1 (May 17, 2024)
 - Use netCDF4 as default in `NetCDFTrajectoryFile`, fallback to SciPy implementation (#1878)
 - Add dependabot for updating actions (#1865)
 
-Jinzhe Zeng+
-Matthew W. Thompson
-Jeremy Leung
-Jessica A. Nash+
+A total of 4 people contributed to this release.
+People with a "+" by their names contributed a patch for the first time.
+
+- Jinzhe Zeng+
+- Matthew W. Thompson
+- Jeremy Leung
+- Jessica A. Nash+
 
 v1.9.9 (July 22, 2023)
 ---------------------


### PR DESCRIPTION
Here's the GitHub-generated Markdown blob:

```
## What's Changed
* Issue 1829 by @CharlieLaughton in https://github.com/mdtraj/mdtraj/pull/1841
* Add atom selection via atom_indices to SASA computation (try #2, three years after) by @gph82 in https://github.com/mdtraj/mdtraj/pull/1844
* [WIP] ReadTheDocs migration by @sukritsingh in https://github.com/mdtraj/mdtraj/pull/1888
* Fix netCDF file loading to no longer import scipy (and add netCDF to CI reqs) by @sukritsingh in https://github.com/mdtraj/mdtraj/pull/1894
* AST-related modifications by @jeremyleung521 in https://github.com/mdtraj/mdtraj/pull/1898
* Allow appending to HDF5 files using `trajectory.save_hdf5` by @sukritsingh in https://github.com/mdtraj/mdtraj/pull/1899
* Mock-testing dependency absence for netCDF4 by @jeremyleung521 in https://github.com/mdtraj/mdtraj/pull/1895
* remove deprecated oldest-supported-numpy by @sroet in https://github.com/mdtraj/mdtraj/pull/1902
* remove remaining instances of six by @jeremyleung521 in https://github.com/mdtraj/mdtraj/pull/1908
* Replace `xdrlib` with `mda_xdrlib` by @chrisjonesBSU in https://github.com/mdtraj/mdtraj/pull/1911
* Add mda-xdrlib to setup.py requirements by @dwhswenson in https://github.com/mdtraj/mdtraj/pull/1913
* Set up versioneer by @mattwthompson in https://github.com/mdtraj/mdtraj/pull/1909
* drop distutils from tests by @dotlambda in https://github.com/mdtraj/mdtraj/pull/1916
* Remove unused Python xdrlib import by @padix-key in https://github.com/mdtraj/mdtraj/pull/1919
* fix pdbstructure "vmd convention" false-positive by @jeremyleung521 in https://github.com/mdtraj/mdtraj/pull/1904
* Fix RMSD externs to be compatible with Cython 3.0. by @Augustin-Zidek in https://github.com/mdtraj/mdtraj/pull/1917

## New Contributors
* @chrisjonesBSU made their first contribution in https://github.com/mdtraj/mdtraj/pull/1911
* @dotlambda made their first contribution in https://github.com/mdtraj/mdtraj/pull/1916
* @Augustin-Zidek made their first contribution in https://github.com/mdtraj/mdtraj/pull/1917

**Full Changelog**: https://github.com/mdtraj/mdtraj/compare/1.10.0...1.10.1