### PR TITLE
Fix Topology double-loading for HDF5 and MOL2 (+ remove false-positive UserWarning)

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -398,7 +398,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
     # These topology formats do not support the 'top' keyword
     # This is to prevent the loader from reading the topology twice.
-    if _get_extension(top) not in ['.h5', '.hdf5', '.mol2']:
+    if isinstance(top, str) and _get_extension(top) not in ['.h5', '.hdf5', '.mol2']:
         kwargs["top"] = _parse_topology(top, **topkwargs)
 
     # get the right loader

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -397,7 +397,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
         top = filename_or_filenames[0]
 
     # This is to prevent the loader from reading the topology twice.
-    if extension not in ['.h5', '.hdf5']:
+    if extension not in ['.h5', '.hdf5', '.arc', '.mol2']:
         kwargs["top"] = _parse_topology(top, **topkwargs)
 
     # get the right loader

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -395,7 +395,10 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     top = topkwargs.pop("top", None)
     if top is None:
         top = filename_or_filenames[0]
-    kwargs["top"] = _parse_topology(top, **topkwargs)
+
+    # This is to prevent the loader from reading the topology twice.
+    if extension not in ['.h5', '.hdf5']:
+        kwargs["top"] = _parse_topology(top, **topkwargs)
 
     # get the right loader
     try:

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -396,8 +396,9 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
     if top is None:
         top = filename_or_filenames[0]
 
+    # These topology formats do not support the 'top' keyword
     # This is to prevent the loader from reading the topology twice.
-    if extension not in ['.h5', '.hdf5', '.arc', '.mol2']:
+    if _get_extension(top) not in ['.h5', '.hdf5', '.mol2']:
         kwargs["top"] = _parse_topology(top, **topkwargs)
 
     # get the right loader

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -398,7 +398,7 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
 
     # These topology formats do not support the 'top' keyword
     # This is to prevent the loader from reading the topology twice.
-    if isinstance(top, str) and _get_extension(top) not in ['.h5', '.hdf5', '.mol2']:
+    if extension not in ['.h5', '.hdf5', '.mol2']:
         kwargs["top"] = _parse_topology(top, **topkwargs)
 
     # get the right loader

--- a/mdtraj/formats/arc.py
+++ b/mdtraj/formats/arc.py
@@ -80,7 +80,6 @@ def load_arc(filename, stride=None, atom_indices=None, frame=None, top=None):
     else:
         topology = None
 
-
     atom_indices = cast_indices(atom_indices)
 
     with ArcTrajectoryFile(filename) as f:

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -73,7 +73,7 @@ Frames = namedtuple(
 
 @FormatRegistry.register_loader(".h5")
 @FormatRegistry.register_loader(".hdf5")
-def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
+def load_hdf5(filename, stride=None, atom_indices=None, frame=None):#, top=None):
     """Load an MDTraj hdf5 trajectory file from disk.
 
     Parameters
@@ -90,6 +90,8 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
         Use this option to load only a single frame from a trajectory on disk.
         If frame is None, the default, the entire trajectory will be loaded.
         If supplied, ``stride`` will be ignored.
+    top : None
+        Not used. Ignored.
 
     Examples
     --------
@@ -115,6 +117,12 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
         raise TypeError(
             "filename must be of type path-like for load_lh5. " "you supplied %s" % type(filename),
         )
+
+    #if top is not None:
+    #    from mdtraj.core.trajectory import _parse_topology
+    #    topology = _parse_topology(top)
+    #else:
+    #    topology = None
 
     atom_indices = cast_indices(atom_indices)
 

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -73,7 +73,7 @@ Frames = namedtuple(
 
 @FormatRegistry.register_loader(".h5")
 @FormatRegistry.register_loader(".hdf5")
-def load_hdf5(filename, stride=None, atom_indices=None, frame=None):#, top=None):
+def load_hdf5(filename, stride=None, atom_indices=None, frame=None):
     """Load an MDTraj hdf5 trajectory file from disk.
 
     Parameters
@@ -90,8 +90,6 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):#, top=None)
         Use this option to load only a single frame from a trajectory on disk.
         If frame is None, the default, the entire trajectory will be loaded.
         If supplied, ``stride`` will be ignored.
-    top : None
-        Not used. Ignored.
 
     Examples
     --------
@@ -117,12 +115,6 @@ def load_hdf5(filename, stride=None, atom_indices=None, frame=None):#, top=None)
         raise TypeError(
             "filename must be of type path-like for load_lh5. " "you supplied %s" % type(filename),
         )
-
-    #if top is not None:
-    #    from mdtraj.core.trajectory import _parse_topology
-    #    topology = _parse_topology(top)
-    #else:
-    #    topology = None
 
     atom_indices = cast_indices(atom_indices)
 


### PR DESCRIPTION
Currently, loading `.h5` and `.mol2` files with `mdtraj.load()` will always return a `UserWarning`, even though no `top` kwarg is passed. This is because the topology is loaded twice for these file types (these loaders don't take the `top` argument), and the topology from the first load triggers the `UserWarning` right before the second successful topology load.

More precisely, the two topology loads happen 
A) once during [topology parsing](https://github.com/mdtraj/mdtraj/blob/main/mdtraj/core/trajectory.py#L398) and 
B) once during this [try/except block](
https://github.com/mdtraj/mdtraj/blob/main/mdtraj/core/trajectory.py#L442-L444) where topology is discarded (because a `top` argument is given) and the topology is reread again. 


This can lead to a large performance hit for large system topologies. In fact there is a huge comment block/TODO dedicated to this: https://github.com/mdtraj/mdtraj/blob/main/mdtraj/core/trajectory.py#L424-L431 . We might want to implement the TODO eventually, but that will require some planning + going through all formats. This is the "quick fix" that alleviates the performance hit, by skipping the first load only for these file types.

====

BEFORE:

```
In [1]: import mdtraj

In [2]: a = mdtraj.load('data/traj.h5')
/Users/user/mdtraj/mdtraj/core/trajectory.py:440: UserWarning: top= kwargs ignored since this file parser does not support it
  warnings.warn("top= kwargs ignored since this file parser does not support it")
In [3]: a = mdtraj.load('data/traj.h5', top='data/traj.h5')
/Users/user/mdtraj/mdtraj/core/trajectory.py:440: UserWarning: top= kwargs ignored since this file parser does not support it
  warnings.warn("top= kwargs ignored since this file parser does not support it")
```

AFTER:
```
In [1]: import mdtraj

In [2]: a = mdtraj.load('data/traj.h5')

In [3]: a = mdtraj.load('data/traj.h5', top='data/traj.h5')
/Users/user/mdtraj/mdtraj/core/trajectory.py:444: UserWarning: top= kwargs ignored since this file parser does not support it
  warnings.warn("top= kwargs ignored since this file parser does not support it")
```