### PR TITLE
add py3dmol visualization to pi stacking

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,4 +18,5 @@ pandas
 numpydoc
 wheel
 tables
+py3Dmol
 # python==3.11

--- a/examples/pi_stacking.ipynb
+++ b/examples/pi_stacking.ipynb
@@ -8,8 +8,147 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pi Stacking Analysis on PDB 4BFQ \n",
+    "\n",
+    "In this first example, we show pi stacking analysis on the PDB structure [4BFQ](https://www.rcsb.org/structure/4BFQ). 4BFQ has two pi-stacking interactions between a ligand (resSeq 301) and Y186. \n",
+    "\n",
+    "Both aromatic residues on the ligand are placed in such a way that the TYR phenol stacks with them.\n",
+    "\n",
+    "Before we show the MDTraj analysis, we will use [py3dmol](https://3dmol.org/) to visualize the structure.\n",
+    "\n",
+    "In the visualization below, we will highlight the following:\n",
+    "\n",
+    "* In silver: The protein\n",
+    "* In light steel blue: Ligands with name \"083\"\n",
+    "* In green: The tyrosine residue on the protein.\n",
+    "* In magenta: One ring on an 083 ligand we will be analyzing. The atoms are C16, C17, C18, C19, C20, C21. (pi stacks with TYR)\n",
+    "* In cyan: Another ring on an 083 ligand we will be analyzing. The atoms are N4 C9 C15, C16, C21, and C8. (pi stacks with TYR)\n",
+    "* In yellow: The third ring on an 083 ligand we will be analyzing. The atoms are N5, C10, C11, C12, C13, C14. (does not stack with TYR)\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/3dmoljs_load.v0": "<div id=\"3dmolviewer_17464823838708847\"  style=\"position: relative; width: 800px; height: 600px;\">\n        <p id=\"3dmolwarning_17464823838708847\" style=\"background-color:#ffcccc;color:black\">3Dmol.js failed to load for some reason.  Please check your browser console for error messages.<br></p>\n        </div>\n<script>\n\nvar loadScriptAsync = function(uri){\n  return new Promise((resolve, reject) => {\n    //this is to ignore the existence of requirejs amd\n    var savedexports, savedmodule;\n    if (typeof exports !== 'undefined') savedexports = exports;\n    else exports = {}\n    if (typeof module !== 'undefined') savedmodule = module;\n    else module = {}\n\n    var tag = document.createElement('script');\n    tag.src = uri;\n    tag.async = true;\n    tag.onload = () => {\n        exports = savedexports;\n        module = savedmodule;\n        resolve();\n    };\n  var firstScriptTag = document.getElementsByTagName('script')[0];\n  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n});\n};\n\nif(typeof $3Dmolpromise === 'undefined') {\n$3Dmolpromise = null;\n  $3Dmolpromise = loadScriptAsync('https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.4.2/3Dmol-min.js');\n}\n\nvar viewer_17464823838708847 = null;\nvar warn = document.getElementById(\"3dmolwarning_17464823838708847\");\nif(warn) {\n    warn.parentNode.removeChild(warn);\n}\n$3Dmolpromise.then(function() {\nviewer_17464823838708847 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_17464823838708847\"),{backgroundColor:\"white\"});\n$3Dmol.download(\"pdb:4BFQ\", viewer_17464823838708847, {}, function() {\nviewer_17464823838708847.zoomTo();\n\tviewer_17464823838708847.setStyle({\"cartoon\": {\"color\": \"silver\"}});\n\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resi\": \"186\"},{\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}});\n\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\"},{\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.15}});\n\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"C16\", \"C17\", \"C18\", \"C19\", \"C20\", \"C21\"]},{\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}});\n\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"N4\", \"C9\", \"C15\", \"C16\", \"C21\", \"C8\"]},{\"stick\": {\"color\": \"cyan\", \"radius\": 0.2}});\n\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"N5\", \"C10\", \"C11\", \"C12\", \"C13\", \"C14\"]},{\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}});\n\tviewer_17464823838708847.zoomTo({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\"});\n\tviewer_17464823838708847.rotate(90,\"y\");\n\tviewer_17464823838708847.rotate(90,\"x\");\nviewer_17464823838708847.render();\n})\n});\n</script>",
+      "text/html": [
+       "<div id=\"3dmolviewer_17464823838708847\"  style=\"position: relative; width: 800px; height: 600px;\">\n",
+       "        <p id=\"3dmolwarning_17464823838708847\" style=\"background-color:#ffcccc;color:black\">3Dmol.js failed to load for some reason.  Please check your browser console for error messages.<br></p>\n",
+       "        </div>\n",
+       "<script>\n",
+       "\n",
+       "var loadScriptAsync = function(uri){\n",
+       "  return new Promise((resolve, reject) => {\n",
+       "    //this is to ignore the existence of requirejs amd\n",
+       "    var savedexports, savedmodule;\n",
+       "    if (typeof exports !== 'undefined') savedexports = exports;\n",
+       "    else exports = {}\n",
+       "    if (typeof module !== 'undefined') savedmodule = module;\n",
+       "    else module = {}\n",
+       "\n",
+       "    var tag = document.createElement('script');\n",
+       "    tag.src = uri;\n",
+       "    tag.async = true;\n",
+       "    tag.onload = () => {\n",
+       "        exports = savedexports;\n",
+       "        module = savedmodule;\n",
+       "        resolve();\n",
+       "    };\n",
+       "  var firstScriptTag = document.getElementsByTagName('script')[0];\n",
+       "  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n",
+       "});\n",
+       "};\n",
+       "\n",
+       "if(typeof $3Dmolpromise === 'undefined') {\n",
+       "$3Dmolpromise = null;\n",
+       "  $3Dmolpromise = loadScriptAsync('https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.4.2/3Dmol-min.js');\n",
+       "}\n",
+       "\n",
+       "var viewer_17464823838708847 = null;\n",
+       "var warn = document.getElementById(\"3dmolwarning_17464823838708847\");\n",
+       "if(warn) {\n",
+       "    warn.parentNode.removeChild(warn);\n",
+       "}\n",
+       "$3Dmolpromise.then(function() {\n",
+       "viewer_17464823838708847 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_17464823838708847\"),{backgroundColor:\"white\"});\n",
+       "$3Dmol.download(\"pdb:4BFQ\", viewer_17464823838708847, {}, function() {\n",
+       "viewer_17464823838708847.zoomTo();\n",
+       "\tviewer_17464823838708847.setStyle({\"cartoon\": {\"color\": \"silver\"}});\n",
+       "\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resi\": \"186\"},{\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\"},{\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.15}});\n",
+       "\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"C16\", \"C17\", \"C18\", \"C19\", \"C20\", \"C21\"]},{\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"N4\", \"C9\", \"C15\", \"C16\", \"C21\", \"C8\"]},{\"stick\": {\"color\": \"cyan\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823838708847.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\", \"atom\": [\"N5\", \"C10\", \"C11\", \"C12\", \"C13\", \"C14\"]},{\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823838708847.zoomTo({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\"});\n",
+       "\tviewer_17464823838708847.rotate(90,\"y\");\n",
+       "\tviewer_17464823838708847.rotate(90,\"x\");\n",
+       "viewer_17464823838708847.render();\n",
+       "})\n",
+       "});\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import py3Dmol\n",
+    "\n",
+    "# Load the PDB structure from the RCSB PDB database\n",
+    "viewer = py3Dmol.view(query=\"pdb:4BFQ\", width=800, height=600)\n",
+    "\n",
+    "# Style the entire protein as silver cartoon\n",
+    "viewer.setStyle({\"cartoon\": {\"color\": \"silver\"}})\n",
+    "\n",
+    "# Make residue 186 on chain E visible as bright green sticks\n",
+    "viewer.addStyle({\"chain\": \"E\", \"resi\": \"186\"}, \n",
+    "                {\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}}) \n",
+    "\n",
+    "# Make all of residue 083 visible as sticks\n",
+    "viewer.addStyle({\"chain\": \"E\", \"resn\": \"083\"}, \n",
+    "                {\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.15}})\n",
+    "\n",
+    "# First highlight group in magenta (pi-stacking)\n",
+    "viewer.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\",\n",
+    "                 \"atom\": [\"C16\", \"C17\", \"C18\", \"C19\", \"C20\", \"C21\"]}, \n",
+    "                {\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Second highlight group in cyan (pi-stacking)\n",
+    "viewer.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\",\n",
+    "                 \"atom\": [\"N4\", \"C9\", \"C15\", \"C16\", \"C21\", \"C8\"]}, \n",
+    "                {\"stick\": {\"color\": \"cyan\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Third highlight group in yellow (NOT pi-stacking)\n",
+    "viewer.addStyle({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\",\n",
+    "                 \"atom\": [\"N5\", \"C10\", \"C11\", \"C12\", \"C13\", \"C14\"]}, \n",
+    "                {\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Set the zoom level to focus on our selections\n",
+    "viewer.zoomTo({\"chain\": \"E\", \"resn\": \"083\", \"resi\": \"301\"})\n",
+    "\n",
+    "viewer.rotate(90, \"y\")  \n",
+    "viewer.rotate(90, \"x\") \n",
+    "# Show the viewer\n",
+    "viewer.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The rings highlighted in magenta and cyan are expected to stack with the TYR residue, while the ring in yellow is not expected to stack with the TYR residue."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,12 +159,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load up some example data from the PDB. 4BFQ has two pi-stacking interactions between a ligand (resSeq 301) and Y186. Both aromatic residues on the ligand are placed in such a way that the TYR phenol stacks with them.\n"
+    "Next, we load the structure from the PDB using MDTraj."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -52,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -91,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -127,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -163,12 +302,122 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "4BFQ has clear face-to-face pi-stacking interactions. T-stacking (edge-to-face) interactions are also supported in `md.pi_stacking`.\n"
+    "## Analyzing T-Stacking Interactions\n",
+    "\n",
+    "4BFQ has clear face-to-face pi-stacking interactions. T-stacking (edge-to-face) interactions are also supported in `md.pi_stacking`.\n",
+    "\n",
+    "Before showing this analysis, we will visualize the structure again using py3Dmol.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/3dmoljs_load.v0": "<div id=\"3dmolviewer_17464823919618523\"  style=\"position: relative; width: 800px; height: 600px;\">\n        <p id=\"3dmolwarning_17464823919618523\" style=\"background-color:#ffcccc;color:black\">3Dmol.js failed to load for some reason.  Please check your browser console for error messages.<br></p>\n        </div>\n<script>\n\nvar loadScriptAsync = function(uri){\n  return new Promise((resolve, reject) => {\n    //this is to ignore the existence of requirejs amd\n    var savedexports, savedmodule;\n    if (typeof exports !== 'undefined') savedexports = exports;\n    else exports = {}\n    if (typeof module !== 'undefined') savedmodule = module;\n    else module = {}\n\n    var tag = document.createElement('script');\n    tag.src = uri;\n    tag.async = true;\n    tag.onload = () => {\n        exports = savedexports;\n        module = savedmodule;\n        resolve();\n    };\n  var firstScriptTag = document.getElementsByTagName('script')[0];\n  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n});\n};\n\nif(typeof $3Dmolpromise === 'undefined') {\n$3Dmolpromise = null;\n  $3Dmolpromise = loadScriptAsync('https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.4.2/3Dmol-min.js');\n}\n\nvar viewer_17464823919618523 = null;\nvar warn = document.getElementById(\"3dmolwarning_17464823919618523\");\nif(warn) {\n    warn.parentNode.removeChild(warn);\n}\n$3Dmolpromise.then(function() {\nviewer_17464823919618523 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_17464823919618523\"),{backgroundColor:\"white\"});\n$3Dmol.download(\"pdb:6A22\", viewer_17464823919618523, {}, function() {\nviewer_17464823919618523.zoomTo();\n\tviewer_17464823919618523.setStyle({\"cartoon\": {\"color\": \"silver\"}});\n\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\"},{\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.2}});\n\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\", \"atom\": [\"S10\", \"C9\", \"C8\", \"N7\", \"C6\"]},{\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}});\n\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\", \"atom\": [\"C14\", \"C15\", \"C16\", \"C17\", \"C18\", \"C19\"]},{\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}});\n\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"378\"},{\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}});\n\tviewer_17464823919618523.zoomTo({\"chain\": \"C\", \"resi\": \"9000\"});\n\tviewer_17464823919618523.rotate(95,\"y\");\n\tviewer_17464823919618523.rotate(150,\"x\");\nviewer_17464823919618523.render();\n})\n});\n</script>",
+      "text/html": [
+       "<div id=\"3dmolviewer_17464823919618523\"  style=\"position: relative; width: 800px; height: 600px;\">\n",
+       "        <p id=\"3dmolwarning_17464823919618523\" style=\"background-color:#ffcccc;color:black\">3Dmol.js failed to load for some reason.  Please check your browser console for error messages.<br></p>\n",
+       "        </div>\n",
+       "<script>\n",
+       "\n",
+       "var loadScriptAsync = function(uri){\n",
+       "  return new Promise((resolve, reject) => {\n",
+       "    //this is to ignore the existence of requirejs amd\n",
+       "    var savedexports, savedmodule;\n",
+       "    if (typeof exports !== 'undefined') savedexports = exports;\n",
+       "    else exports = {}\n",
+       "    if (typeof module !== 'undefined') savedmodule = module;\n",
+       "    else module = {}\n",
+       "\n",
+       "    var tag = document.createElement('script');\n",
+       "    tag.src = uri;\n",
+       "    tag.async = true;\n",
+       "    tag.onload = () => {\n",
+       "        exports = savedexports;\n",
+       "        module = savedmodule;\n",
+       "        resolve();\n",
+       "    };\n",
+       "  var firstScriptTag = document.getElementsByTagName('script')[0];\n",
+       "  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n",
+       "});\n",
+       "};\n",
+       "\n",
+       "if(typeof $3Dmolpromise === 'undefined') {\n",
+       "$3Dmolpromise = null;\n",
+       "  $3Dmolpromise = loadScriptAsync('https://cdnjs.cloudflare.com/ajax/libs/3Dmol/2.4.2/3Dmol-min.js');\n",
+       "}\n",
+       "\n",
+       "var viewer_17464823919618523 = null;\n",
+       "var warn = document.getElementById(\"3dmolwarning_17464823919618523\");\n",
+       "if(warn) {\n",
+       "    warn.parentNode.removeChild(warn);\n",
+       "}\n",
+       "$3Dmolpromise.then(function() {\n",
+       "viewer_17464823919618523 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_17464823919618523\"),{backgroundColor:\"white\"});\n",
+       "$3Dmol.download(\"pdb:6A22\", viewer_17464823919618523, {}, function() {\n",
+       "viewer_17464823919618523.zoomTo();\n",
+       "\tviewer_17464823919618523.setStyle({\"cartoon\": {\"color\": \"silver\"}});\n",
+       "\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\"},{\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\", \"atom\": [\"S10\", \"C9\", \"C8\", \"N7\", \"C6\"]},{\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"9000\", \"atom\": [\"C14\", \"C15\", \"C16\", \"C17\", \"C18\", \"C19\"]},{\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823919618523.addStyle({\"chain\": \"C\", \"resi\": \"378\"},{\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}});\n",
+       "\tviewer_17464823919618523.zoomTo({\"chain\": \"C\", \"resi\": \"9000\"});\n",
+       "\tviewer_17464823919618523.rotate(95,\"y\");\n",
+       "\tviewer_17464823919618523.rotate(150,\"x\");\n",
+       "viewer_17464823919618523.render();\n",
+       "})\n",
+       "});\n",
+       "</script>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import py3Dmol\n",
+    "\n",
+    "# Load the PDB structure from the RCSB PDB database\n",
+    "viewer = py3Dmol.view(query=\"pdb:6A22\", width=800, height=600)\n",
+    "\n",
+    "# Style the entire protein as silver cartoon\n",
+    "viewer.setStyle({\"cartoon\": {\"color\": \"silver\"}})\n",
+    "\n",
+    "# Make the whole ligand visible as sticks\n",
+    "viewer.addStyle({\"chain\": \"C\", \"resi\": \"9000\"}, \n",
+    "                {\"stick\": {\"color\": \"lightsteelblue\", \"radius\": 0.2}})\n",
+    "\n",
+    "# First ligand group (Ring 1) in magenta (t-stacking, edge-to-face with PHE)\n",
+    "viewer.addStyle({\"chain\": \"C\", \"resi\": \"9000\",\n",
+    "                 \"atom\": [\"S10\", \"C9\", \"C8\", \"N7\", \"C6\"]}, \n",
+    "                {\"stick\": {\"color\": \"magenta\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Second ligand group (Ring 2) in yellow (NOT pi-stacking)\n",
+    "viewer.addStyle({\"chain\": \"C\", \"resi\": \"9000\",\n",
+    "                 \"atom\": [\"C14\", \"C15\", \"C16\", \"C17\", \"C18\", \"C19\"]}, \n",
+    "                {\"stick\": {\"color\": \"yellow\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Highlight the PHE residue 378 in green\n",
+    "viewer.addStyle({\"chain\": \"C\", \"resi\": \"378\"}, \n",
+    "                {\"stick\": {\"color\": \"#00FF00\", \"radius\": 0.2}})\n",
+    "\n",
+    "# Zoom specifically to the green PHE residue\n",
+    "viewer.zoomTo({\"chain\": \"C\", \"resi\": \"9000\"})\n",
+    "\n",
+    "# Apply rotation after zooming\n",
+    "viewer.rotate(95, \"y\")\n",
+    "viewer.rotate(150, \"x\")\n",
+    "\n",
+    "# Show the viewer\n",
+    "viewer.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -200,8 +449,8 @@
    ],
    "source": [
     "lig_aromatic_atms_to_test = [\n",
-    "    (\"S10\", \"C9\", \"C8\", \"N7\", \"C6\"),  # t-stacking, edge-to-face with PHR\n",
-    "    (\"C14\", \"C15\", \"C16\", \"C17\", \"C18\", \"C19\"),  # NOT pi-stacking\n",
+    "    (\"S10\", \"C9\", \"C8\", \"N7\", \"C6\"),  # t-stacking, edge-to-face with PHR, shown in magenta in the visualization\n",
+    "    (\"C14\", \"C15\", \"C16\", \"C17\", \"C18\", \"C19\"),  # NOT pi-stacking shown in yellow in the visualization\n",
     "]\n",
     "lig_grps = []\n",
     "for lig_grp in lig_aromatic_atms_to_test:\n",
@@ -231,7 +480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +507,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "mdtraj-issue",
    "language": "python",
    "name": "python3"
   },
@@ -272,7 +521,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
For @rdirisio or anyone with an interest in docs. As I was reviewing the pi stacking code, I found it helpful to visualize the structures. I used VMD, but I've translated it to py3dmol.  There are also some light edits to the notebook structure. I realize this would mean adding another documentation dependency, so am looking to gather thoughts.

Screenshots from locally built documentation, it's also interactive!

![image](https://github.com/user-attachments/assets/c363327c-ef8a-4c7c-be1f-99c8d74a9b92)

![image](https://github.com/user-attachments/assets/be3ec91a-f402-4239-ac91-bbbe40dbfe17)

