### PR TITLE
Performance enhancement for `md.join`

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -611,14 +611,15 @@ def join(trajs, check_topology=True, discard_overlapping_frames=False):
     discard_overlapping_frames : bool
         Check for overlapping frames and discard
     """
-    return functools.reduce(
-        lambda x, y: x.join(
-            y,
-            check_topology=check_topology,
-            discard_overlapping_frames=discard_overlapping_frames,
-        ),
-        trajs,
-    )
+    list_trajs = list(trajs)
+    if len(list_trajs) == 1:
+        return list_trajs[0]
+    else:
+        joined_traj = list_trajs[0].join(list_trajs[1:], 
+                                         check_topology=check_topology, 
+                                         discard_overlapping_frames=False
+                                         )
+        return joined_traj
 
 
 class Trajectory:

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -615,10 +615,11 @@ def join(trajs, check_topology=True, discard_overlapping_frames=False):
     if len(list_trajs) == 1:
         return list_trajs[0]
     else:
-        joined_traj = list_trajs[0].join(list_trajs[1:], 
-                                         check_topology=check_topology, 
-                                         discard_overlapping_frames=False
-                                         )
+        joined_traj = list_trajs[0]
+        joined_traj = joined_traj.join(list_trajs[1:], 
+                                       check_topology=check_topology, 
+                                       discard_overlapping_frames=False
+                                       )
         return joined_traj
 
 


### PR DESCRIPTION
This PR aims to resolve potential performance issues for `md.join`, especially when joining a large amount of pieces together.

The details of the problem is described in Issue #1961. Here's the revised code and benchmark. It is obvious the new version is orders of magnitude faster than the old code.

![image](https://github.com/user-attachments/assets/9cd648e0-b86f-420a-a516-641d2d613e02)

