### PR TITLE
pin numpy>=1.25 at run time, numpy>=2.0 at build time for numpy C-API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "versioneer[toml]",
     "wheel",
-    "numpy<3",
+    "numpy>=2.0.0,<3",
     "Cython>=3.0.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -298,7 +298,7 @@ metadata = dict(
     packages=find_packages(),
     cmdclass={**versioneer.get_cmdclass(), "build_ext": build_ext},
     install_requires=[
-        "numpy<3",
+        "numpy>=1.25.0,<3",
         "scipy",
         "pyparsing",
         "packaging",


### PR DESCRIPTION
Proabably should've done this when we dropped `oldest-supported-numpy` and added numpy 2 support but here it is. 

This ensures numpy 2 is used during build time so the compiled files are compatible with numpy 1 and 2. numpy>=1.25 is required at run time so the C-API exporting works.

https://github.com/scipy/oldest-supported-numpy