### PR TITLE
limit warnings in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ filterwarnings = [
     "ignore:.*top= kwargs ignored since this file parser does not support it.*:UserWarning",
     "ignore:.*object name is a Python keyword.*:tables.NaturalNameWarning",
     "ignore:.*Casting *:mdtraj.utils.validation.TypeCastPerformanceWarning",
+    "ignore:.*Unlikely unit cell *:UserWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ filterwarnings = [
     "ignore:.*The 'netCDF4' Python package.*:UserWarning",
     "ignore:.*top= kwargs ignored since this file parser does not support it.*:UserWarning",
     "ignore:.*object name is a Python keyword.*:tables.NaturalNameWarning",
-    "ignore:.*Casting times.*:mdtraj.utils.validation.TypeCastPerformanceWarning",
+    "ignore:.*Casting *:mdtraj.utils.validation.TypeCastPerformanceWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -24,6 +24,7 @@
 import itertools
 
 import numpy as np
+import pytest
 
 import mdtraj as md
 from mdtraj.testing import eq
@@ -41,11 +42,12 @@ def test_contact_0(get_fn):
         scheme="closest-heavy",
     )
     sidechain, sidechain_pairs = md.compute_contacts(pdb, contacts, scheme="sidechain")
-    sidechain_heavy, sidechain_heavy_pairs = md.compute_contacts(
-        pdb,
-        contacts,
-        scheme="sidechain-heavy",
-    )
+    with pytest.warns(UserWarning, match="selected topology includes at least one glycine"):
+        sidechain_heavy, sidechain_heavy_pairs = md.compute_contacts(
+            pdb,
+            contacts,
+            scheme="sidechain-heavy",
+        )
 
     ref_ca = np.loadtxt(get_fn("cc_ca.dat"))
     ref_closest = np.loadtxt(get_fn("cc_closest.dat"))
@@ -122,8 +124,9 @@ def test_contact_4(get_fn):
         get_fn("1am7_protein.pdb"),
     )  # protonated and including at least one glycine residue (which has no heavy atoms in its sidechain)
 
-    md.compute_contacts(
-        pdb,
-        contacts="all",
-        scheme="sidechain-heavy",
-    )  # test passes if this doesn't raise an exception
+    with pytest.warns(UserWarning, match="selected topology includes at least one glycine"):
+        md.compute_contacts(
+            pdb,
+            contacts="all",
+            scheme="sidechain-heavy",
+        )  # test passes if this doesn't raise an exception

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -108,15 +108,16 @@ def test_contact_2(get_fn):
 def test_contact_3(get_fn):
     pdb = md.load(get_fn("bpti.pdb"))
     beta = 20
-    dists, pairs = md.compute_contacts(pdb, soft_min=True, soft_min_beta=beta)
+    with np.errstate(divide="ignore", over="ignore"):
+        dists, pairs = md.compute_contacts(pdb, soft_min=True, soft_min_beta=beta)
+        maps = md.geometry.squareform(dists, pairs)
 
-    maps = md.geometry.squareform(dists, pairs)
-    for i, (r0, r1) in enumerate(pairs):
-        for t in range(pdb.n_frames):
-            assert np.allclose(
-                beta / np.log(np.sum(np.exp(beta / maps[t, r0, r1]))),
-                dists[t, i],
-            )
+        for i, (r0, r1) in enumerate(pairs):
+            for t in range(pdb.n_frames):
+                assert np.allclose(
+                    beta / np.log(np.sum(np.exp(beta / maps[t, r0, r1]))),
+                    dists[t, i],
+                )
 
 
 def test_contact_4(get_fn):

--- a/tests/test_drid.py
+++ b/tests/test_drid.py
@@ -59,7 +59,9 @@ def test_drid_2():
     got = compute_drid(t).reshape(n_frames, n_atoms, 3)
 
     for i in range(n_frames):
-        recip = 1 / squareform(pdist(t.xyz[i]))
+        with np.errstate(divide="ignore"):
+            # For catching division by zero errors
+            recip = 1 / squareform(pdist(t.xyz[i]))
         recip[np.diag_indices(n=recip.shape[0])] = np.nan
         recip[bonds[:, 0], bonds[:, 1]] = np.nan
         recip[bonds[:, 1], bonds[:, 0]] = np.nan

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -140,10 +140,10 @@ def test_dihedral_indices(get_fn):
     phi0_ind = np.array([3, 12, 13, 14]) - 1  # Taken from PDB, so subtract 1
     psi0_ind = np.array([1, 2, 3, 12]) - 1  # Taken from PDB, so subtract 1
 
-    ind = mdtraj.geometry.dihedral.indices_phi(traj)
+    ind = mdtraj.geometry.dihedral.indices_phi(traj.topology)
     eq(ind[0], phi0_ind)
 
-    ind = mdtraj.geometry.dihedral.indices_psi(traj)
+    ind = mdtraj.geometry.dihedral.indices_psi(traj.topology)
     eq(ind[0], psi0_ind)
 
 

--- a/tests/test_gro.py
+++ b/tests/test_gro.py
@@ -24,6 +24,8 @@
 import os
 import tempfile
 
+import pytest
+
 import mdtraj as md
 from mdtraj.formats import GroTrajectoryFile
 from mdtraj.testing import eq
@@ -108,7 +110,8 @@ def test_load(get_fn):
         eq(t.unitcell_vectors, tref.unitcell_vectors)
 
     # if there are 2 residues with same renum but different resname
