### PR TITLE
speedup some cython functions by enforcing nogil for exceptions (add return code)

### DIFF
--- a/mdtraj/geometry/src/image_molecules.pxi
+++ b/mdtraj/geometry/src/image_molecules.pxi
@@ -12,7 +12,7 @@ cdef extern from "math_patch.h" nogil:
     float roundf(float x)
     float floorf(float x)
 
-cdef void make_whole(float[:,::1] frame_positions,
+cdef int make_whole(float[:,::1] frame_positions,
                 float[:,::1] frame_unitcell_vectors,
                 int32_t[:,:] sorted_bonds) nogil:
     # Fix each molecule to ensure the periodic boundary conditions are not
@@ -33,7 +33,7 @@ cdef void make_whole(float[:,::1] frame_positions,
             offset[k] += frame_unitcell_vectors[0, k]*roundf((delta[0]-offset[0])/frame_unitcell_vectors[0,0])
             frame_positions[atom2, k] = frame_positions[atom2, k] - offset[k]
 
-cdef void anchor_dists(float[:,::1] frame_positions,
+cdef int anchor_dists(float[:,::1] frame_positions,
                   float[:,::1] frame_unitcell_vectors,
                   int[:] anchor_molecule_indices,
                   int[:] anchor_molecule_offsets,
@@ -65,7 +65,7 @@ cdef void anchor_dists(float[:,::1] frame_positions,
             anchor_nearest_atoms[mol2, mol1, 0] = ca1
             anchor_nearest_atoms[mol2, mol1, 1] = ca2
 
-cdef void wrap_mols(float[:,::1] frame_positions,
+cdef int wrap_mols(float[:,::1] frame_positions,
                     float[:,::1] frame_unitcell_vectors,
                     float[:] center,
                     int[:] other_molecule_indices,

--- a/mdtraj/geometry/src/image_molecules.pxi
+++ b/mdtraj/geometry/src/image_molecules.pxi
@@ -12,9 +12,9 @@ cdef extern from "math_patch.h" nogil:
     float roundf(float x)
     float floorf(float x)
 
-cdef void make_whole(float[:,::1] frame_positions,
-                float[:,::1] frame_unitcell_vectors,
-                int32_t[:,:] sorted_bonds) noexcept nogil:
+cdef int make_whole(float[:,::1] frame_positions,
+                    float[:,::1] frame_unitcell_vectors,
+                    int32_t[:,:] sorted_bonds) except -1 nogil:
     # Fix each molecule to ensure the periodic boundary conditions are not
     # splitting it into pieces.
     cdef int atom1, atom2, j, k
@@ -33,13 +33,13 @@ cdef void make_whole(float[:,::1] frame_positions,
             offset[k] += frame_unitcell_vectors[0, k]*roundf((delta[0]-offset[0])/frame_unitcell_vectors[0,0])
             frame_positions[atom2, k] = frame_positions[atom2, k] - offset[k]
 
-cdef void anchor_dists(float[:,::1] frame_positions,
-                  float[:,::1] frame_unitcell_vectors,
-                  int[:] anchor_molecule_indices,
-                  int[:] anchor_molecule_offsets,
-                  float[:,:] anchor_dist,
-                  int[:,:,:] anchor_nearest_atoms,
-                  int num_anchors) noexcept nogil:
+cdef int anchor_dists(float[:,::1] frame_positions,
+                      float[:,::1] frame_unitcell_vectors,
+                      int[:] anchor_molecule_indices,
+                      int[:] anchor_molecule_offsets,
+                      float[:,:] anchor_dist,
+                      int[:,:,:] anchor_nearest_atoms,
+                      int num_anchors) except -1 nogil:
     cdef int ca1, ca2, mol1, mol2, i1, i2, j1, j2
     cdef float cdist
     cdef int[:] atoms1, atoms2
@@ -65,11 +65,11 @@ cdef void anchor_dists(float[:,::1] frame_positions,
             anchor_nearest_atoms[mol2, mol1, 0] = ca1
             anchor_nearest_atoms[mol2, mol1, 1] = ca2
 
-cdef void wrap_mols(float[:,::1] frame_positions,
-                    float[:,::1] frame_unitcell_vectors,
-                    float[:] center,
-                    int[:] other_molecule_indices,
-                    int[:] other_molecule_offsets) noexcept nogil:
+cdef int wrap_mols(float[:,::1] frame_positions,
+                   float[:,::1] frame_unitcell_vectors,
+                   float[:] center,
+                   int[:] other_molecule_indices,
+                   int[:] other_molecule_offsets) except -1 nogil:
     # Loop over all molecules, apply the correct offset (so that anchor
     # molecules will end up centered in the periodic box), and then wrap
     # the molecule into the box.

--- a/mdtraj/geometry/src/image_molecules.pxi
+++ b/mdtraj/geometry/src/image_molecules.pxi
@@ -33,6 +33,8 @@ cdef int make_whole(float[:,::1] frame_positions,
             offset[k] += frame_unitcell_vectors[0, k]*roundf((delta[0]-offset[0])/frame_unitcell_vectors[0,0])
             frame_positions[atom2, k] = frame_positions[atom2, k] - offset[k]
 
+    return 0
+
 cdef int anchor_dists(float[:,::1] frame_positions,
                       float[:,::1] frame_unitcell_vectors,
                       int[:] anchor_molecule_indices,
@@ -64,6 +66,8 @@ cdef int anchor_dists(float[:,::1] frame_positions,
             anchor_nearest_atoms[mol1, mol2, 1] = ca2
             anchor_nearest_atoms[mol2, mol1, 0] = ca1
             anchor_nearest_atoms[mol2, mol1, 1] = ca2
+
+    return 0
 
 cdef int wrap_mols(float[:,::1] frame_positions,
                    float[:,::1] frame_unitcell_vectors,
@@ -113,6 +117,7 @@ cdef int wrap_mols(float[:,::1] frame_positions,
             for k in range(3):
                 frame_positions[mol[j], k] += mol_offset[k]-mol_center[k]
 
+    return 0
 
 cdef void image_frame(frame_positions,
                  frame_unitcell_vectors,

--- a/mdtraj/geometry/src/image_molecules.pxi
+++ b/mdtraj/geometry/src/image_molecules.pxi
@@ -12,9 +12,9 @@ cdef extern from "math_patch.h" nogil:
     float roundf(float x)
     float floorf(float x)
 
-cdef int make_whole(float[:,::1] frame_positions,
+cdef void make_whole(float[:,::1] frame_positions,
                 float[:,::1] frame_unitcell_vectors,
-                int32_t[:,:] sorted_bonds) nogil:
+                int32_t[:,:] sorted_bonds) noexcept nogil:
     # Fix each molecule to ensure the periodic boundary conditions are not
     # splitting it into pieces.
     cdef int atom1, atom2, j, k
@@ -33,13 +33,13 @@ cdef int make_whole(float[:,::1] frame_positions,
             offset[k] += frame_unitcell_vectors[0, k]*roundf((delta[0]-offset[0])/frame_unitcell_vectors[0,0])
             frame_positions[atom2, k] = frame_positions[atom2, k] - offset[k]
 
-cdef int anchor_dists(float[:,::1] frame_positions,
+cdef void anchor_dists(float[:,::1] frame_positions,
                   float[:,::1] frame_unitcell_vectors,
                   int[:] anchor_molecule_indices,
                   int[:] anchor_molecule_offsets,
                   float[:,:] anchor_dist,
                   int[:,:,:] anchor_nearest_atoms,
-                  int num_anchors) nogil:
+                  int num_anchors) noexcept nogil:
     cdef int ca1, ca2, mol1, mol2, i1, i2, j1, j2
     cdef float cdist
     cdef int[:] atoms1, atoms2
@@ -65,11 +65,11 @@ cdef int anchor_dists(float[:,::1] frame_positions,
             anchor_nearest_atoms[mol2, mol1, 0] = ca1
             anchor_nearest_atoms[mol2, mol1, 1] = ca2
 
-cdef int wrap_mols(float[:,::1] frame_positions,
+cdef void wrap_mols(float[:,::1] frame_positions,
                     float[:,::1] frame_unitcell_vectors,
                     float[:] center,
                     int[:] other_molecule_indices,
-                    int[:] other_molecule_offsets) nogil:
+                    int[:] other_molecule_offsets) noexcept nogil:
     # Loop over all molecules, apply the correct offset (so that anchor
     # molecules will end up centered in the periodic box), and then wrap
     # the molecule into the box.

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -910,7 +910,6 @@ def test_make_whole(get_fn):
     assert np.allclose(bond_lenghts1, bond_lenghts2)
 
 
-@pytest.mark.skip(reason="Broken, maybe only on Python 3.11")
 def test_image_molecules(get_fn):
     # Load trajectory with periodic box
     t = md.load(
@@ -926,7 +925,7 @@ def test_image_molecules(get_fn):
     # Image inplace with making molecules whole
     t.image_molecules(inplace=True, make_whole=True)
     # Test coordinates in t are not corrupted to NaNs (issue #1813)
-    assert np.any(np.isnan(t.xyz)) is False
+    assert not np.any(np.isnan(t.xyz))
     # Image with specified anchor molecules
     molecules = t.topology.find_molecules()
     anchor_molecules = molecules[0:3]


### PR DESCRIPTION
#1975 

Not sure if it actually speeds up anything or if this actually did anything, but the "performance hints" are gone during compilation.