### PR TITLE
Dropping Python 3.10

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,6 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"

--- a/docs/new_to_python.rst
+++ b/docs/new_to_python.rst
@@ -32,7 +32,7 @@ blocks you need for numerical and scientific computing, and with a great
 package manager, ``conda``, for installing additional packages.
 
 .. tip:: `Download <http://continuum.io/downloads>`_ Anaconda scientific
-         python. We test against python 3.10, 3.11, and 3.12
+         python. We test against python 3.11, 3.12, and 3.13
 
 
 Installing MDTraj

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ metadata = dict(
     url="http://mdtraj.org",
     download_url="https://github.com/rmcgibbo/mdtraj/releases/latest",
     platforms=["Linux", "Mac OS-X", "Unix", "Windows"],
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     classifiers=CLASSIFIERS.splitlines(),
     packages=find_packages(),
     cmdclass={**versioneer.get_cmdclass(), "build_ext": build_ext},


### PR DESCRIPTION
resolves #2027

Dropping support for python 3.10, as discussed.