### PR TITLE
Preserve `chain_ids` for `to_openmm` and `from_openmm`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,9 +1,6 @@
 name: CI
 on:
   push:
-    branches:
-      - master
-      - main
   pull_request:
     branches:
       - master

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,9 @@
 name: CI
 on:
   push:
+    branches:
+      - master
+      - main
   pull_request:
     branches:
       - master

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -377,7 +377,7 @@ class Topology:
         }
 
         for chain in self.chains:
-            c = out.addChain()
+            c = out.addChain(id=chain.chain_id)
             for residue in chain.residues:
                 r = out.addResidue(residue.name, c, id=str(residue.resSeq))
                 for atom in residue.atoms:
@@ -441,7 +441,7 @@ class Topology:
         atom_mapping = {}
 
         for chain in value.chains():
-            c = out.add_chain()
+            c = out.add_chain(chain_id=chain.id)
             for residue in chain.residues():
                 try:
                     r = out.add_residue(residue.name, c, resSeq=int(residue.id))

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -59,6 +59,35 @@ def test_topology_openmm(get_fn):
 
 
 @needs_openmm
+def test_topology_openmm_preserve_chain_id_when_specified(get_fn):
+    top = md.load(get_fn("custom.pdb")).topology
+    for chain in top.chains:
+        assert chain.chain_id is not None
+    openmm_top = top.to_openmm()
+    chain = next(openmm_top.chains())
+    eq(chain.id, "X")
+
+
+@needs_openmm
+def test_topology_openmm_roundtrip_chain_id(get_fn):
+    top = md.load(get_fn("custom.pdb")).topology
+    top2 = md.Topology.from_openmm(top.to_openmm())
+    for chain1, chain2 in zip(top.chains, top2.chains):
+        eq(chain1.chain_id, "X")
+        eq(chain2.chain_id, "X")
+
+
+@needs_openmm
+def test_topology_openmm_preserve_chain_id_even_when_empty(get_fn):
+    top = md.load(get_fn("native.pdb")).topology
+    for chain in top.chains:
+        assert chain.chain_id is not None
+    openmm_top = top.to_openmm()
+    chain = next(openmm_top.chains())
+    eq(chain.id, " ")
+
+
+@needs_openmm
 def test_topology_openmm_boxes(get_fn):
     traj = md.load(get_fn("1vii_sustiva_water.pdb"))
     mmtop = traj.topology.to_openmm(traj=traj)


### PR DESCRIPTION
Hi all,

This PR perserves `chain_id`s when going to/from openmm topologies. It is pretty analogous to https://github.com/mdtraj/mdtraj/pull/1858. 

This allows preservation of chain IDs when reading/writing PDBx/mmCIF files, since, for reading, `PDBXTrajectoryFile.__init__` uses `from_openmm`, leveraging openmm's `PDBxFile` object that maintains chain IDs itself,  and, for writing, the `PDBxTrajectoryFile.write` method uses `to_openmm`.

The `topology` property, and the `topology.setter` in `HDF5TrajectoryFile` need extra work to carry through chain IDs in topologies there since they use a `topology_dict` that doesn't carry through chain IDs.