### PR TITLE
Minor bug fix for documentation equations 

### DIFF
--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -142,11 +142,7 @@ def relative_shape_anisotropy(traj):
 
     .. math::
 
-        \\kappa^2 = \\frac{3}{2} \\frac{
-            \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4
-        }{
-            (\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2
-        } - \\frac{1}{2}
+        \\kappa^2 = \\frac{3}{2} \\frac{\\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4}{(\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2} - \\frac{1}{2}
 
 
     Parameters

--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -142,7 +142,7 @@ def relative_shape_anisotropy(traj):
 
     .. math::
 
-        \\kappa^2 = \\frac{3}{2}\\frac{
+        \\kappa^2 = \\frac{3}{2} \\frac{
             \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4
         }{
             (\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2

--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -142,11 +142,11 @@ def relative_shape_anisotropy(traj):
 
     .. math::
 
-        \\kappa^2 = \frac{3}{2}\frac{
+        \\kappa^2 = \\frac{3}{2}\\frac{
             \\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4
         }{
             (\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2
-        } - \frac{1}{2}
+        } - \\frac{1}{2}
 
 
     Parameters

--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -90,7 +90,7 @@ def asphericity(traj):
 
     .. math::
 
-        b = \frac{1}{2}(\\lambda_1^2 + \\lambda_2^2)
+        b = \\frac{1}{2}(\\lambda_1^2 + \\lambda_2^2)
 
 
     Parameters

--- a/mdtraj/geometry/shape.py
+++ b/mdtraj/geometry/shape.py
@@ -142,7 +142,9 @@ def relative_shape_anisotropy(traj):
 
     .. math::
 
-        \\kappa^2 = \\frac{3}{2} \\frac{\\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4}{(\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2} - \\frac{1}{2}
+        \\kappa^2 = \\frac{3}{2}
+        \\frac{\\lambda_1^4 + \\lambda_2^4 + \\lambda_3^4}{(\\lambda_1^2 + \\lambda_2^2 + \\lambda_3^2)^2}
+        - \\frac{1}{2}
 
 
     Parameters


### PR DESCRIPTION
Fix for equation rendering on the documentation page for [`asphericity`](https://mdtraj.readthedocs.io/en/latest/api/generated/mdtraj.asphericity.html) and [`relative_shape_anisotropy`](https://mdtraj.readthedocs.io/en/latest/api/generated/mdtraj.relative_shape_antisotropy.html) in `mdtraj/mdtraj/geometry`.

<img width="759" height="327" alt="Screenshot 2025-07-23 at 1 34 44 PM" src="https://github.com/user-attachments/assets/d65f2052-67ba-4342-993d-877454582936" />
<img width="742" height="353" alt="Screenshot 2025-07-23 at 1 34 49 PM" src="https://github.com/user-attachments/assets/77d2ad2a-8d88-4b45-a6f3-1572e92fbe4e" />
