### PR TITLE
Python3.14 testing and building

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["11", "12", "13"]
+        python: ["11", "12", "13", "14"]
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,6 +38,16 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up conda environment
+      if: ${{ matrix.python-version != '3.14.0rc3' }}
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-file: devtools/conda-envs/test.yaml
+        create-args: >-
+          python=${{ matrix.python-version }}
+          openmm
+
+    - name: Set up conda environment (py3.14)
+      if: ${{ matrix.python-version == '3.14.0rc3' }}
       uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: devtools/conda-envs/test.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
     - uses: actions/checkout@v5
@@ -42,6 +43,7 @@ jobs:
         environment-file: devtools/conda-envs/test.yaml
         create-args: >-
           python=${{ matrix.python-version }}
+          conda-forge/label/python_rc::_python_rc
 
     - name: Install package
       run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.14"
+          - "3.14.0rc3"
 
     steps:
     - uses: actions/checkout@v5

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -8,7 +8,6 @@ dependencies:
   - netCDF4
   - networkx
   - numpy
-  - openmm
   - pandas
   - pyparsing
   - pytables


### PR DESCRIPTION
Thought I was in my own fork but whatever.

Our testing is currently bottlenecked by the lack of a py3.14 compatible release of openmm. I dropped `openmm` here for the time being and things are working fine (i.e. tests run and all pass).

I'll update the PR after Python 3.14 has officially released next Tuesday, then we can merge this in, along with https://github.com/conda-forge/mdtraj-feedstock/pull/82.

EDIT: `cibuildwheel` works fine
https://github.com/jeremyleung521/mdtraj/actions/runs/18227642437/job/51902948368