### PR TITLE
Allow mdtraj.rmsd() to calculate without alignment

### DIFF
--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -101,10 +101,14 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         the trajectory's coordinates, the center and traces will be out of
         date and the RMSDs will be incorrect.
     superpose : bool, default=True
-        Whether to use the Theobald QCP method to calculate RMSD. If True, the 
-        QCP method is used, which inherently superposes the structure based on 
-        the `atom_indices` selection. If False, RMSD is directly calculated with
-        no optimization and no superposition done. The `precentered` option is ignored.
+        Whether to use the Theobald QCP method to calculate RMSD. If True, the
+        QCP method is used, which inherently superposes the structure based on
+        the `atom_indices` selection. If False, the Theolbald QCP method is not used
+        and the RMSD is directly calculated pairwise with no optimization and additional
+        no superposition done.
+        The `precentered` option is ignored. Users are expected to manually superpose
+        and/or image their trajectories using `Trajectory.image_molecules()` and/or
+        `Trajectory.make_molecules_whole()` and/or `Trajectory.superpose()`.
 
     Examples
     --------
@@ -222,6 +226,11 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         # t2 = time.time()
         # print 'rmsd: %s, centering: %s' % (t2-t1, t1-t0)
     else:
+        if precentered:
+            warnings.warn(
+                'in rmsd(), precentered is ignored when superpose=False',
+                RuntimeWarning)
+
         if parallel:
             for i in prange(target_n_frames, nogil=True):
                 msd = msd_nosuperpose(n_atoms, target_xyz[i], ref_xyz_frame)

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -61,8 +61,9 @@ cdef extern from "math.h":
 
 @cython.boundscheck(False)
 def rmsd(target, reference, int frame=0, atom_indices=None,
-         ref_atom_indices=None, bool parallel=True, bool precentered=False):
-    """rmsd(target, reference, frame=0, atom_indices=None, parallel=True, precentered=False)
+         ref_atom_indices=None, bool parallel=True, bool precentered=False, superpose=True):
+    """rmsd(target, reference, frame=0, atom_indices=None, ref_atom_indices=None,
+            parallel=True, precentered=False, superpose=True)
 
     Compute RMSD of all conformations in target to a reference conformation.
     Note, this will center the conformations in place.
@@ -97,6 +98,11 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         be unsafe; if you use Trajectory.center_coordinates and then modify
         the trajectory's coordinates, the center and traces will be out of
         date and the RMSDs will be incorrect.
+    superpose : bool, default=True
+        Whether to use the Theobald QCP method to calculate RMSD. If True, the 
+        QCP method is used, which inherently superposes the structure based on 
+        the `atom_indices` selection. If False, RMSD is directly calculated with
+        no optimization and no superposition done.
 
     Examples
     --------
@@ -171,39 +177,50 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
     cdef float[:] target_g
     cdef int target_n_frames = target.xyz.shape[0]
     cdef int n_atoms = target.xyz.shape[1] if np.all(atom_indices == slice(None)) else len(atom_indices)
+    cdef float[:] distances = np.zeros(target_n_frames, dtype=np.float32)
 
     # make sure *every* frame in target_xyz is in proper c-major order
     target_xyz = np.asarray(target.xyz[:, atom_indices, :], order='C', dtype=np.float32)
     # only extract the `frame`-th conformation from ref_xyz
     ref_xyz_frame = np.asarray(reference.xyz[frame, ref_atom_indices, :], order='C', dtype=np.float32)
 
-    # t0 = time.time()
-    if precentered and (reference._rmsd_traces is not None) and (target._rmsd_traces is not None) and atom_indices_is_none:
-        target_g = np.asarray(target._rmsd_traces, order='C', dtype=np.float32)
-        ref_g = reference._rmsd_traces[frame]
+    if superpose:
+        # t0 = time.time()
+        if precentered and (reference._rmsd_traces is not None) and (target._rmsd_traces is not None) and atom_indices_is_none:
+            target_g = np.asarray(target._rmsd_traces, order='C', dtype=np.float32)
+            ref_g = reference._rmsd_traces[frame]
+        else:
+            if precentered:
+                warnings.warn(
+                    'in rmsd(), precentered is ignored when atom_indices != None',
+                    RuntimeWarning)
+            target_g = np.empty(target_n_frames, dtype=np.float32)
+            inplace_center_and_trace_atom_major(&target_xyz[0,0,0], &target_g[0], target_n_frames, n_atoms)
+            inplace_center_and_trace_atom_major(&ref_xyz_frame[0, 0], &ref_g, 1, n_atoms)
+    
+        # t1 = time.time()
+    
+        if parallel:
+            for i in prange(target_n_frames, nogil=True):
+                msd = msd_nosuperpose(n_atoms, n_atoms, &target_xyz[i, 0, 0], &ref_xyz_frame[0, 0], target_g[i], ref_g, 0, NULL)
+                distances[i] = sqrtf(msd)
+        else:
+            for i in range(target_n_frames):
+                msd = msd_atom_major(n_atoms, n_atoms, &target_xyz[i, 0, 0], &ref_xyz_frame[0, 0], target_g[i], ref_g, 0, NULL)
+                distances[i] = sqrtf(msd)
+    
+        # t2 = time.time()
+        # print 'rmsd: %s, centering: %s' % (t2-t1, t1-t0)
     else:
