### PR TITLE
rewrite trajectory.py topology parsing with match/case

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -190,7 +190,7 @@ def _parse_topology(top, **kwargs):
                     topology = load_hoomdxml(top, **kwargs).topology
                 case ".gsd":
                     topology = load_gsd_topology(top, **kwargs)
-                case ext:
+                case ext:  # raise error when we hit any other cases
                     raise OSError(
                         "The topology is loaded by filename extension, and the "
                         'detected "{}" format is not supported. Supported topology '


### PR DESCRIPTION
Since we (and the world) dropped python 3.9 support, I rewrote a huge block in trajectory.py with match/case instead of if/elif because it was really wordy. 

Lengthwise it's the same (mostly because I divided a block into two due to a line being too long), but it's cleaner, easier to read with less characters and does less checks, not that it should affect efficiency too much.