### PR TITLE
Preserve chain_id when creating sub-topology

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -90,6 +90,7 @@ def _topology_from_subset(topology, atom_indices):
 
     for chain in topology._chains:
         newChain = newTopology.add_chain()
+        newChain.chain_id = chain.chain_id
         for residue in chain._residues:
             resSeq = getattr(residue, "resSeq", None) or residue.index
             newResidue = None

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -286,7 +286,7 @@ class HDF5TrajectoryFile:
 
         for chain_dict in sorted(topology_dict["chains"], key=operator.itemgetter("index")):
             chain = topology.add_chain()
-            chain.chain_id = chain_dict["chain_id"] if "chain_id" in chain_dict else None
+            chain.chain_id = chain_dict.get("chain_id", None)
             for residue_dict in sorted(chain_dict["residues"], key=operator.itemgetter("index")):
                 try:
                     resSeq = residue_dict["resSeq"]

--- a/mdtraj/formats/hdf5.py
+++ b/mdtraj/formats/hdf5.py
@@ -286,6 +286,7 @@ class HDF5TrajectoryFile:
 
         for chain_dict in sorted(topology_dict["chains"], key=operator.itemgetter("index")):
             chain = topology.add_chain()
+            chain.chain_id = chain_dict["chain_id"] if "chain_id" in chain_dict else None
             for residue_dict in sorted(chain_dict["residues"], key=operator.itemgetter("index")):
                 try:
                     resSeq = residue_dict["resSeq"]
@@ -337,6 +338,7 @@ class HDF5TrajectoryFile:
                 chain_dict = {
                     "residues": [],
                     "index": int(chain.index),
+                    "chain_id": str(chain.chain_id)
                 }
                 for residue in chain.residues:
                     residue_dict = {


### PR DESCRIPTION
When extracting part of a structure into a new trajectory, the original code forgets to copy the `chain_id` field to the new `chain` object, resulting in `None` values.

This one-line fix ensures the `chain_id` is properly transferred when creating a sub-topology.