-        if precentered:
-            warnings.warn(
-                'in rmsd(), precentered is ignored when atom_indices != None',
-                RuntimeWarning)
-        target_g = np.empty(target_n_frames, dtype=np.float32)
-        inplace_center_and_trace_atom_major(&target_xyz[0,0,0], &target_g[0], target_n_frames, n_atoms)
-        inplace_center_and_trace_atom_major(&ref_xyz_frame[0, 0], &ref_g, 1, n_atoms)
-
-    # t1 = time.time()
-
-    cdef float[:] distances = np.zeros(target_n_frames, dtype=np.float32)
-    if parallel:
-        for i in prange(target_n_frames, nogil=True):
-            msd = msd_atom_major(n_atoms, n_atoms, &target_xyz[i, 0, 0], &ref_xyz_frame[0, 0], target_g[i], ref_g, 0, NULL)
-            distances[i] = sqrtf(msd)
-    else:
-        for i in range(target_n_frames):
-            msd = msd_atom_major(n_atoms, n_atoms, &target_xyz[i, 0, 0], &ref_xyz_frame[0, 0], target_g[i], ref_g, 0, NULL)
-            distances[i] = sqrtf(msd)
-
-    # t2 = time.time()
-    # print 'rmsd: %s, centering: %s' % (t2-t1, t1-t0)
+        if parallel:
+            for i in prange(target_n_frames, nogil=True):
+                msd = msd_nosuperpose(n_atoms, &target_xyz[i], &ref_xyz_frame)
+                distances[i] = sqrtf(msd)
+        else:
+            for i in range(target_n_frames):
+                msd = msd_nosuperpose(n_atoms, &target_xyz[i], &ref_xyz_frame)
+                distances[i] = sqrtf(msd)
+ 
     return np.array(distances, copy=False)
 
 
