### PR TITLE
feat: deprecate `delete_atom_by_index` in favour of `atom_slice`

### DIFF
--- a/mdtraj/core/topology.py
+++ b/mdtraj/core/topology.py
@@ -62,10 +62,8 @@ from mdtraj.core.residue_names import (
     _WATER_RESIDUES,
 )
 from mdtraj.core.selection import parse_selection
-from mdtraj.utils import ensure_type, ilen, import_
+from mdtraj.utils import deprecated, ensure_type, ilen, import_
 from mdtraj.utils.singleton import Singleton
-from mdtraj.utils import deprecated
-
 
 if TYPE_CHECKING:
     import networkx as nx
@@ -857,7 +855,7 @@ class Topology:
         else:
             residue._atoms.insert(rindex, atom)
         return atom
-    
+
     @deprecated("delete_atom_by_index was replaced Trajectory.atom_slice with retain=False.")
     def delete_atom_by_index(self, index: int) -> None:
         """Delete an Atom from the topology.

--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -2059,7 +2059,7 @@ class Trajectory:
             # So we need to get the indices of all atoms not in atom_indices
             all_indices = np.arange(self.n_atoms)
             atom_indices = np.setdiff1d(all_indices, atom_indices)
-    
+
         xyz = np.array(self.xyz[:, sorted(atom_indices)], order="C")
         topology = None
         if self._topology is not None:

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -457,7 +457,5 @@ def test_delete_atom_by_index(get_fn):
 
 def test_delete_atom_by_index_deprecated(get_fn):
     top = md.load(get_fn("ala_ala_ala.pdb")).topology
-    with pytest.deprecated_call(): 
+    with pytest.deprecated_call():
         top.delete_atom_by_index(0)
-
-

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -954,37 +954,41 @@ def test_atom_slicing(get_fn):
     eq(t1.xyz, t2.xyz)
     eq(t1.time, t2.time)
 
+
 def test_atom_slicing_retain_inplace(get_fn):
     t = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.gro"))
     t.atom_slice([0], inplace=True)
-    assert t.n_atoms==1
-    assert t.top.n_atoms==1
+    assert t.n_atoms == 1
+    assert t.top.n_atoms == 1
 
 
 def test_atom_slicing_retain_not_inplace(get_fn):
     t = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.gro"))
     n_atoms = t.n_atoms
     t1 = t.atom_slice([0], inplace=False)
-    assert t.n_atoms==n_atoms
-    assert t.top.n_atoms==n_atoms
-    assert t1.n_atoms==1
-    assert t1.top.n_atoms==1
+    assert t.n_atoms == n_atoms
+    assert t.top.n_atoms == n_atoms
+    assert t1.n_atoms == 1
+    assert t1.top.n_atoms == 1
+
 
 def test_atom_slicing_not_retain_inplace(get_fn):
     t = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.gro"))
     n_atoms = t.n_atoms
     t.atom_slice([0], retain=False, inplace=True)
-    assert t.n_atoms==n_atoms-1
-    assert t.top.n_atoms==n_atoms-1
+    assert t.n_atoms == n_atoms - 1
+    assert t.top.n_atoms == n_atoms - 1
+
 
 def test_atom_slicing_not_retain_not_inplace(get_fn):
     t = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.gro"))
     n_atoms = t.n_atoms
     t1 = t.atom_slice([0], retain=False, inplace=False)
-    assert t.n_atoms==n_atoms
-    assert t.top.n_atoms==n_atoms
-    assert t1.n_atoms==n_atoms-1
-    assert t1.top.n_atoms==n_atoms-1
+    assert t.n_atoms == n_atoms
+    assert t.top.n_atoms == n_atoms
+    assert t1.n_atoms == n_atoms - 1
+    assert t1.top.n_atoms == n_atoms - 1
+
 
 def test_load_with_frame(get_fn):
     t1 = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.pdb"), frame=3)


### PR DESCRIPTION
This address https://github.com/mdtraj/mdtraj/issues/2025.  I realise the discussion isn't really finished but my fix was relatively simple so I went ahead and did it.  I can make adjustments if necessary. 

1. `Topology.delete_atom_by_index` is now deprecated. 
2. `Trajectory.atom_slice` now accepts a flag `retain=True` which is the default behaviour. 
3. with `retain=False` it mimics the behaviour of `delete_atom_by_index` with the exception that you can supply multiple indices. 

Lemme know what you think! 

FYI - I used AI to do this (Sonnet), although just as an experiment - I've checked, adjusted and agree with everything. 