### PR TITLE
Allow ArcTrajectoryFile to optionally take topology

### DIFF
--- a/mdtraj/formats/arc.py
+++ b/mdtraj/formats/arc.py
@@ -37,17 +37,13 @@ class _EOF(IOError):
 
 
 @FormatRegistry.register_loader(".arc")
-def load_arc(filename, top=None, stride=None, atom_indices=None, frame=None):
+def load_arc(filename, stride=None, atom_indices=None, frame=None, top=None):
     """Load a TINKER .arc file from disk.
 
     Parameters
     ----------
     filename : path-like
         Path of TINKER .arc file.
-    top : {str, Trajectory, Topology}
-        While the ARC format does does contain minimal topology information, it does
-        not include residue information. Pass in either the path to a pdb file, a 
-        trajectory, or a topology to supply this information.
     stride : int, default=None
         Only read every stride-th frame
     atom_indices : array_like, optional
@@ -57,6 +53,10 @@ def load_arc(filename, top=None, stride=None, atom_indices=None, frame=None):
         Use this option to load only a single frame from a trajectory on disk.
         If frame is None, the default, the entire trajectory will be loaded.
         If supplied, ``stride`` will be ignored.
+    top : {str, Trajectory, Topology}, optional
+        While the ARC format does does contain minimal topology information, it does
+        not include residue information. Pass in either a file path 
+        (e.g. to pdb), a trajectory, or a topology object to supply this information.
 
     Returns
     -------

--- a/tests/test_arc.py
+++ b/tests/test_arc.py
@@ -1,10 +1,10 @@
 ##############################################################################
 # MDTraj: A Python Library for Loading, Saving, and Manipulating
 #         Molecular Dynamics Trajectories.
-# Copyright 2012-2017 Stanford University and the Authors
+# Copyright 2012-2025 Stanford University and the Authors
 #
 # Authors: Lee-Ping Wang
-# Contributors: Robert McGibbon
+# Contributors: Robert McGibbon, Jeremy M. G. Leung
 #
 # MDTraj is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -25,10 +25,12 @@ import numpy as np
 
 import mdtraj as md
 from mdtraj.formats import ArcTrajectoryFile, PDBTrajectoryFile
+from mdtraj.formats.arc import load_arc
 from mdtraj.testing import eq
 
 
 def test_read_0(get_fn):
+    '''Check if .arc positions are read correctly'''
     with ArcTrajectoryFile(get_fn("4waters.arc")) as f:
         xyz, leng, ang = f.read()
     with PDBTrajectoryFile(get_fn("4waters.pdb")) as f:
@@ -42,6 +44,31 @@ def test_read_arctraj(get_fn):
     eq(traj.xyz, owntop.xyz)
 
 
+def test_read_arctraj_top(get_fn):
+    '''Check if anything other than residues differ between loading 
+    a ``.arc`` file with two different topologies'''
+    pdbtop = load_arc(get_fn("4waters.arc"), top=get_fn("4waters.pdb"))
+    arctop = load_arc(get_fn("4waters.arc"))
+ 
+    eq(pdbtop.n_atoms, arctop.n_atoms)
+    eq(pdbtop.xyz, arctop.xyz)
+
+    # Only the residues should differ
+    assert pdbtop.n_residues == 4
+    assert arctop.n_residues == 1
+
+    for ipdb, iarc in zip(pdbtop.top._atoms, arctop.top._atoms):
+        # check if atoms are in the same order with same element identity
+        eq(ipdb.name, iarc.name)
+        eq(ipdb.element, iarc.element)
+ 
+    for ipdb, iarc in zip(pdbtop.top._bonds, arctop.top._bonds):
+        # Check if connectivity is the same, based on index, which is 
+        # implicitly checked in the for loop above
+        eq(ipdb.atom1.index, iarc.atom1.index)
+        eq(ipdb.atom2.index, iarc.atom2.index)
+
+
 def test_read_pbc(get_fn):
     with ArcTrajectoryFile(get_fn("thf200.arc")) as f:
         xyz, leng, ang = f.read()
@@ -49,3 +76,4 @@ def test_read_pbc(get_fn):
     eq(xyz[0, -1], np.array([29.013880, 6.255754, 44.074519]), decimal=3)
     eq(leng, np.array([[45.119376, 45.119376, 45.119376]]), decimal=3)
     eq(ang, np.array([[90.0, 90.0, 90.0]]), decimal=3)
+

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -784,7 +784,10 @@ def test_open_and_load(get_fn):
         else:
             md.open(get_fn(file))
 
-        md.load(get_fn(file), top=get_fn("native.pdb"))
+        if file.endswith('.arc'):
+            md.load(get_fn(file), top=get_fn("4waters.pdb"))
+        else:
+            md.load(get_fn(file), top=get_fn("frame0.pdb"))
 
 
 def test_length(get_fn):


### PR DESCRIPTION
Been recently working on `.arc` trajectory files (yay Tinker). While the file itself contains _some_ information on topology, it does not have residue information. This means all atoms are [funneled into a single residue](https://github.com/mdtraj/mdtraj/blob/main/mdtraj/formats/arc.py#L100-L103). ([actual code](https://github.com/mdtraj/mdtraj/blob/main/mdtraj/formats/arc.py#L353-L356))

This PR adds in the functionality to feed in a topology (file name, trajectory objects, or topology objects) to `load_arc()`, allowing users to better read in arc trajectory files for analysis. Most of the code is essentially modeled off of the [NetCDF trajectory loader](https://github.com/mdtraj/mdtraj/blob/main/mdtraj/formats/netcdf.py), which requires a topology. Existing behavior for not feeding in a topology is retained.


Testing script:
```
import mdtraj
a = mdtraj.load('seg.arc', top='seg.pdb')
b = mdtraj.load('seg.arc')

print(len(a.topology._residues))  # prints 2112
print(len(b.topology._residues))  # prints 1

print(a.topology._residues[0])  # prints TYR1
print(b.topology._residues[0])  # prints RES1
```

Remove the `.txt` to run. Wouldn't upload to GitHub otherwise.
[seg.arc.txt](https://github.com/user-attachments/files/19250715/seg.arc.txt)
[seg.pdb.txt](https://github.com/user-attachments/files/19250717/seg.pdb.txt)