@@ -675,3 +692,43 @@ def getMultipleAlignDisplaceRMSDs_atom_major(float[:, :, ::1] xyz_align1 not Non
             distances[i] = sqrtf(msd)
 
     return np.array(distances, copy=False), np.array(rot, copy=False)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def msd_nosuperpose(int n_atoms,
+                    float[:, ::1] xyz_current not None,
+                    float[:, ::1] xyz_ref not None):
+    """
+    Private function to directly calculate the MSD of one frame without alignment.
+
+    Parameters
+    ----------
+    n_atoms : int
+        The number of atoms in this frame.
+    xyz_current : np.ndarray(float), shape = (n_atoms, 3), dtype = np.float32
+        The xyz coordinates of the current frame.
+    xyz_ref : np.ndarray(float), shape = (n_atoms, 3), dtype = np.float32
+        The xyz coordinates of the reference frame.
+
+
+    Returns
+    -------
+    msd : float
+        The mean square deviation of xyz_current from xyz_ref.
+
+    """
+    cdef Py_ssize_t atom_count
+    cdef Py_ssize_t dims_count
+    cdef float msd_temp = 0
+
+    # Shortcut out if same xyz.
+    if xyz_current == xyz_ref:
+        return msd_temp
+
+    # Loop through each atom and each dimension to calculate difference from ref 
+    for atom_count in range(n_atoms):
+        for dims_count in range(3):
+            msd_temp += (xyz_current[atom_count][dims_count]- xyz_ref[atom_count][dims_count])**2
+    return msd_temp / n_atoms
+

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -4,7 +4,7 @@
 # Copyright 2012-2013 Stanford University and the Authors
 #
 # Authors: Robert McGibbon, Kyle Beauchamp
-# Contributors:
+# Contributors: Jeremy M. G. Leung
 #
 # MDTraj is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -215,7 +215,6 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         # print 'rmsd: %s, centering: %s' % (t2-t1, t1-t0)
     else:
         if parallel:
-            #pass
             for i in prange(target_n_frames, nogil=True):
                 msd = msd_nosuperpose(n_atoms, target_xyz[i], ref_xyz_frame)
                 distances[i] = sqrtf(msd)
@@ -723,10 +722,6 @@ cdef const float msd_nosuperpose(const Py_ssize_t n_atoms,
     """
     cdef Py_ssize_t atom_count, dims_count
     cdef float msd_temp = 0
-
-    # Shortcut out if same xyz.
-    if xyz_current == xyz_ref:
-        return msd_temp
 
     # Loop through each atom and each dimension to calculate difference from ref 
     for atom_count in range(n_atoms):

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -104,7 +104,7 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         Whether to use the Theobald QCP method to calculate RMSD. If True, the 
         QCP method is used, which inherently superposes the structure based on 
         the `atom_indices` selection. If False, RMSD is directly calculated with
-        no optimization and no superposition done.
+        no optimization and no superposition done. The `precentered` option is ignored.
 
     Examples
     --------

--- a/mdtraj/rmsd/_rmsd.pyx
+++ b/mdtraj/rmsd/_rmsd.pyx
@@ -119,6 +119,13 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
     >>> trajectory.center_coordinates()
     >>> rmsds = md.rmsd(trajectory, trajectory, 0, precentered=True)
 
+    The default option aligns the trajectory to the reference based on selection indicated by 
+    `atom_indices` and `ref_atom_indices`. If you want to manually align the trajectory to a 
+    different selection (or not at all), use `md.superpose()` and the `superpose=False` option.
+
+    >>> trajectory.superpose(trajectory, 0, atom_slice=trajectory.top.select('protein and not element H'))
+    >>> rmsds = md.rmsd(trajectory, trajectory, superpose=False)
+
     See Also
     --------
     Trajectory.center_coordinates
@@ -135,6 +142,7 @@ def rmsd(target, reference, int frame=0, atom_indices=None,
         A 1-D numpy array of the optimal root-mean-square deviations from
         the `frame`-th conformation in reference to each of the conformations
         in target.
+
     """
     # import time
     cdef bool atom_indices_is_none = False

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -172,7 +172,7 @@ def test_superpose_refinds():
     assert not np.allclose(normal.xyz, normal_xyz)
 
 
-def test_rmsd_atom_indices_nosuperpose(get_fn):
+def test_rmsd_atom_indices(get_fn):
     native = md.load(get_fn("native.pdb"))
     atom_indices = np.arange(10)
 
@@ -201,8 +201,7 @@ def test_rmsd_atom_indices_nosuperpose(get_fn):
     eq(dist1b, dist1c)  # Should be the same regardless of how you align
     eq(dist1b, dist2)   # Should be the same with coords from different file format
 
-
-@pytest.mark.parametrize('superpose', [True, False])
+@pytest.mark.parametrize('superpose', [True, False], ids=['superpose','qcp'])
 def test_rmsd_ref_ainds_superpose(get_fn, superpose):
     native = md.load(get_fn("native.pdb"))
     t1 = md.load(get_fn("traj.h5"))

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -4,7 +4,7 @@
 # Copyright 2012-2013 Stanford University and the Authors
 #
 # Authors: Robert McGibbon
-# Contributors:
+# Contributors: Jeremy M. G. Leung
 #
 # MDTraj is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -24,21 +24,29 @@
 import numpy as np
 
 import mdtraj as md
+import pytest
 from mdtraj.geometry.alignment import compute_average_structure, rmsd_qcp
 from mdtraj.testing import eq
 
-np.random.seed(52)
+
+rng = np.random.default_rng(seed=52)
 
 
-def test_trajectory_rmsd(get_fn):
+@pytest.mark.parametrize('parallel', [True, False], ids=['parallel', 'serial'])
+@pytest.mark.parametrize('superpose', [True, False], ids=['superpose','qcp'])
+def test_trajectory_rmsd(get_fn, parallel, superpose):
     t = md.load(get_fn("traj.h5"))
-    for parallel in [True, False]:
-        calculated = md.rmsd(t, t, 0, parallel=parallel)
-        reference = np.zeros(t.n_frames)
-        for i in range(t.n_frames):
-            reference[i] = rmsd_qcp(t.xyz[0], t.xyz[i])
+    
+    if superpose is False:
+        t.superpose(t, 0)
+    calculated = md.rmsd(t, t, 0, parallel=parallel, superpose=superpose)
 
-        eq(calculated, reference, decimal=3)
+    t = md.load(get_fn("traj.h5"))
+    reference = np.zeros(t.n_frames)
+    for i in range(t.n_frames):
+        reference[i] = rmsd_qcp(t.xyz[0], t.xyz[i])
+
+    eq(calculated, reference, decimal=3)
 
 
 def test_precentered_1(get_fn):
@@ -103,13 +111,13 @@ def test_superpose_0(get_fn):
 
 def test_superpose_1():
     # make one frame far from the origin
-    reference = md.Trajectory(xyz=np.random.randn(1, 100, 3) + 100, topology=None)
+    reference = md.Trajectory(xyz=rng.standard_normal((1, 100, 3)) + 100, topology=None)
     reference_xyz = reference.xyz.copy()
 
     for indices in [None, np.arange(90)]:
         # make another trajectory in a similar rotational state
         query = md.Trajectory(
-            xyz=reference.xyz + 0.01 * np.random.randn(*reference.xyz.shape),
+            xyz=reference.xyz + 0.01 * rng.standard_normal(reference.xyz.shape),
             topology=None,
         )
         query.superpose(reference, 0, atom_indices=indices)
@@ -122,8 +130,8 @@ def test_superpose_1():
 
 
 def test_superpose_2():
-    t1 = md.Trajectory(xyz=np.random.randn(1, 100, 3) + 100, topology=None)
-    t2 = md.Trajectory(xyz=np.random.randn(1, 100, 3) + 100, topology=None)
+    t1 = md.Trajectory(xyz=rng.standard_normal((1, 100, 3)) + 100, topology=None)
+    t2 = md.Trajectory(xyz=rng.standard_normal((1, 100, 3)) + 100, topology=None)
     t2_copy = t2.xyz.copy()
 
     t1.superpose(t2)
@@ -135,7 +143,7 @@ def test_superpose_2():
 
 def test_superpose_refinds():
     # make one frame far from the origin
-    normal = np.random.randn(1, 100, 3)
+    normal = rng.standard_normal((1, 100, 3))
     normal_xyz = normal.copy()
 
     flipped = np.zeros_like(normal)
@@ -164,22 +172,38 @@ def test_superpose_refinds():
     assert not np.allclose(normal.xyz, normal_xyz)
 
 
-def test_rmsd_atom_indices(get_fn):
+def test_rmsd_atom_indices_nosuperpose(get_fn):
     native = md.load(get_fn("native.pdb"))
-    t1 = md.load(get_fn("traj.h5"))
-
     atom_indices = np.arange(10)
-    dist1 = md.rmsd(t1, native, atom_indices=atom_indices)
 
+    # RMSD without alignment
+    t1 = md.load(get_fn("traj.h5"))
+    dist1a = md.rmsd(t1, native, atom_indices=atom_indices, superpose=False)
+
+    # RMSD with alignment via superpose
+    t1 = md.load(get_fn("traj.h5"))
+    t1.superpose(native, atom_indices=atom_indices)
+    dist1b = md.rmsd(t1, native, atom_indices=atom_indices, superpose=False)
+    
+    # RMSD with alignment via Theobald QCP
+    t1 = md.load(get_fn("traj.h5"))
+    dist1c = md.rmsd(t1, native, atom_indices=atom_indices, superpose=True)
+   
     t2 = md.load(get_fn("traj.h5"))
     t2.restrict_atoms(atom_indices)
     native.restrict_atoms(atom_indices)
     dist2 = md.rmsd(t2, native)
 
-    eq(dist1, dist2)
+    with pytest.raises(AssertionError):
+        # Values for aligned and not aligned should be different
+        eq(dist1a, dist1b)
+
+    eq(dist1b, dist1c)  # Should be the same regardless of how you align
+    eq(dist1b, dist2)   # Should be the same with coords from different file format
 
 
-def test_rmsd_ref_ainds(get_fn):
+@pytest.mark.parametrize('superpose', [True, False])
+def test_rmsd_ref_ainds_superpose(get_fn, superpose):
     native = md.load(get_fn("native.pdb"))
     t1 = md.load(get_fn("traj.h5"))
 
@@ -189,6 +213,7 @@ def test_rmsd_ref_ainds(get_fn):
         native,
         atom_indices=atom_indices,
         ref_atom_indices=atom_indices,
+        superpose=superpose,
     )
 
     bad_atom_indices = np.arange(10, 20)
@@ -198,6 +223,7 @@ def test_rmsd_ref_ainds(get_fn):
         native,
         atom_indices=atom_indices,
         ref_atom_indices=bad_atom_indices,
+        superpose=superpose,
     )
 
     assert np.all(dist2 > dist1)
