### PR TITLE
move rng/ptraj generation for distance tests into fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,12 @@
 ##############################################################################
 
 import os
+import itertools
 
 import pytest
+import numpy as np
+
+import mdtraj as md
 
 flaky_pdb_dl = pytest.mark.flaky(rerun=3, reason='github-node flaky pdb dl')
 
@@ -35,3 +39,24 @@ def get_fn():
         return f"{test_dir}/data/{fn}"
 
     return _get_fn
+
+
+@pytest.fixture
+def gen_random_ptraj(request, tmp_path):
+    """
+    Fixture for preparing a temp location
+    """
+    request.cls.N_FRAMES = N_FRAMES = 20
+    request.cls.N_ATOMS = N_ATOMS = 20
+    
+    request.cls.rng = rng = np.random.default_rng()
+    
+    request.cls.xyz = xyz = np.asarray(rng.standard_normal((N_FRAMES, N_ATOMS, 3), dtype=np.float32))
+    request.cls.pairs = pairs = np.array(list(itertools.combinations(range(N_ATOMS), 2)), dtype=np.int32)
+    request.cls.times = times = np.array([[i, 0] for i in range(N_FRAMES)[::2]], dtype=np.int32)
+    
+    request.cls.ptraj = md.Trajectory(xyz=xyz, topology=None)
+    request.cls.ptraj.unitcell_vectors = np.ascontiguousarray(
+        rng.standard_normal((N_FRAMES, 3, 3)) + 2 * np.eye(3, 3),
+        dtype=np.float32,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def get_fn():
     return _get_fn
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def gen_random_ptraj(request):
     """
     Fixture for preparing a test trajectories with random coordinates 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,12 @@ def get_fn():
     return _get_fn
 
 
-@pytest.fixture
-def gen_random_ptraj(request, tmp_path):
+@pytest.fixture(scope="class")
+def gen_random_ptraj(request):
     """
-    Fixture for preparing a temp location
+    Fixture for preparing a test trajectories with random coordinates 
+    and unitcell
+
     """
     request.cls.N_FRAMES = N_FRAMES = 20
     request.cls.N_ATOMS = N_ATOMS = 20

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -39,323 +39,285 @@ from mdtraj.geometry.distance import (
 from mdtraj.testing import assert_allclose, eq
 
 
-flaky_on_macos = pytest.mark.flaky(condition=sys.platform.startswith('darwin'), reruns=3, reason='flaky on macos')
-
-
-N_FRAMES = 20
-N_ATOMS = 20
-
-rng = np.random.default_rng()
-
-xyz = np.asarray(rng.standard_normal((N_FRAMES, N_ATOMS, 3), dtype=np.float32))
-pairs = np.array(list(itertools.combinations(range(N_ATOMS), 2)), dtype=np.int32)
-times = np.array([[i, 0] for i in range(N_FRAMES)[::2]], dtype=np.int32)
-
-ptraj = md.Trajectory(xyz=xyz, topology=None)
-ptraj.unitcell_vectors = np.ascontiguousarray(
-    rng.standard_normal((N_FRAMES, 3, 3)) + 2 * np.eye(3, 3),
-    dtype=np.float32,
-)
-
-
-def test_generator():
-    pairs2 = itertools.combinations(range(N_ATOMS), 2)
-    a = compute_distances(ptraj, pairs)
-    b = compute_distances(ptraj, pairs2)
-    eq(a, b)
-
-
-def test_0():
-    a = compute_distances(ptraj, pairs, periodic=False, opt=True)
-    b = compute_distances(ptraj, pairs, periodic=False, opt=False)
-    eq(a, b)
-
-
-@flaky_on_macos
-def test_compute_distances_core_nonperiodic():
-    a = compute_distances(ptraj, pairs, periodic=False, opt=True)
-    b = compute_distances_core(
-        ptraj.xyz,
-        pairs,
-        unitcell_vectors=ptraj.unitcell_vectors,
-        periodic=False,
-        opt=True,
-    )
-    eq(a, b)
-
-    a = compute_distances(ptraj, pairs, periodic=False, opt=False)
-    b = compute_distances_core(
-        ptraj.xyz,
-        pairs,
-        unitcell_vectors=ptraj.unitcell_vectors,
-        periodic=False,
-        opt=False,
-    )
-    eq(a, b)
-
-
-def test_compute_distances_core_periodic():
-    # opt
-    a = compute_distances(ptraj, pairs, periodic=True, opt=True)
-    b = compute_distances_core(
-        ptraj.xyz,
-        pairs,
-        unitcell_vectors=ptraj.unitcell_vectors,
-        periodic=True,
-        opt=True,
-    )
-    eq(a, b, decimal=3)
-
-    # no-opt
-    a = compute_distances(ptraj, pairs, periodic=True, opt=False)
-    b = compute_distances_core(
-        ptraj.xyz,
-        pairs,
-        unitcell_vectors=ptraj.unitcell_vectors,
-        periodic=True,
-        opt=False,
-    )
-    eq(a, b, decimal=3)
-
-
-def test_1():
-    a = compute_displacements(ptraj, pairs, periodic=False, opt=True)
-    b = compute_displacements(ptraj, pairs, periodic=False, opt=False)
-    eq(a, b)
-
-
-def test_2():
-    a = compute_distances(ptraj, pairs, periodic=False, opt=False)
-    b = compute_displacements(ptraj, pairs, periodic=False, opt=False)
-    eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
-
-
-def test_3():
-    a = compute_distances(ptraj, pairs, periodic=False, opt=True)
-    b = compute_displacements(ptraj, pairs, periodic=False, opt=True)
-    eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
-
-
-@flaky_on_macos
-def test_0p():
-    a = compute_distances(ptraj, pairs, periodic=True, opt=True)
-    b = compute_distances(ptraj, pairs, periodic=True, opt=False)
-    print(a, b)
-    eq(a, b, decimal=3)
-
-
-@flaky_on_macos
-def test_1p():
-    a = compute_displacements(ptraj, pairs, periodic=True, opt=True)
-    b = compute_displacements(ptraj, pairs, periodic=True, opt=False)
-    eq(a, b, decimal=3)
-
-
-@flaky_on_macos
-def test_2p():
-    a = compute_distances(ptraj, pairs, periodic=True, opt=False)
-    b = compute_displacements(ptraj, pairs, periodic=True, opt=False)
-    assert a.shape == (len(ptraj), len(pairs))
-    assert b.shape == (len(ptraj), len(pairs), 3), str(b.shape)
-    b = np.sqrt(np.sum(np.square(b), axis=2))
-    eq(a, b, decimal=5)
-
-
-@flaky_on_macos
-def test_3p():
-    a = compute_distances(ptraj, pairs, periodic=True, opt=True)
-    b = compute_displacements(ptraj, pairs, periodic=True, opt=True)
-    print(a, b)
-    eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
-
-
-def test_4():
-    # using a really big box, we should get the same results with and without
-    # pbcs
-    box = np.array([[100, 0, 0], [0, 200, 0], [0, 0, 300]])
-    box = np.zeros((N_FRAMES, 3, 3)) + box  # broadcast it out
-    a = _displacement_mic(xyz, pairs, box, False)
-    b = _displacement(xyz, pairs)
-    eq(a, b, decimal=3)
-
-
-def test_5():
-    # simple wrap around along the z axis.
-    xyz = np.array([[[0.0, 0.0, 0.0], [0.0, 0.0, 2.2]]])
-    box = np.eye(3, 3).reshape(1, 3, 3)
-    result = _displacement_mic(xyz, np.array([[0, 1]]), box, True)
-    eq(result, np.array([[[0, 0, 0.2]]]))
-
-
-def test_6(get_fn):
-    ext_ref = (
-        np.array(
-            [
-                17.4835,
-                22.2418,
-                24.2910,
-                22.5505,
-                12.8686,
-                22.1090,
-                7.4472,
-                22.4253,
-                19.8283,
-                20.6935,
-            ],
+class Test_Distance():
+    def test_generator(self, gen_random_ptraj):
+        self.pairs2 = itertools.combinations(range(self.N_ATOMS), 2)
+        a = compute_distances(self.ptraj, self.pairs)
+        b = compute_distances(self.ptraj, self.pairs2)
+        eq(a, b)
+    
+    
+    def test_0(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=True)
+        b = compute_distances(self.ptraj, self.pairs, periodic=False, opt=False)
+        eq(a, b)
+    
+    def test_compute_distances_core_nonperiodic(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=True)
+        b = compute_distances_core(
+            self.ptraj.xyz,
+            self.pairs,
+            unitcell_vectors=self.ptraj.unitcell_vectors,
+            periodic=False,
+            opt=True,
         )
-        / 10
-    )
-    traj = md.load(get_fn("test_good.nc"), top=get_fn("test.parm7"))
-    _run_amber_traj(traj, ext_ref)
-
-
-def test_7(get_fn):
-    ext_ref = (
-        np.array(
-            [
-                30.9184,
-                23.9040,
-                25.3869,
-                28.0060,
-                25.9704,
-                24.6836,
-                23.0508,
-                27.1983,
-                24.4954,
-                26.7448,
-            ],
+        eq(a, b)
+    
+        a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=False)
+        b = compute_distances_core(
+            self.ptraj.xyz,
+            self.pairs,
+            unitcell_vectors=self.ptraj.unitcell_vectors,
+            periodic=False,
+            opt=False,
         )
-        / 10
-    )
-    traj = md.load(get_fn("test_bad.nc"), top=get_fn("test.parm7"))
-    _run_amber_traj(traj, ext_ref)
-
-
-def _run_amber_traj(traj, ext_ref):
-    # Test triclinic case where simple approach in Tuckerman text does not
-    # always work
-    distopt = md.compute_distances(traj, [[0, 9999]], opt=True)
-    distslw = md.compute_distances(traj, [[0, 9999]], opt=False)
-    dispopt = md.compute_displacements(traj, [[0, 9999]], opt=True)
-    dispslw = md.compute_displacements(traj, [[0, 9999]], opt=False)
-
-    eq(distopt, distslw, decimal=5)
-    eq(dispopt, dispslw, decimal=5)
-
-    assert_allclose(distopt.flatten(), ext_ref, atol=2e-5)
-
-    # Make sure distances from displacements are the same
-    eq(np.sqrt((dispopt.squeeze() ** 2).sum(axis=1)), distopt.squeeze())
-    eq(np.sqrt((dispslw.squeeze() ** 2).sum(axis=1)), distslw.squeeze())
-    eq(dispopt, dispslw, decimal=5)
-
-
-def test_closest_contact():
-    box_size = np.array([3.0, 4.0, 5.0])
-    traj = md.Trajectory(xyz=xyz * box_size, topology=None)
-    _verify_closest_contact(traj)
-    traj.unitcell_lengths = np.array([box_size for i in range(N_FRAMES)])
-    traj.unitcell_angles = np.array([[90.0, 90.0, 90.0] for i in range(N_FRAMES)])
-    _verify_closest_contact(traj)
-    traj.unitcell_angles = np.array([[80.0, 90.0, 100.0] for i in range(N_FRAMES)])
-    _verify_closest_contact(traj)
-
-
-def _verify_closest_contact(traj):
-    group1 = np.array([i for i in range(N_ATOMS // 2)], dtype=int)
-    group2 = np.array([i for i in range(N_ATOMS // 2, N_ATOMS)], dtype=int)
-    contact = find_closest_contact(traj, group1, group2)
-    pairs = np.array([(i, j) for i in group1 for j in group2], dtype=int)
-    dists = md.compute_distances(traj, pairs, True)[0]
-    _ = md.compute_distances(traj, pairs, False)[0]
-    nearest = np.argmin(dists)
-    eq(float(dists[nearest]), contact[2], decimal=5)
-    assert (pairs[nearest, 0] == contact[0] and pairs[nearest, 1] == contact[1]) or (
-        pairs[nearest, 0] == contact[1] and pairs[nearest, 1] == contact[0]
-    )
-
-
-def test_distance_nan():
-    xyz = np.array([[1, 1, 1], [2, 1, 1], [np.nan, np.nan, np.nan]]).reshape(1, 3, 3)
-    dists = md.compute_distances(md.Trajectory(xyz=xyz, topology=None), [[0, 1]])
-    assert np.isfinite(dists).all()
-
-
-def test_closest_contact_nan_pos():
-    box_size = np.array([3.0, 4.0, 5.0])
-    xyz = rng.standard_normal((2, 20, 3), dtype=np.float32)
-    xyz *= box_size
-    # Set the last frame to nan
-    xyz[-1] = np.nan
-    # Slice of the last frame, so nans should not cause troubles.
-    xyz = xyz[:-1]
-    traj = md.Trajectory(xyz=xyz, topology=None)
-    _verify_closest_contact(traj)
-
-
-def test_distance_t_inputs():
-    incorrect_pairs = np.array((0, ptraj.n_atoms + 1))
-    with pytest.raises(ValueError, match="atom_pairs"):
-        compute_distances_t(ptraj, incorrect_pairs, times)
-
-    incorrect_times = np.array((0, ptraj.n_frames + 1))
-    with pytest.raises(ValueError, match="time_pairs"):
-        compute_distances_t(ptraj, pairs, incorrect_times)
-
-
-def test_distances_t(get_fn):
-    a = compute_distances_t(ptraj, pairs, times, periodic=True, opt=True)
-    b = compute_distances_t(ptraj, pairs, times, periodic=True, opt=False)
-    eq(a, b)
-    c = compute_distances_t(ptraj, pairs, times, periodic=False, opt=True)
-    d = compute_distances_t(ptraj, pairs, times, periodic=False, opt=False)
-    eq(c, d)
-
-
-def test_distances_t_at_0(get_fn):
-    times = np.array([[0, 0]], dtype=np.int32)
-    a = compute_distances_t(ptraj, pairs, times, periodic=True, opt=True)
-    b = compute_distances_t(ptraj, pairs, times, periodic=True, opt=False)
-    c = compute_distances(ptraj[:1], pairs, periodic=True, opt=True)
-    d = compute_distances(ptraj[:1], pairs, periodic=True, opt=False)
-    eq(a, c)
-    eq(b, d)
-
-
-def _run_amber_traj_t(traj, ext_ref):
-    # Test triclinic case where simple approach in Tuckerman text does not
-    # always work
-    _ = compute_distances_t(
-        traj,
-        atom_pairs=[[0, 9999]],
-        time_pairs=[[0, 2]],
-        opt=True,
-    )
-    _ = compute_distances_t(
-        traj,
-        atom_pairs=[[0, 9999]],
-        time_pairs=[[0, 2]],
-        opt=False,
-    )
-
-
-def test_amber_t(get_fn):
-    ext_ref = (
-        np.array(
-            [
-                17.4835,
-                22.2418,
-                24.2910,
-                22.5505,
-                12.8686,
-                22.1090,
-                7.4472,
-                22.4253,
-                19.8283,
-                20.6935,
-            ],
+        eq(a, b)
+    
+    def test_compute_distances_core_periodic(self, gen_random_ptraj):
+        # opt
+        a = compute_distances(self.ptraj, self.pairs, periodic=True, opt=True)
+        b = compute_distances_core(
+            self.ptraj.xyz,
+            self.pairs,
+            unitcell_vectors=self.ptraj.unitcell_vectors,
+            periodic=True,
+            opt=True,
         )
-        / 10
-    )
-    traj = md.load(get_fn("test_good.nc"), top=get_fn("test.parm7"))
-    _run_amber_traj_t(traj, ext_ref)
+        eq(a, b, decimal=3)
+    
+        # no-opt
+        a = compute_distances(self.ptraj, self.pairs, periodic=True, opt=False)
+        b = compute_distances_core(
+            self.ptraj.xyz,
+            self.pairs,
+            unitcell_vectors=self.ptraj.unitcell_vectors,
+            periodic=True,
+            opt=False,
+        )
+        eq(a, b, decimal=3)
+    
+    def test_1(self, gen_random_ptraj):
+        a = compute_displacements(self.ptraj, self.pairs, periodic=False, opt=True)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=False, opt=False)
+        eq(a, b)
+    
+    def test_2(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=False)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=False, opt=False)
+        eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
+    
+    def test_3(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=True)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=False, opt=True)
+        eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
+    
+    def test_0p(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=True, opt=True)
+        b = compute_distances(self.ptraj, self.pairs, periodic=True, opt=False)
+        print(a, b)
+        eq(a, b, decimal=3)
+    
+    def test_1p(self, gen_random_ptraj):
+        a = compute_displacements(self.ptraj, self.pairs, periodic=True, opt=True)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=True, opt=False)
+        eq(a, b, decimal=3)
+    
+    def test_2p(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=True, opt=False)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=True, opt=False)
+        assert a.shape == (len(self.ptraj), len(self.pairs))
+        assert b.shape == (len(self.ptraj), len(self.pairs), 3), str(b.shape)
+        b = np.sqrt(np.sum(np.square(b), axis=2))
+        eq(a, b, decimal=5)
+    
+    def test_3p(self, gen_random_ptraj):
+        a = compute_distances(self.ptraj, self.pairs, periodic=True, opt=True)
+        b = compute_displacements(self.ptraj, self.pairs, periodic=True, opt=True)
+        print(a, b)
+        eq(a, np.sqrt(np.sum(np.square(b), axis=2)))
+    
+    def test_4(self, gen_random_ptraj):
+        # using a really big box, we should get the same results with and without
+        # pbcs
+        box = np.array([[100, 0, 0], [0, 200, 0], [0, 0, 300]])
+        box = np.zeros((self.N_FRAMES, 3, 3)) + box  # broadcast it out
+        a = _displacement_mic(self.xyz, self.pairs, box, False)
+        b = _displacement(self.xyz, self.pairs)
+        eq(a, b, decimal=3)
+    
+    
+    def test_5(self, gen_random_ptraj):
+        # simple wrap around along the z axis.
+        xyz = np.array([[[0.0, 0.0, 0.0], [0.0, 0.0, 2.2]]])
+        box = np.eye(3, 3).reshape(1, 3, 3)
+        result = _displacement_mic(xyz, np.array([[0, 1]]), box, True)
+        eq(result, np.array([[[0, 0, 0.2]]]))
+    
+    def test_6(self, get_fn):
+        ext_ref = (
+            np.array(
+                [
+                    17.4835,
+                    22.2418,
+                    24.2910,
+                    22.5505,
+                    12.8686,
+                    22.1090,
+                    7.4472,
+                    22.4253,
+                    19.8283,
+                    20.6935,
+                ],
+            )
+            / 10
+        )
+        traj = md.load(get_fn("test_good.nc"), top=get_fn("test.parm7"))
+        self._run_amber_traj(traj, ext_ref)
+    
+    def test_7(self, get_fn):
+        ext_ref = (
+            np.array(
+                [
+                    30.9184,
+                    23.9040,
+                    25.3869,
+                    28.0060,
+                    25.9704,
+                    24.6836,
+                    23.0508,
+                    27.1983,
+                    24.4954,
+                    26.7448,
+                ],
+            )
+            / 10
+        )
+        traj = md.load(get_fn("test_bad.nc"), top=get_fn("test.parm7"))
+        self._run_amber_traj(traj, ext_ref)
+    
+    def _run_amber_traj(self, traj, ext_ref):
+        # Test triclinic case where simple approach in Tuckerman text does not
+        # always work
+        distopt = md.compute_distances(traj, [[0, 9999]], opt=True)
+        distslw = md.compute_distances(traj, [[0, 9999]], opt=False)
+        dispopt = md.compute_displacements(traj, [[0, 9999]], opt=True)
+        dispslw = md.compute_displacements(traj, [[0, 9999]], opt=False)
+    
+        eq(distopt, distslw, decimal=5)
+        eq(dispopt, dispslw, decimal=5)
+    
+        assert_allclose(distopt.flatten(), ext_ref, atol=2e-5)
+    
+        # Make sure distances from displacements are the same
+        eq(np.sqrt((dispopt.squeeze() ** 2).sum(axis=1)), distopt.squeeze())
+        eq(np.sqrt((dispslw.squeeze() ** 2).sum(axis=1)), distslw.squeeze())
+        eq(dispopt, dispslw, decimal=5)
+    
+    def test_closest_contact(self, gen_random_ptraj):
+        box_size = np.array([3.0, 4.0, 5.0])
+        traj = md.Trajectory(xyz=self.xyz * box_size, topology=None)
+        self._verify_closest_contact(gen_random_ptraj, traj)
+        traj.unitcell_lengths = np.array([box_size for i in range(self.N_FRAMES)])
+        traj.unitcell_angles = np.array([[90.0, 90.0, 90.0] for i in range(self.N_FRAMES)])
+        self._verify_closest_contact(gen_random_ptraj,traj=traj)
+        traj.unitcell_angles = np.array([[80.0, 90.0, 100.0] for i in range(self.N_FRAMES)])
+        self._verify_closest_contact(gen_random_ptraj, traj=traj)
+    
+    def _verify_closest_contact(self, gen_random_ptraj, traj):
+        group1 = np.array([i for i in range(self.N_ATOMS // 2)], dtype=int)
+        group2 = np.array([i for i in range(self.N_ATOMS // 2, self.N_ATOMS)], dtype=int)
+        contact = find_closest_contact(traj, group1, group2)
+        pairs = np.array([(i, j) for i in group1 for j in group2], dtype=int)
+        dists = md.compute_distances(traj, pairs, True)[0]
+        _ = md.compute_distances(traj, pairs, False)[0]
+        nearest = np.argmin(dists)
+        eq(float(dists[nearest]), contact[2], decimal=5)
+        assert (pairs[nearest, 0] == contact[0] and pairs[nearest, 1] == contact[1]) or (
+            pairs[nearest, 0] == contact[1] and pairs[nearest, 1] == contact[0]
+        )
+    
+    
+    def test_distance_nan(self):
+        xyz = np.array([[1, 1, 1], [2, 1, 1], [np.nan, np.nan, np.nan]]).reshape(1, 3, 3)
+        dists = md.compute_distances(md.Trajectory(xyz=xyz, topology=None), [[0, 1]])
+        assert np.isfinite(dists).all()
+    
+    
+    def test_closest_contact_nan_pos(self, gen_random_ptraj):
+        box_size = np.array([3.0, 4.0, 5.0])
+        xyz = self.rng.standard_normal((2, 20, 3), dtype=np.float32)
+        xyz *= box_size
+        # Set the last frame to nan
+        xyz[-1] = np.nan
+        # Slice of the last frame, so nans should not cause troubles.
+        xyz = xyz[:-1]
+        traj = md.Trajectory(xyz=xyz, topology=None)
+        self._verify_closest_contact(gen_random_ptraj, traj)
+    
+    
+    def test_distance_t_inputs(self, gen_random_ptraj):
+        incorrect_pairs = np.array((0, self.ptraj.n_atoms + 1))
+        with pytest.raises(ValueError, match="atom_pairs"):
+            compute_distances_t(self.ptraj, incorrect_pairs, self.times)
+    
+        incorrect_times = np.array((0, self.ptraj.n_frames + 1))
+        with pytest.raises(ValueError, match="time_pairs"):
+            compute_distances_t(self.ptraj, self.pairs, incorrect_times)
+    
+    
+    def test_distances_t(self, get_fn):
+        a = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=True)
+        b = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=False)
+        eq(a, b)
+        c = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=False, opt=True)
+        d = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=False, opt=False)
+        eq(c, d)
+    
+    
+    def test_distances_t_at_0(self, get_fn):
+        self.times = np.array([[0, 0]], dtype=np.int32)
+        a = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=True)
+        b = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=False)
+        c = compute_distances(self.ptraj[:1], self.pairs, periodic=True, opt=True)
+        d = compute_distances(self.ptraj[:1], self.pairs, periodic=True, opt=False)
+        eq(a, c)
+        eq(b, d)
+    
+    
+    def _run_amber_traj_t(self, traj, ext_ref):
+        # Test triclinic case where simple approach in Tuckerman text does not
+        # always work
+        _ = compute_distances_t(
+            traj,
+            atom_pairs=[[0, 9999]],
+            time_pairs=[[0, 2]],
+            opt=True,
+        )
+        _ = compute_distances_t(
+            traj,
+            atom_pairs=[[0, 9999]],
+            time_pairs=[[0, 2]],
+            opt=False,
+        )
+    
+    
+    def test_amber_t(self, get_fn):
+        ext_ref = (
+            np.array(
+                [
+                    17.4835,
+                    22.2418,
+                    24.2910,
+                    22.5505,
+                    12.8686,
+                    22.1090,
+                    7.4472,
+                    22.4253,
+                    19.8283,
+                    20.6935,
+                ],
+            )
+            / 10
+        )
+        traj = md.load(get_fn("test_good.nc"), top=get_fn("test.parm7"))
+        self._run_amber_traj_t(traj, ext_ref)

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -46,7 +46,6 @@ class Test_Distance():
         b = compute_distances(self.ptraj, self.pairs2)
         eq(a, b)
     
-    
     def test_0(self, gen_random_ptraj):
         a = compute_distances(self.ptraj, self.pairs, periodic=False, opt=True)
         b = compute_distances(self.ptraj, self.pairs, periodic=False, opt=False)
@@ -145,7 +144,6 @@ class Test_Distance():
         b = _displacement(self.xyz, self.pairs)
         eq(a, b, decimal=3)
     
-    
     def test_5(self, gen_random_ptraj):
         # simple wrap around along the z axis.
         xyz = np.array([[[0.0, 0.0, 0.0], [0.0, 0.0, 2.2]]])
@@ -236,12 +234,10 @@ class Test_Distance():
             pairs[nearest, 0] == contact[1] and pairs[nearest, 1] == contact[0]
         )
     
-    
     def test_distance_nan(self):
         xyz = np.array([[1, 1, 1], [2, 1, 1], [np.nan, np.nan, np.nan]]).reshape(1, 3, 3)
         dists = md.compute_distances(md.Trajectory(xyz=xyz, topology=None), [[0, 1]])
         assert np.isfinite(dists).all()
-    
     
     def test_closest_contact_nan_pos(self, gen_random_ptraj):
         box_size = np.array([3.0, 4.0, 5.0])
@@ -254,7 +250,6 @@ class Test_Distance():
         traj = md.Trajectory(xyz=xyz, topology=None)
         self._verify_closest_contact(gen_random_ptraj, traj)
     
-    
     def test_distance_t_inputs(self, gen_random_ptraj):
         incorrect_pairs = np.array((0, self.ptraj.n_atoms + 1))
         with pytest.raises(ValueError, match="atom_pairs"):
@@ -264,7 +259,6 @@ class Test_Distance():
         with pytest.raises(ValueError, match="time_pairs"):
             compute_distances_t(self.ptraj, self.pairs, incorrect_times)
     
-    
     def test_distances_t(self, get_fn):
         a = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=True)
         b = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=True, opt=False)
@@ -272,7 +266,6 @@ class Test_Distance():
         c = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=False, opt=True)
         d = compute_distances_t(self.ptraj, self.pairs, self.times, periodic=False, opt=False)
         eq(c, d)
-    
     
     def test_distances_t_at_0(self, get_fn):
         self.times = np.array([[0, 0]], dtype=np.int32)
@@ -282,7 +275,6 @@ class Test_Distance():
         d = compute_distances(self.ptraj[:1], self.pairs, periodic=True, opt=False)
         eq(a, c)
         eq(b, d)
-    
     
     def _run_amber_traj_t(self, traj, ext_ref):
         # Test triclinic case where simple approach in Tuckerman text does not
@@ -299,7 +291,6 @@ class Test_Distance():
             time_pairs=[[0, 2]],
             opt=False,
         )
-    
     
     def test_amber_t(self, get_fn):
         ext_ref = (
@@ -321,3 +312,4 @@ class Test_Distance():
         )
         traj = md.load(get_fn("test_good.nc"), top=get_fn("test.parm7"))
         self._run_amber_traj_t(traj, ext_ref)
+


### PR DESCRIPTION
The generation of a random `ptraj` and other associated variables for `test_distances.py` are currently at the top of the test file. Unfortunately, some tests below share the same variable names (e.g. `xyz`), which means they could be overwritten when the tests are run out of order using `pytest-xdist`. My hypothesis is that this is [causing some](https://github.com/jeremyleung521/mdtraj/actions/runs/13777969584/job/38530872667#step:6:3054) [flaky behavior in the CI](https://github.com/mdtraj/mdtraj/actions/runs/13732317066/job/38411437988#step:6:3026).

I moved all that to `conftest.py` as fixture class variables, which should prevent those variables from being overwritten. Some egregious errors include the parts of the `xyz` array being rewritten [into NaNs](https://github.com/mdtraj/mdtraj/blob/main/tests/test_distance.py#L279), which prevents [other tests from completing](https://github.com/mdtraj/mdtraj/actions/runs/13732317066/job/38411437988#step:6:3026).