### PR TITLE
Updating macos-13 runner to macos-15-intel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os:
           - macOS-latest  # arm64
-          - macOS-13  # x86-64
+          - macOS-15-intel  # x86-64
           - ubuntu-latest
           - ubuntu-24.04-arm
         python-version:


### PR DESCRIPTION
macos-13 runners (for x86-64) are closing down December 4th, 2025
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

This pushes all our runners to macos-15-intel, which will be the last macOS x86-64 runners (since Apple dropped support for x86-64). These runners will last until Fall 2027.