### PR TITLE
Remove scipy import in `_lprmsd.pyx` to make mdtraj submodules importable without scipy

### DIFF
--- a/mdtraj/rmsd/_lprmsd.pyx
+++ b/mdtraj/rmsd/_lprmsd.pyx
@@ -26,7 +26,6 @@
 ##############################################################################
 import cython
 import numpy as np
-import scipy.spatial.distance
 from mdtraj.utils import ensure_type
 
 cimport numpy as np


### PR DESCRIPTION
Hi all,

The cython file `_lprmsd.pyx` imports `scipy.spatial.distance`, even though it doesn't use anything from `scipy` at all. This prevents any submodule of mdtraj from being imported without scipy installed, since mdtraj's `__init__.py` imports lprmsd for `__all__` . 

It also appears that care was used to _selectively_ import scipy in various places throughout the repository:
- [here, only in smooth()](https://github.com/mdtraj/mdtraj/blob/76a7563dc708c7a2c3918c0b506b3eaaca34272d/mdtraj/core/trajectory.py#L2142)
- [here, only in AmberNetCDFRestartFile](https://github.com/mdtraj/mdtraj/blob/76a7563dc708c7a2c3918c0b506b3eaaca34272d/mdtraj/formats/amberrst.py#L540-L545)
- [here, only inside kabsch_sander()](https://github.com/mdtraj/mdtraj/blob/76a7563dc708c7a2c3918c0b506b3eaaca34272d/mdtraj/geometry/hbond.py#L314)

So, I imagine that scipy is meant to be a looser dependency than, say, numpy.  The `_lprmsd.pyx` file is currently preventing that from being the case.

If one removes the import of scipy in `_lprmsd.pyx`, then one can `import mdtraj`, or, e.g. `from mdtraj.core.trajectory import Trajectory` successfully without scipy installed.