### PR TITLE
Fix Chimera/Non traditional numbering for mdtraj.load()

### DIFF
--- a/mdtraj/formats/pdb/pdbstructure.py
+++ b/mdtraj/formats/pdb/pdbstructure.py
@@ -132,6 +132,9 @@ def _read_residue_number(num_str, pdbstructure=None, curr_atom=None):
         if pdbstructure._next_residue_number > 9999 and num_str in _residue_num_initial_nondecimal_vals:
             # If the next residue number is > 9999 and our current residue number is one of the nondecimal keys,
             # Raise an OverflowError, which will switch to the correct mode to read num_str. 
+            pdbstructure.switch = True
+            raise OverflowError("Need to parse residue number using non-decimal residue modes.")
+        elif pdbstructure.switch and pdbstructure._next_residue_number > 9999:
             raise OverflowError("Need to parse residue number using non-decimal residue modes.")
         else:
             #  Within "normal" pdb specifications
@@ -270,6 +273,7 @@ class PdbStructure:
             "overflow": _overflow_residue_check,
         }
         self._residue_num_nondec_mode = None  # None (decimal until changes), 'hex', 'chimera'
+        self.switch = False
 
         # initialize models
         self.load_all_models = load_all_models


### PR DESCRIPTION
As described in #1945 
After generating both `init.pdb` and `traj.dcd` within openMM. I would run:

`traj = mdtraj.load("traj.dcd", top="init.pdb")`

However, I would get an error when running this, as there were >9999 residue numbers in my pdb:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 traj = mdtraj.load("traj2.dcd", top="init2.pdb")
      2 traj.restrict_atoms(traj.topology.select("protein"))

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/core/trajectory.py:396, in load(filename_or_filenames, discard_overlapping_frames, **kwargs)
    394 topkwargs.pop("stride", None)
    395 topkwargs.pop("start", None)
--> 396 kwargs["top"] = _parse_topology(
    397     kwargs.get("top", filename_or_filenames[0]),
    398     **topkwargs,
    399 )
    401 # get the right loader
    402 try:
    403     # loader = _LoaderRegistry[extension][0]

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/core/trajectory.py:170, in _parse_topology(top, **kwargs)
    168     topology = top.topology
    169 elif isinstance(top, (str, os.PathLike)) and (ext in [".pdb", ".pdb.gz", ".pdbx", ".cif", ".h5", ".lh5"]):
--> 170     _traj = load_frame(top, 0, **kwargs)
    171     topology = _traj.topology
    172 elif isinstance(top, (str, os.PathLike)) and (ext in [".prmtop", ".parm7", ".prm7"]):

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/core/trajectory.py:313, in load_frame(filename, index, top, atom_indices, **kwargs)
    310 else:
    311     _assert_files_or_dirs_exist(filename)
--> 313 return loader(filename, frame=index, **kwargs)

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbfile.py:152, in load_pdb(filename, stride, atom_indices, frame, no_boxchk, standard_names, top)
    146     raise TypeError(
    147         "filename must be of type string or path-like for load_pdb. " "you supplied %s" % type(filename),
    148     )
    150 atom_indices = cast_indices(atom_indices)
--> 152 with PDBTrajectoryFile(filename, standard_names=standard_names, top=top) as f:
    153     atom_slice = slice(None) if atom_indices is None else atom_indices
    154     if frame is not None:

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbfile.py:289, in PDBTrajectoryFile.__init__(self, filename, mode, force_overwrite, standard_names, top)
    286     else:
    287         self._file = open_maybe_zipped(filename, "r")
--> 289     self._read_models()
    290 elif mode == "w":
    291     self._header_written = False

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbfile.py:617, in PDBTrajectoryFile._read_models(self)
    614 if not self._mode == "r":
    615     raise ValueError("file not opened for reading")
--> 617 pdb = PdbStructure(self._file, load_all_models=True)
    619 # load all of the positions (from every model)
    620 _positions = []

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbstructure.py:287, in PdbStructure.__init__(self, input_stream, load_all_models)
    285 self._unit_cell_angles = None
    286 # read file
--> 287 self._load(input_stream)

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbstructure.py:303, in PdbStructure._load(self, input_stream)
    301         self._add_model(Model(new_number))
    302         state = None
--> 303     self._add_atom(Atom(pdb_line, self))
    304 # Notice MODEL punctuation, for the next level of detail
    305 # in the structure->model->chain->residue->atom->position hierarchy
    306 elif pdb_line.find("MODEL") == 0:
    307     # model_number = int(pdb_line[10:14])

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbstructure.py:879, in Atom.__init__(self, pdb_line, pdbstructure)
    876 self.residue_name = self.residue_name_with_spaces.strip()
    878 self.chain_id = pdb_line[21]
--> 879 self.residue_number = _read_residue_number(pdb_line[22:26], pdbstructure, self)
    881 self.insertion_code = pdb_line[26]
    882 # coordinates, occupancy, and temperature factor belong in Atom.Location object

File /projects/parisahlab/apowers4/miniconda3/envs/openmm/lib/python3.12/site-packages/mdtraj/formats/pdb/pdbstructure.py:141, in _read_residue_number(num_str, pdbstructure, curr_atom)
    136         raise OverflowError("Need to parse residue number using non-decimal residue modes.")
    137     # elif pdbstructure.switch and pdbstructure._next_residue_number > 9999:
    138     #     raise OverflowError("Need to parse residue number using non-decimal residue modes.")
    139     else:
    140         #  Within "normal" pdb specifications
--> 141         return int(num_str)
    142 except (AttributeError, OverflowError, KeyError):
    143     # we need to figure out on the 1st try which mode to switch to. There are currently 3 options:
    144     # VMD (hex) and Chimera (their own 'hybrid36' mode) and Overflow (****).
   (...)
    147     # activated when _next_residue_number > 9999 (maximum in decimal) and current num_str
    148     # isn't 9999.
    149     if pdbstructure is None:

ValueError: invalid literal for int() with base 10: 'A001'
```

In order to fix it I made an attribute for class `PdbStructure`, so that it would have an additional check and not fail after the initial 'A000' chimera line.

(Also, I submitted this to merge to `numpy2` branch, as I assume you don't want this going to `main` right away.