### PR TITLE
remove unused variables and fix overflow checks

### DIFF
--- a/mdtraj/formats/xtc/src/README
+++ b/mdtraj/formats/xtc/src/README
@@ -15,3 +15,4 @@ Changes from upsteam's xdrfile-1.1.4 include:
  - Bugfix in do_trnheader to return the appropriate error code when reading magic, and properly check the value of the magic in xdrfile_trr.c
  - Bugfix of float exception (divide by zero) in xdrfile.c, see https://github.com/SimTk/mdtraj/issues/616
  - Implemented efficient seeking pattern inspired by xdrlib2 (part of MDAnalysis)
+ - Removed unused variables and compiler warnings, fixed overflow error handling (return -1 instead of just printing to stderr)

--- a/mdtraj/formats/xtc/src/xdrfile.c
+++ b/mdtraj/formats/xtc/src/xdrfile.c
@@ -782,10 +782,10 @@ xdrfile_decompress_coord_float(float     *ptr,
 							   XDRFILE*   xfp)
 {
 	int minint[3], maxint[3], *lip;
-	int smallidx, minidx, maxidx;
+	int smallidx;
 	unsigned sizeint[3], sizesmall[3], bitsizeint[3], size3;
 	int k, *buf1, *buf2, lsize, flag;
-	int smallnum, smaller, larger, i, is_smaller, run;
+	int smallnum, smaller, i, is_smaller, run;
 	float *lfp, inv_precision;
 	int tmp, *thiscoord,  prevcoord[3];
 	unsigned int bitsize;
@@ -866,14 +866,11 @@ xdrfile_decompress_coord_float(float     *ptr,
 		return 0; /* not sure what has happened here or why we return... */
 	}
 	tmp=smallidx+8;
-	maxidx = (LASTIDX<tmp) ? LASTIDX : tmp;
-	minidx = maxidx - 8; /* often this equal smallidx */
 	tmp = smallidx-1;
 	tmp = (FIRSTIDX>tmp) ? FIRSTIDX : tmp;
 	smaller = magicints[tmp] / 2;
 	smallnum = magicints[smallidx] / 2;
 	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx] ;
-	larger = magicints[maxidx];
 
 	/* buf2[0] holds the length in bytes */
 