@@ -261,9 +287,10 @@ def test_rmsd_atom_indices_vs_ref_indices():
     # here the 2nd chain in the top_2 is rmsd-compatible to the one in the top_1
     # so we should be able to compute rsmd between them.
 
-    trj_1 = md.Trajectory(np.random.RandomState(0).randn(n_frames, n_atoms_1, 3), top_1)
-    trj_2 = md.Trajectory(np.random.RandomState(0).randn(n_frames, n_atoms_2, 3), top_2)
+    trj_1 = md.Trajectory(rng.standard_normal((n_frames, n_atoms_1, 3)), top_1)
+    trj_2 = md.Trajectory(rng.standard_normal((n_frames, n_atoms_2, 3)), top_2)
 
     md.rmsd(trj_1, trj_2, atom_indices=[0], ref_atom_indices=[1])
     md.rmsd(trj_2, trj_1, atom_indices=[1], ref_atom_indices=[0])
     # if this don't fail then it's good no matter the result
+


### PR DESCRIPTION
Resolves #2008 

Users can now run RMSD without aligning. First pass around this, unless someone wants to work out the math described in https://github.com/mdtraj/mdtraj/issues/1188.

Usage:
```
# Suppose you have `traj1` and `ref` md.Trajectory objects, which have different xyz coordinates

# RMSD without aligning
rmsd1 = md.rmsd(traj1, ref, superpose=False)  # RMSD without aligning

# RMSD after aligning manually
traj1.superpose(ref) # Align traj1 to ref, done inplace
rmsd2 = md.rmsd(traj1, ref, superpose=False)  # Calculate without alignment

# Let RMSD/Theobald QCP do the alignment
rmsd3 = md.rmsd(traj1, ref, superpose=True)  
rmsd3 = md.rmsd(traj1, ref)  # These two are equivalent

# Note `rmsd1` != `rmsd2` == `rmsd3`
```

