### PR TITLE
update pypi upload trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/mdtraj
-    if: github.event_name == 'published'
+    if: github.event_name == 'release'
     permissions:
         # IMPORTANT: this permission is mandatory for trusted publishing
         id-token: write


### PR DESCRIPTION
I think we want to use "release" rather than "published" for the event type in order to upload to pypi.

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release