### PR TITLE
Add formal charge to the `to_dataframe()` and `from_dataframe()` methods

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -648,7 +648,10 @@ class Topology:
             fc = atom["formal_charge"]
             if fc is not None:
                 if pd.notna(fc):
-                    fc = float(fc)
+                    try:
+                        fc = int(fc)
+                    except ValueError:
+                        raise ValueError(f"Formal charge {fc} cannot be cast to an integer.")
                 else:
                     fc = None
                     
@@ -1792,7 +1795,7 @@ class Atom:
         index: int,
         residue: Residue,
         serial: int | None = None,
-        formal_charge: float | None = None,
+        formal_charge: int | None = None,
     ):
         """Construct a new Atom.  You should call add_atom() on the Topology instead of calling this directly."""
         # The name of the Atom

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -645,14 +645,23 @@ class Topology:
                     atom["resSeq"],
                     atom["segmentID"],
                 )
-
+            fc = atom["formal_charge"]
+            if fc is not None:
+                try:
+                    if pd.notna(fc):
+                        fc = int(fc)
+                    else:
+                        fc = None
+                except Exception:
+                    fc = None
+                    
             a = Atom(
                 atom["name"],
                 elem.get_by_symbol(atom["element"]),
                 atom_index,
                 r, # type: ignore
                 serial=atom["serial"],
-                formal_charge=atom["formal_charge"],
+                formal_charge=fc,
             )
             out._atoms[atom_index] = a
             r._atoms.append(a) # type: ignore

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -647,12 +647,9 @@ class Topology:
                 )
             fc = atom["formal_charge"]
             if fc is not None:
-                try:
-                    if pd.notna(fc):
-                        fc = float(fc)
-                    else:
-                        fc = None
-                except Exception:
+                if pd.notna(fc):
+                    fc = float(fc)
+                else:
                     fc = None
                     
             a = Atom(

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -608,7 +608,7 @@ class Topology:
         try:
             atoms = atoms.astype({"formal_charge": "Int64"})
         except ValueError as e:
-            raise ValueError(f"Error converting formal_charge to Int64: {e}")
+            raise ValueError(f"Formal charge conversion failed: all values in 'formal_charge' must be integers or None. Original error: {e}")
 
         out = cls()
         if not isinstance(atoms, pd.DataFrame):

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -517,6 +517,7 @@ class Topology:
                 atom.residue.name,
                 atom.residue.chain.index,
                 atom.segment_id,
+                atom.formal_charge
             )
             for atom in self.atoms
         ]
@@ -531,6 +532,7 @@ class Topology:
                 "resName",
                 "chainID",
                 "segmentID",
+                "formal_charge"
             ],
         )
 
@@ -561,8 +563,7 @@ class Topology:
             frame should have columns "serial" (atom index), "name" (atom name),
             "element" (atom's element), "resSeq" (index of the residue)
             "resName" (name of the residue), "chainID" (index of the chain),
-            and optionally "segmentID", following the same conventions
-            as wwPDB 3.0 format.
+            and optionally "segmentID" and "formal_charge", following the same conventions as wwPDB 3.0 format.
         bonds : np.ndarray, shape=(n_bonds, 4) or (n_bonds, 2), dtype=float, Optional
             The bonds in the topology, represented as a n_bonds x 4 or n_bonds x 2
             size array of the indices of the atoms involved, type, and order of each
@@ -591,6 +592,9 @@ class Topology:
         ]:
             if col not in atoms.columns:
                 raise ValueError("dataframe must have column %s" % col)
+
+        if "formal_charge" not in atoms.columns:
+            atoms["formal_charge"] = None
 
         if "segmentID" not in atoms.columns:
             atoms["segmentID"] = ""
@@ -648,6 +652,7 @@ class Topology:
                 atom_index,
                 r, # type: ignore
                 serial=atom["serial"],
+                formal_charge=atom["formal_charge"],
             )
             out._atoms[atom_index] = a
             r._atoms.append(a) # type: ignore

--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -649,7 +649,7 @@ class Topology:
             if fc is not None:
                 try:
                     if pd.notna(fc):
-                        fc = int(fc)
+                        fc = float(fc)
                     else:
                         fc = None
                 except Exception:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -119,7 +119,12 @@ def test_topology_openmm_formal_charges(get_fn):
 
     # Check that the formal charges are the same
     eq(formal_charges, mdtraj_formal_charges)
- 
+
+import pandas as pd
+
+def normalize_charge(charge):
+    # Convert None to pandas NA, leave numbers intact
+    return pd.NA if charge is None else charge 
 def test_topology_dataframe_formal_charges(get_fn):
     """
     Test that formal charges are maintained when converting a topology
@@ -130,6 +135,7 @@ def test_topology_dataframe_formal_charges(get_fn):
 
     # Get the original formal charges from the MDTraj topology.
     original_formal_charges = [atom.formal_charge for atom in topology.atoms]
+    normalized_original = [normalize_charge(charge) for charge in original_formal_charges]
 
     # Convert topology to DataFrame and bonds array.
     atoms_df, bonds = topology.to_dataframe()
@@ -141,7 +147,7 @@ def test_topology_dataframe_formal_charges(get_fn):
     converted_formal_charges = [atom.formal_charge for atom in topology_from_df.atoms]
 
     # Check that formal charges are conserved.
-    eq(original_formal_charges, converted_formal_charges)   
+    eq(normalized_original, converted_formal_charges)   
 
 def test_topology_pandas(get_fn):
     topology = md.load(get_fn("native.pdb")).topology

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -110,6 +110,7 @@ def test_topology_openmm_formal_charges(get_fn):
         # so we just return (skip the test)
         return
 
+
     # Convert to MDTraj topology
     mdtraj_topology = md.Topology.from_openmm(pdb.topology)
 
@@ -118,7 +119,29 @@ def test_topology_openmm_formal_charges(get_fn):
 
     # Check that the formal charges are the same
     eq(formal_charges, mdtraj_formal_charges)
-    
+ 
+def test_topology_dataframe_formal_charges(get_fn):
+    """
+    Test that formal charges are maintained when converting a topology
+    to a DataFrame and back. Uses a PDB file with formal charges.
+    """
+    # Load the topology from a PDB file with formal charges.
+    topology = md.load(get_fn("1ply_charge.pdb")).topology
+
+    # Get the original formal charges from the MDTraj topology.
+    original_formal_charges = [atom.formal_charge for atom in topology.atoms]
+
+    # Convert topology to DataFrame and bonds array.
+    atoms_df, bonds = topology.to_dataframe()
+
+    # Convert topology back from the DataFrame.
+    topology_from_df = md.Topology.from_dataframe(atoms_df, bonds)
+
+    # Extract formal charges from the converted topology.
+    converted_formal_charges = [atom.formal_charge for atom in topology_from_df.atoms]
+
+    # Check that formal charges are conserved.
+    eq(original_formal_charges, converted_formal_charges)   
 
 def test_topology_pandas(get_fn):
     topology = md.load(get_fn("native.pdb")).topology


### PR DESCRIPTION
This PR is to addressing issue #2001 
1. Atoms with formal charges are now supported by `to_dataframe()` and `from_dataframe()`
2. Unit tests for these two functions are provided