@@ -1013,7 +1010,6 @@ xdrfile_compress_coord_float(float   *ptr,
 	float *lfp, lf;
 	int tmp, tmpsum, *thiscoord,  prevcoord[3];
 	unsigned int tmpcoord[30];
-	int errval=1;
 	unsigned int bitsize;
 
 	if(xfp==NULL)
@@ -1074,7 +1070,7 @@ xdrfile_compress_coord_float(float   *ptr,
         {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-			errval=0;
+			return -1; /* return -1 for upstream error handling */
 		}
 		lint1 = lf;
 		if (lint1 < minint[0]) minint[0] = lint1;
@@ -1089,7 +1085,7 @@ xdrfile_compress_coord_float(float   *ptr,
         {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-			errval=0;
+			return -1;  /* return -1 for upstream error handling */
 		}
 		lint2 = lf;
 		if (lint2 < minint[1]) minint[1] = lint2;
@@ -1102,7 +1098,7 @@ xdrfile_compress_coord_float(float   *ptr,
 			lf = *lfp * precision - 0.5;
 		if (fabs(lf) > INT_MAX-2)
         {
-			errval=0;
+			return -1;
 		}
 		lint3 = lf;
 		if (lint3 < minint[2]) minint[2] = lint3;
@@ -1126,7 +1122,7 @@ xdrfile_compress_coord_float(float   *ptr,
 		 * would cause overflow
 		 */
 		fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-		errval=0;
+		return -1;  /* return -1 for upstream error handling */
 	}
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
@@ -1299,10 +1295,10 @@ xdrfile_decompress_coord_double(double     *ptr,
 								XDRFILE*   xfp)
 {
 	int minint[3], maxint[3], *lip;
-	int smallidx, minidx, maxidx;
+	int smallidx;
 	unsigned sizeint[3], sizesmall[3], bitsizeint[3], size3;
 	int k, *buf1, *buf2, lsize, flag;
-	int smallnum, smaller, larger, i, is_smaller, run;
+	int smallnum, smaller, i, is_smaller, run;
 	double *lfp, inv_precision;
 	float float_prec, tmpdata[30];
 	int tmp, *thiscoord,  prevcoord[3];
@@ -1380,14 +1376,11 @@ xdrfile_decompress_coord_double(double     *ptr,
 	if (xdrfile_read_int(&smallidx,1,xfp) == 0)
 		return 0;
 	tmp=smallidx+8;
-	maxidx = (LASTIDX<tmp) ? LASTIDX : tmp;
-	minidx = maxidx - 8; /* often this equal smallidx */
 	tmp = smallidx-1;
 	tmp = (FIRSTIDX>tmp) ? FIRSTIDX : tmp;
 	smaller = magicints[tmp] / 2;
 	smallnum = magicints[smallidx] / 2;
-	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx] ;
-	larger = magicints[maxidx];
+	sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
 
 	/* buf2[0] holds the length in bytes */
 
@@ -1506,7 +1499,6 @@ xdrfile_compress_coord_double(double   *ptr,
 	float float_prec, lf,tmpdata[30];
 	int tmp, tmpsum, *thiscoord,  prevcoord[3];
 	unsigned int tmpcoord[30];
-	int errval=1;
 	unsigned int bitsize;
 
     bitsizeint[0] = 0;
@@ -1563,7 +1555,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		if (fabs(lf) > INT_MAX-2) {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-			errval=0;
+			return -1; /* return -1 for upstream error handling */
 		}
 		lint1 = lf;
 		if (lint1 < minint[0]) minint[0] = lint1;
@@ -1577,7 +1569,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		if (fabs(lf) > INT_MAX-2) {
 			/* scaling would cause overflow */
 			fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-			errval=0;
+			return -1;  /* return -1 for upstream error handling */
 		}
 		lint2 = lf;
 		if (lint2 < minint[1]) minint[1] = lint2;
@@ -1589,7 +1581,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		else
 			lf = (float)*lfp * float_prec - 0.5;
 		if (fabs(lf) > INT_MAX-2) {
-			errval=0;
+			return -1;
 		}
 		lint3 = lf;
 		if (lint3 < minint[2]) minint[2] = lint3;
@@ -1613,7 +1605,7 @@ xdrfile_compress_coord_double(double   *ptr,
 		 * would cause overflow
 		 */
 		fprintf(stderr, "(xdrfile error) Internal overflow compressing coordinates.\n");
-		errval=0;
+		return -1;  /* return -1 for upstream error handling */
 	}
 	sizeint[0] = maxint[0] - minint[0]+1;
 	sizeint[1] = maxint[1] - minint[1]+1;
@@ -1940,99 +1932,6 @@ static int ctofstr(char *dest, int destlen, char *src)
         *dest++ = ' ';
     return 0;
 }
-
-
-void
-F77_FUNC(xdrrstring,XDRRSTRING)(int *fid, char *str, int *ret, int len)
-{
-	char *cstr;
-
-	if((cstr=(char*)malloc((len+1)*sizeof(char)))==NULL) {
-		*ret = 0;
-		return;
-	}
-	if (ftocstr(cstr, len+1, str, len)) {
-		*ret = 0;
-		free(cstr);
-		return;
-	}
-
-	*ret = xdrfile_read_string(cstr, len+1,f77xdr[*fid]);
-	ctofstr( str, len , cstr);
-	free(cstr);
-}
-
-void
-F77_FUNC(xdrwstring,XDRWSTRING)(int *fid, char *str, int *ret, int len)
-{
-	char *cstr;
-
-	if((cstr=(char*)malloc((len+1)*sizeof(char)))==NULL) {
-		*ret = 0;
-		return;
-	}
-	if (ftocstr(cstr, len+1, str, len)) {
-		*ret = 0;
-		free(cstr);
-		return;
-	}
-
-	*ret = xdrfile_write_string(cstr, f77xdr[*fid]);
-	ctofstr( str, len , cstr);
-	free(cstr);
-}
-
-void
-F77_FUNC(xdrropaque,XDRROPAQUE)(int *fid, char *data, int *ndata, int *ret)
-{
-	*ret = xdrfile_read_opaque(data,*ndata,f77xdr[*fid]);
-}
-
-void
-F77_FUNC(xdrwopaque,XDRWOPAQUE)(int *fid, char *data, int *ndata, int *ret)
-{
-	*ret = xdrfile_write_opaque(data,*ndata,f77xdr[*fid]);
-}
-
-
-/* Write single-precision compressed 3d coordinates */
-void
-F77_FUNC(xdrccs,XDRCCS)(int *fid, float *data, int *ncoord,
-						float *precision, int *ret)
-{
-    *ret = xdrfile_compress_coord_float(data,*ncoord,*precision,f77xdr[*fid]);
-}
-
-
-/* Read single-precision compressed 3d coordinates */
-void
-F77_FUNC(xdrdcs,XDRDCS)(int *fid, float *data, int *ncoord,
-						float *precision, int *ret)
-{
-	*ret = xdrfile_decompress_coord_float(data,ncoord,precision,f77xdr[*fid]);
-}
-
-
-/* Write compressed 3d coordinates from double precision data */
-void
-F77_FUNC(xdrccd,XDRCCD)(int *fid, double *data, int *ncoord,
-						double *precision, int *ret)
-{
-	*ret = xdrfile_compress_coord_double(data,*ncoord,*precision,f77xdr[*fid]);
-}
-
-/* Read compressed 3d coordinates into double precision data */
-void
-F77_FUNC(xddcd,XDRDCD)(int *fid, double *data, int *ncoord,
-					   double *precision, int *ret)
-{
-    *ret = xdrfile_decompress_coord_double(data,ncoord,precision,f77xdr[*fid]);
-}
-
-
-
-
-
 
 
 #endif /* DOXYGEN */

--- a/mdtraj/formats/xtc/src/xdrfile_xtc.c
+++ b/mdtraj/formats/xtc/src/xdrfile_xtc.c
@@ -63,7 +63,7 @@ static int xtc_header(XDRFILE *xd,int *natoms,int *step,float *time,mybool bRead
 static int xtc_coord(XDRFILE *xd,int *natoms,matrix box,rvec *x,float *prec,
 					 mybool bRead)
 {
-	int i,j,result;
+	int result;
 
 	/* box */
 	result = xdrfile_read_float(box[0],DIM*DIM,xd);
@@ -116,8 +116,9 @@ int read_xtc_nframes(char* fn, unsigned long *nframes) {
 	x = malloc(natoms * sizeof(*x));
 
     xd = xdrfile_open(fn, "r");
-    if (NULL == xd)
+    if (NULL == xd) {
         return exdrFILENOTFOUND;
+	}
 
 	do {
 		result = read_xtc(xd, natoms, &step, &time, box, x, &prec);


### PR DESCRIPTION
While investigating the Cython in this code base, I noticed several compiler warnings while building. The warnings were caused mostly by declared but unused variables. This PR addressed compiler warnings for the XTC module (which is the first one built by `setup.py`).  Most of the other modules also have a lot of compiler warnings.

A few notable/interesting things about this code and PR

* It seems to have been lifted from Gromacs, though the links in the README to the source is no longer there.
* Since it was directly lifted from somewhere else, it contained a lot of things I **think** we don't need like Fortran wrappers for the functions. I removed these.
* The error handling in some of the functions seemed incorrect. There were checks for overflow or underflow, but when found the program would print to `stderr`, set a variable that ended up not being used, and continue on it's way. My hunch is that this wasn't a problem because overflows are rarely encountered. That being said, I verified behavior upstream of the function and changed the behavior in these cases to `return -1`. This should ensure that errors are properly handled if encountered now.

I understand this may be a "if it isn't broken, don't fix it" kind of thing, but there are a lot of compiler errors and these obfuscate things that we should actually worry about. 

I saw several warnings about deprecation of NumPy API calls that occur when building that I am still figuring out.

I added the `-Werror` flag in `setup.py` to address these modules. Here is the output from the build process for the warnings that are fixed (I may have removed one variable at this point, I don't remember)

```
Using built-in specs.
COLLECT_GCC=/usr/bin/gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/9/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:hsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 9.4.0-1ubuntu1~20.04.2' --with-bugurl=file:///usr/share/doc/gcc-9/README.Bugs --enable-languages=c,ada,c++,go,brig,d,fortran,objc,obj-c++,gm2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-9 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-9-9QDOt0/gcc-9-9.4.0/debian/tmp-nvptx/usr,hsa --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 9.4.0 (Ubuntu 9.4.0-1ubuntu1~20.04.2) 
warning: mdtraj/formats/dcd/dcdlib.pxd:12:12: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: mdtraj/formats/dcd/dcdlib.pxd:12:16: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: mdtraj/formats/dcd/dcdlib.pxd:12:20: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
performance hint: mdtraj/geometry/src/image_molecules.pxi:15:5: Exception check on 'make_whole' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'make_whole' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'make_whole' to allow an error code to be returned.
performance hint: mdtraj/geometry/src/image_molecules.pxi:36:5: Exception check on 'anchor_dists' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'anchor_dists' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'anchor_dists' to allow an error code to be returned.
performance hint: mdtraj/geometry/src/image_molecules.pxi:68:5: Exception check on 'wrap_mols' will always require the GIL to be acquired.
Possible solutions:
	1. Declare 'wrap_mols' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
	2. Use an 'int' return type on 'wrap_mols' to allow an error code to be returned.
C compiler:
Attempting to autodetect OpenMP support... Compiler supports OpenMP
Attempting to autodetect SSE2   support... Compiler supports SSE2
Attempting to autodetect SSE3   support... Compiler supports SSE3
Attempting to autodetect SSE4.1 support... Compiler supports SSE4.1
Attempting to autodetect NEON   support... Did not detect NEON support

[ 1/10] Cythonizing mdtraj/formats/dcd/dcd.pyx
[ 2/10] Cythonizing mdtraj/formats/dtr/dtr.pyx
[ 3/10] Cythonizing mdtraj/formats/xtc/trr.pyx
[ 4/10] Cythonizing mdtraj/formats/xtc/xtc.pyx
[ 5/10] Cythonizing mdtraj/geometry/drid.pyx
[ 6/10] Cythonizing mdtraj/geometry/neighborlist.pyx
[ 7/10] Cythonizing mdtraj/geometry/neighbors.pyx
[ 8/10] Cythonizing mdtraj/geometry/src/_geometry.pyx
[ 9/10] Cythonizing mdtraj/rmsd/_lprmsd.pyx
[10/10] Cythonizing mdtraj/rmsd/_rmsd.pyx
running build_ext
building 'mdtraj.formats.xtc' extension
creating build/temp.linux-x86_64-cpython-313/mdtraj/formats/xtc/src
gcc -pthread -B /home/janash/miniconda3/envs/mdtraj-test/shared/python_compiler_compat -fno-strict-overflow -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/janash/miniconda3/envs/mdtraj-test/include -fPIC -O2 -isystem /home/janash/miniconda3/envs/mdtraj-test/include -fPIC -Imdtraj/formats/xtc -Imdtraj/formats/xtc/include/ -Imdtraj/formats/xtc/ -I/home/janash/miniconda3/envs/mdtraj-test/lib/python3.13/site-packages/numpy/_core/include -I/home/janash/miniconda3/envs/mdtraj-test/include/python3.13 -c mdtraj/formats/xtc/src/xdr_seek.c -o build/temp.linux-x86_64-cpython-313/mdtraj/formats/xtc/src/xdr_seek.o -Wno-unused-function -Wno-unreachable-code -Wno-sign-compare -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Werror
gcc -pthread -B /home/janash/miniconda3/envs/mdtraj-test/shared/python_compiler_compat -fno-strict-overflow -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/janash/miniconda3/envs/mdtraj-test/include -fPIC -O2 -isystem /home/janash/miniconda3/envs/mdtraj-test/include -fPIC -Imdtraj/formats/xtc -Imdtraj/formats/xtc/include/ -Imdtraj/formats/xtc/ -I/home/janash/miniconda3/envs/mdtraj-test/lib/python3.13/site-packages/numpy/_core/include -I/home/janash/miniconda3/envs/mdtraj-test/include/python3.13 -c mdtraj/formats/xtc/src/xdrfile.c -o build/temp.linux-x86_64-cpython-313/mdtraj/formats/xtc/src/xdrfile.o -Wno-unused-function -Wno-unreachable-code -Wno-sign-compare -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -Werror
mdtraj/formats/xtc/src/xdrfile.c: In function ‘xdrfile_decompress_coord_float’:
mdtraj/formats/xtc/src/xdrfile.c:785:16: error: variable ‘maxidx’ set but not used [-Werror=unused-but-set-variable]
  785 |  int smallidx, maxidx;
      |                ^~~~~~
mdtraj/formats/xtc/src/xdrfile.c: In function ‘xdrfile_compress_coord_float’:
mdtraj/formats/xtc/src/xdrfile.c:1016:6: error: variable ‘errval’ set but not used [-Werror=unused-but-set-variable]
 1016 |  int errval=1;
      |      ^~~~~~
mdtraj/formats/xtc/src/xdrfile.c: In function ‘xdrfile_decompress_coord_double’:
mdtraj/formats/xtc/src/xdrfile.c:1305:25: error: variable ‘larger’ set but not used [-Werror=unused-but-set-variable]
 1305 |  int smallnum, smaller, larger, i, is_smaller, run;
      |                         ^~~~~~
mdtraj/formats/xtc/src/xdrfile.c:1302:16: error: variable ‘minidx’ set but not used [-Werror=unused-but-set-variable]
 1302 |  int smallidx, minidx, maxidx;
      |                ^~~~~~
mdtraj/formats/xtc/src/xdrfile.c: In function ‘xdrfile_compress_coord_double’:
mdtraj/formats/xtc/src/xdrfile.c:1509:6: error: variable ‘errval’ set but not used [-Werror=unused-but-set-variable]
 1509 |  int errval=1;
      |      ^~~~~~
cc1: all warnings being treated as errors
error: command '/usr/bin/gcc' failed with exit code 1
```

There are several NumPy warnings remaining (snippet below):

```
/home/janash/miniconda3/envs/mdtraj-test/lib/python3.13/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: error: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Werror=cpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
mdtraj/formats/xtc/xtc.c: In function ‘__pyx_pw_6mdtraj_7formats_3xtc_17XTCTrajectoryFile_17_write’:
mdtraj/formats/xtc/xtc.c:1166:40: error: ‘__pyx_v_status’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1166 |   #define PyInt_FromLong               PyLong_FromLong

```