### PR TITLE
Simplify testing on python 3.14 (with openmm)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,16 +38,6 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Set up conda environment
-      if: ${{ matrix.python-version != '3.14' }}
-      uses: mamba-org/setup-micromamba@v2
-      with:
-        environment-file: devtools/conda-envs/test.yaml
-        create-args: >-
-          python=${{ matrix.python-version }}
-          openmm
-
-    - name: Set up conda environment (py3.14)
-      if: ${{ matrix.python-version == '3.14' }}
       uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: devtools/conda-envs/test.yaml

--- a/devtools/conda-envs/test.yaml
+++ b/devtools/conda-envs/test.yaml
@@ -8,6 +8,7 @@ dependencies:
   - netCDF4
   - networkx
   - numpy
+  - openmm
   - pandas
   - pyparsing
   - pytables


### PR DESCRIPTION
Simplify testing workflow for python 3.14 when openmm support python 3.14, as per #2089.

To be merged when openmm officially supports python 3.14.
