### PR TITLE
update dependabot weekly and pre-commit monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,5 @@ repos:
     - id: ruff
       args: [--fix]
     - id: ruff-format
+ci:
+  autoupdate_schedule: 'monthly'


### PR DESCRIPTION
As per https://github.com/mdtraj/mdtraj/pull/2080#issuecomment-3267497653, we're updating pre-commit monthly. Also doing dependabot updates weekly, since we really don't need every minuscule point update.

Doing it less frequently allow updates to stack.