<strike>I'm not sure how much slower this is, but I'll test it in a little bit.</strike> See EDIT 2 below

I also added tests for my additions, and updated `test_rmsd.py` so it no longer rely on the global instance pRNG. 

Annotated output showing the level of cythonization. (remove .txt)
[_rmsd.html.txt](https://github.com/user-attachments/files/19641225/_rmsd.html.txt)




====

EDIT:
I also tried doing a shortcut (similar to the [Theobald QCP code](https://github.com/mdtraj/mdtraj/blob/969b2e1f71f2dfb4f96230392f4925d9649ede11/mdtraj/rmsd/src/theobald_rmsd_generic.h#L74-L80)) where if the xyz are the same it would return 0. It compiles fine if I run `cythonize -a _rmsd.pyx` but it fails to compile via `pip install`. Not sure what's happening here, but any help would be great. I currently removed these lines so it works.

https://github.com/mdtraj/mdtraj/blob/969b2e1f71f2dfb4f96230392f4925d9649ede11/mdtraj/rmsd/_rmsd.pyx#L727-L729

Error:
```
      mdtraj/rmsd/_rmsd.cpp:22733:25: error: invalid operands to binary expression ('__Pyx_memviewslice' and '__Pyx_memviewslice')
       22733 | __pyx_t_1 = (__pyx_t_16 == __pyx_v_ref_xyz_frame);
             |              ~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~
```

=====

EDIT2: Timing
Calculation is faster [9] than using QCP [8], but if you factor in superposing, It's about 4x slower [10]. Most of the run time is from superposing [11].

```
In [8]: timeit.timeit('mdtraj.rmsd(a,a,0)', setup='import mdtraj; a = mdtraj.load("traj.h5")', number=1000)
Out[8]: 0.025098250014707446

In [9]: timeit.timeit('mdtraj.rmsd(a,a,0, superpose=False)', setup='import mdtraj; a = mdtraj.load("traj.h5")', number=1000)
Out[9]: 0.012531082989880815

In [10]: timeit.timeit('a.superpose(a,0); mdtraj.rmsd(a,a,0, superpose=False)', setup='import mdtraj; a = mdtraj.load("traj.h5")', number=
       ⋮ 1000)
Out[10]: 0.12832299998262897

In [11]: timeit.timeit('a.superpose(a,0)', setup='import mdtraj; a = mdtraj.load("traj.h5")', number=1000)
Out[11]: 0.12596291699446738
```