### PR TITLE
Pass chain_id when instantiating top from_openmm

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -441,7 +441,7 @@ class Topology:
         atom_mapping = {}
 
         for chain in value.chains():
-            c = out.add_chain()
+            c = out.add_chain(chain_id=chain.id)
             for residue in chain.residues():
                 try:
                     r = out.add_residue(residue.name, c, resSeq=int(residue.id))


### PR DESCRIPTION
I only bumped into missing chain_id fields when reading from mmCIF now, but it seems natural to add it since #1715

In order to test properly, a sample cif file would need to be added in /tests/data, which I can do if you think it's necessary.

As always, thanks for taking this into consideration!