-    t = md.load(get_fn("two_residues_same_resnum.gro"))
+    with pytest.warns(UserWarning, match="two consecutive residues with same number"):
+        t = md.load(get_fn("two_residues_same_resnum.gro"))
     eq(t.n_residues, 2)
 
 

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -467,7 +467,8 @@ def test_overflow_indexing(get_fn):
 
 
 def test_blank_indexing(get_fn):
-    traj = load_pdb(get_fn("blank_indexing.pdb"))  # this should just not fail
+    with pytest.warns(UserWarning):
+        traj = load_pdb(get_fn("blank_indexing.pdb"))  # this should just not fail
 
     assert traj.n_atoms == 8
     assert traj.n_residues == 6

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -172,7 +172,8 @@ def test_topology_pandas_TIP4PEW(get_fn):
 
 
 def test_topology_pandas_2residues_same_resSeq(get_fn):
-    topology = md.load(get_fn("two_residues_same_resnum.gro")).topology
+    with pytest.warns(UserWarning, match="two consecutive residues with same number"):
+        topology = md.load(get_fn("two_residues_same_resnum.gro")).topology
     atoms, bonds = topology.to_dataframe()
 
     topology2 = md.Topology.from_dataframe(atoms, bonds)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -346,6 +346,7 @@ def test_center_aind(get_fn):
     eq(mu0, mu2)
 
 
+@pytest.mark.filterwarnings("ignore:atom_indices are not monotonically")
 def test_float_atom_indices_exception(ref_traj, get_fn, monkeypatch):
     def test_base(ref_traj, get_fn):
         # Is an informative error message given when you supply floats for atom_indices?
@@ -947,6 +948,7 @@ def test_load_with_atom_indices(get_fn):
     eq(t1.time, t2.time)
 
 
+@pytest.mark.filterwarnings("ignore:atom_indices are not monotonically")
 def test_atom_slicing(get_fn):
     t = md.load(get_fn("frame0.xtc"), top=get_fn("frame0.gro"))
     t1 = t.atom_slice([0, 1])


### PR DESCRIPTION
This removes the following warnings from tests. Part of a de-cluttering process.


These are hidden:
```
/Users/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/core/topology.py:97: UserWarning: atom_indices are not monotonically increasing
    warnings.warn("atom_indices are not monotonically increasing")
```

```
tests/test_utils.py::test_ensure_type_11
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/utils/validation.py:123: TypeCastPerformanceWarning: Casting  dtype=int64 to <class 'numpy.float32'> 
    warnings.warn(

```

```
tests/test_dssp.py::test_1[1vii.pdb]
tests/test_gro.py::test_read_write
tests/test_gro.py::test_read_write_precision
tests/test_gro.py::test_load
tests/test_shape.py::test_principal_moments
tests/test_shape.py::test_asphericity
tests/test_shape.py::test_shape_metrics
tests/test_pdb.py::test_1vii_url_and_gz
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/formats/pdb/pdbfile.py:208: UserWarning: Unlikely unit cell vectors detected in PDB file likely resulting from a dummy CRYST1 record. Discarding unit cell vectors.
    warnings.warn(
```
-----
This test is modified so it doesn't throw this anymore.
```
 tests/test_geometry.py::test_dihedral_indices
tests/test_geometry.py::test_dihedral_indices
  /Users/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/geometry/dihedral.py:237: DeprecationWarning: Passing a Trajectory object to _atom_sequence isdeprecated. Please pass a Topology object
    warnings.warn(
```

----
Theses warnings are captured and the test will fail if the warning(s) was/were not raised. It's part of what the test is testing :)
```
tests/test_pdb.py::test_blank_indexing
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/formats/pdb/pdbstructure.py:204: UserWarning: Need to guess atom number       starting from atom 100000.
    warnings.warn(

tests/test_pdb.py::test_blank_indexing
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/formats/pdb/pdbstructure.py:273: UserWarning: Need to guess residue number string      starting from residue10000, atom 100000.
    warnings.warn(
```


```
tests/test_contact.py::test_contact_0
tests/test_contact.py::test_contact_4
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/geometry/contact.py:220: UserWarning: selected topology includes at least one glycine residue, which has no heavy atoms in its sidechain. The distances involving glycine residues will be computed using the sidechain hydrogen instead.
    warnings.warn(

```

```
 tests/test_gro.py::test_load
tests/test_topology.py::test_topology_pandas_2residues_same_resSeq
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/formats/gro.py:364: UserWarning: WARNING: two consecutive residues with same number (GST, HST)
    warnings.warn(

```


----
These tests are expected to generate NaN/divide by zero errors and we're hiding them.

```
tests/test_contact.py::test_contact_3
  /home/runner/micromamba/envs/mdtraj-test/lib/python3.13/site-packages/mdtraj/geometry/contact.py:271: RuntimeWarning: overflow encountered in exp
    np.exp(

tests/test_contact.py::test_contact_3
  /home/runner/work/mdtraj/mdtraj/tests/test_contact.py:117: RuntimeWarning: divide by zero encountered in scalar divide
    beta / np.log(np.sum(np.exp(beta / maps[t, r0, r1]))),
```

```
tests/test_drid.py::test_drid_2
  /home/runner/work/mdtraj/mdtraj/tests/test_drid.py:62: RuntimeWarning: divide by zero encountered in divide
    recip = 1 / squareform(pdist(t.xyz[i]))

```