### PR TITLE
Remove netCDF4 dependency, set up PyPI build variants

### DIFF
--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -17,4 +17,5 @@ dependencies:
   - pytest-xdist
   - python
   - scipy
+  - scripttest
   - zlib

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -17,5 +17,4 @@ dependencies:
   - pytest-xdist
   - python
   - scipy
-  - scripttest
   - zlib

--- a/mdtraj/utils/delay_import.py
+++ b/mdtraj/utils/delay_import.py
@@ -95,17 +95,6 @@ MESSAGES = {
 
     conda install -c conda-forge openmm
     """,
-    "scripttest": """
-    The code at {filename}:{line_number} requires the scripttest package,
-    which is a python package for testing command-line applications
-
-    scripttest can be downloaded from https://pypi.python.org/pypi/ScriptTest/,
-    or installed with the python "easy_install" or "pip" package managers using:
-
-    # easy_install scripttest
-    or
-    # pip install scripttest
-    """,
     "openmm.app": """
     The code at {filename}:{line_number} requires the openmm.app module, which is
     the python OpenMM application layer. OpenMM is a toolkit for molecular simulation
@@ -124,10 +113,6 @@ MESSAGES = {
     # easy_install pandas
     or
     # pip install pandas
-    """,
-    "scipy": """,
-
-    The code at {filename}:{line_number} requires the scipy package
     """,
 }
 

--- a/setup.py
+++ b/setup.py
@@ -320,9 +320,9 @@ metadata = dict(
         "packaging",
     ],
     extras_require={
-        "tests" = EXTRAS_REQUIRE["tests"],
-        "optional" = EXTRAS_REQUIRE["optional"],
-        "all" = EXTRAS_REQUIRE["test"] + EXTRAS_REQUIRE["optional"],
+        "tests" : EXTRAS_REQUIRE["tests"],
+        "optional" : EXTRAS_REQUIRE["optional"],
+        "all" : EXTRAS_REQUIRE["test"] + EXTRAS_REQUIRE["optional"],
     },
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -321,7 +321,7 @@ metadata = dict(
     extras_require={
         "tests" : EXTRAS_REQUIRE["tests"],
         "optional" : EXTRAS_REQUIRE["optional"],
-        "all" : EXTRAS_REQUIRE["test"] + EXTRAS_REQUIRE["optional"],
+        "all" : EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["optional"],
     },
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -293,7 +293,7 @@ metadata = dict(
     url="http://mdtraj.org",
     download_url="https://github.com/rmcgibbo/mdtraj/releases/latest",
     platforms=["Linux", "Mac OS-X", "Unix", "Windows"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=CLASSIFIERS.splitlines(),
     packages=find_packages(),
     cmdclass={**versioneer.get_cmdclass(), "build_ext": build_ext},
@@ -302,8 +302,21 @@ metadata = dict(
         "scipy",
         "pyparsing",
         "packaging",
-        "netCDF4",
     ],
+    extra_require={
+        "tests": [
+            "pytest",
+            "pytest-rerunfailures",
+            "pytest-xdist",
+            "scripttest",
+        ],
+        "optional": [
+            "tables",
+            "networkx",
+            "netCDF4",
+            "pandas",
+        ],
+    },
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,22 @@ def geometry_extensions():
     ]
 
 
+EXTRAS_REQUIRE = {
+    "tests": [
+        "pytest",
+        "pytest-rerunfailures",
+        "pytest-xdist",
+        "scripttest",
+    ],
+    "optional": [
+        "tables",
+        "networkx",
+        "netCDF4",
+        "pandas",
+    ],
+}
+
+
 metadata = dict(
     name="mdtraj",
     author="Robert McGibbon",
@@ -303,19 +319,10 @@ metadata = dict(
         "pyparsing",
         "packaging",
     ],
-    extra_require={
-        "tests": [
-            "pytest",
-            "pytest-rerunfailures",
-            "pytest-xdist",
-            "scripttest",
-        ],
-        "optional": [
-            "tables",
-            "networkx",
-            "netCDF4",
-            "pandas",
-        ],
+    extras_require={
+        "tests" = EXTRAS_REQUIRE["tests"],
+        "optional" = EXTRAS_REQUIRE["optional"],
+        "all" = EXTRAS_REQUIRE["test"] + EXTRAS_REQUIRE["optional"],
     },
     package_data={"mdtraj.formats.pdb": ["data/*"]},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -287,7 +287,6 @@ EXTRAS_REQUIRE = {
         "pytest",
         "pytest-rerunfailures",
         "pytest-xdist",
-        "scripttest",
     ],
     "optional": [
         "tables",


### PR DESCRIPTION
Removing netCDF4 as a hard dependency (see https://github.com/mdtraj/mdtraj/issues/1897).

While I was at it, I added in `mdtraj[tests]` and `mdtraj[optional]`, which should allow you to install most of the other dependencies without having to resort to the test conda env recipe, and `pip install mdtraj[all]` should install both sets. I also updated the `delay_import` documentation to remove `scripttest` (not used anymore) and `scipy` (a hard dependency now).

I believe we are dropping python 3.9 (EOL later this year) so did that in the metadata as well.