### PR TITLE
bugfix: delete_atom_by_index updates bond list

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -869,7 +869,10 @@ class Topology:
         return atom
 
     def delete_atom_by_index(self, index: int) -> None:
-        """Delete an Atom from the topology.
+        """Delete an Atom from the topology. 
+        Atom is removed and all subsequent atoms are reindexed.
+        All bonds involving this atom are likewise removed. This may result
+        in disconnected groups of atoms. 
 
         Parameters
         ----------
@@ -884,6 +887,9 @@ class Topology:
             )
         for i in range(index + 1, len(self._atoms)):
             self._atoms[i].index -= 1
+        
+        self._bonds = [bond for bond in self._bonds if a not in bond]
+        
         a.residue._atoms.remove(a)
         self._atoms.remove(a)
         self._numAtoms -= 1

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -427,3 +427,28 @@ def test_topology_join_keep_resSeq(get_fn):
 
     eq(out_resSeq_keepId_True, expected_resSeq_keepId_True)
     eq(out_resSeq_keepId_False, expected_resSeq_keepId_False)
+
+def test_delete_atom_by_index(get_fn):
+    """
+REMARK *                                                                              
+REMARK   DATE:     8/ 5/ 9     14:44:19      CREATED BY USER: mjw                     
+ATOM      1  N   ALA     1       0.024  -0.103  -0.101  1.00  0.00      AAL 
+ATOM      2  HT1 ALA     1       0.027  -1.132  -0.239  1.00  0.00      AAL 
+ATOM      3  HT2 ALA     1      -0.805   0.163   0.471  1.00  0.00      AAL 
+ATOM      4  HT3 ALA     1      -0.059   0.384  -1.019  1.00  0.00      AAL 
+ATOM      5  CA  ALA     1       1.247   0.375   0.636  1.00  0.00      AAL 
+...
+    """
+    index=0
+    top = md.load(get_fn("ala_ala_ala.pdb")).topology
+    n_bonds_original = top.n_bonds
+    n_atoms_original = top.n_atoms
+    atom_to_remove = top._atoms[index]
+    top.delete_atom(index)
+    assert top.n_atoms == n_atoms_original - 1
+    assert top.n_bonds == n_bonds_original - 4
+    assert all([atom_to_remove not in bond for bond in top.bonds])
+    assert eq(list(range(top.n_atoms)), [atom.index for atom in top.atoms]) 
+
+
+    

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -444,7 +444,7 @@ ATOM      5  CA  ALA     1       1.247   0.375   0.636  1.00  0.00      AAL
     n_bonds_original = top.n_bonds
     n_atoms_original = top.n_atoms
     atom_to_remove = top._atoms[index]
-    top.delete_atom(index)
+    top.delete_atom_by_index(index)
     assert top.n_atoms == n_atoms_original - 1
     assert top.n_bonds == n_bonds_original - 4
     assert all([atom_to_remove not in bond for bond in top.bonds])


### PR DESCRIPTION
This addresses https://github.com/mdtraj/mdtraj/issues/1900

When `delete_atom_by_index` is called the bond list is now updated so that bonds involving the atom are removed.  

I've added a  test involving Ala3 . 

Tests for topology: 

```bash
tests/test_topology.py::test_topology_openmm SKIPPED (needs OpenMM)                                     [  3%]
tests/test_topology.py::test_topology_openmm_preserve_chain_id_when_specified SKIPPED (needs OpenMM)    [  6%]
tests/test_topology.py::test_topology_openmm_roundtrip_chain_id SKIPPED (needs OpenMM)                  [  9%]
tests/test_topology.py::test_topology_openmm_preserve_chain_id_even_when_empty SKIPPED (needs OpenMM)   [ 12%]
tests/test_topology.py::test_topology_openmm_boxes SKIPPED (needs OpenMM)                               [ 15%]
tests/test_topology.py::test_topology_openmm_formal_charges SKIPPED (needs OpenMM)                      [ 18%]
tests/test_topology.py::test_topology_dataframe_formal_charges PASSED                                   [ 21%]
tests/test_topology.py::test_topology_pandas PASSED                                                     [ 24%]
tests/test_topology.py::test_topology_pandas_TIP4PEW PASSED                                             [ 27%]
tests/test_topology.py::test_topology_pandas_2residues_same_resSeq PASSED                               [ 30%]
tests/test_topology.py::test_topology_numbers PASSED                                                    [ 33%]
tests/test_topology.py::test_topology_unique_elements_bpti PASSED                                       [ 36%]
tests/test_topology.py::test_chain PASSED                                                               [ 39%]
tests/test_topology.py::test_residue PASSED                                                             [ 42%]
tests/test_topology.py::test_segment_id PASSED                                                          [ 45%]
tests/test_topology.py::test_nonconsective_resSeq PASSED                                                [ 48%]
tests/test_topology.py::test_pickle PASSED                                                              [ 51%]
tests/test_topology.py::test_atoms_by_name PASSED                                                       [ 54%]
tests/test_topology.py::test_select_atom_indices PASSED                                                 [ 57%]
tests/test_topology.py::test_top_dataframe_openmm_roundtrip SKIPPED (needs OpenMM)                      [ 60%]
tests/test_topology.py::test_n_bonds PASSED                                                             [ 63%]
tests/test_topology.py::test_load_unknown_topology PASSED                                               [ 66%]
tests/test_topology.py::test_unique_pairs PASSED                                                        [ 69%]
tests/test_topology.py::test_select_pairs PASSED                                                        [ 72%]
tests/test_topology.py::test_to_fasta PASSED                                                            [ 75%]
tests/test_topology.py::test_subset PASSED                                                              [ 78%]
tests/test_topology.py::test_subset_re_index_residues PASSED                                            [ 81%]
tests/test_topology.py::test_molecules PASSED                                                           [ 84%]
tests/test_topology.py::test_copy_and_hash PASSED                                                       [ 87%]
tests/test_topology.py::test_topology_sliced_residue_indices PASSED                                     [ 90%]
tests/test_topology.py::test_topology_join PASSED                                                       [ 93%]
tests/test_topology.py::test_topology_join_keep_resSeq PASSED                                           [ 96%]
tests/test_topology.py::test_delete_atom_by_index PASSED                                                [100%]
```