### PR TITLE
add flaky/rerun-failures to tests that require pulling off a pdb

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,8 @@ import os
 
 import pytest
 
+flaky_pdb_dl = pytest.mark.flaky(rerun=3, reason='github-node flaky pdb dl')
+
 
 @pytest.fixture(scope="session")
 def get_fn():

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -45,13 +45,15 @@ flaky_on_macos = pytest.mark.flaky(condition=sys.platform.startswith('darwin'), 
 N_FRAMES = 20
 N_ATOMS = 20
 
-xyz = np.asarray(np.random.randn(N_FRAMES, N_ATOMS, 3), dtype=np.float32)
+rng = np.random.default_rng()
+
+xyz = np.asarray(rng.standard_normal((N_FRAMES, N_ATOMS, 3), dtype=np.float32))
 pairs = np.array(list(itertools.combinations(range(N_ATOMS), 2)), dtype=np.int32)
 times = np.array([[i, 0] for i in range(N_FRAMES)[::2]], dtype=np.int32)
 
 ptraj = md.Trajectory(xyz=xyz, topology=None)
 ptraj.unitcell_vectors = np.ascontiguousarray(
-    np.random.randn(N_FRAMES, 3, 3) + 2 * np.eye(3, 3),
+    rng.standard_normal((N_FRAMES, 3, 3)) + 2 * np.eye(3, 3),
     dtype=np.float32,
 )
 
@@ -281,7 +283,7 @@ def test_distance_nan():
 
 def test_closest_contact_nan_pos():
     box_size = np.array([3.0, 4.0, 5.0])
-    xyz = np.asarray(np.random.randn(2, 20, 3), dtype=np.float32)
+    xyz = rng.standard_normal((2, 20, 3), dtype=np.float32)
     xyz *= box_size
     # Set the last frame to nan
     xyz[-1] = np.nan

--- a/tests/test_dssp.py
+++ b/tests/test_dssp.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import mdtraj as md
+from conftest import flaky_pdb_dl
 
 
 def call_dssp(get_fn, ref_name, frame=0):
@@ -63,6 +64,7 @@ def test_2(get_fn, tmpdir, fn):
         assert_(call_dssp(get_fn, fn, i), md.compute_dssp(t[i], simplified=False)[0])
 
 
+@flaky_pdb_dl
 @pytest.mark.parametrize('pdbid', ["1GAI", "6gsv", "2AAC"])
 def test_3(get_fn, tmpdir, pdbid):
     """This test checks dssp assignments on pdb files downloaded from rcsb"""

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -28,6 +28,7 @@ import tempfile
 import numpy as np
 import pytest
 
+from conftest import flaky_pdb_dl
 from mdtraj import Topology, load, load_pdb
 from mdtraj.formats.pdb import pdbstructure
 from mdtraj.formats.pdb.pdbstructure import PdbStructure
@@ -207,6 +208,7 @@ def test_pdbstructure_3():
         eq(expected[i], c)
 
 
+@flaky_pdb_dl
 def test_pdb_from_url():
     # load pdb from URL
     t1 = load_pdb("http://www.rcsb.org/pdb/files/4ZUO.pdb.gz")


### PR DESCRIPTION
Allowing tests that pull pdb off rcsb.org to rerun up to 3 times. My current theory is that the pdb pulled is corrupted, leading to failed tests. 

This is an error observed in #1986 and #1983 (among other places). (Somehow not reproducible locally though)