### PR TITLE
Fix pyparsing Deprecations

### DIFF
--- a/mdtraj/core/selection.py
+++ b/mdtraj/core/selection.py
@@ -38,9 +38,9 @@ from pyparsing import (
     Word,
     alphanums,
     alphas,
-    infixNotation,
+    infix_notation,
     opAssoc,
-    quotedString,
+    quoted_string,
 )
 
 # this number arises from the current selection language, if the cache size is exceeded, it hurts performance a bit.
@@ -357,29 +357,29 @@ class parse_selection:
         # or quoted strings but we exclude any of the logical
         # operands (e.g. 'or') from being parsed literals
         literal = ~(keywords(BinaryInfixOperand) | keywords(UnaryInfixOperand)) + (
-            Word(NUMS) | quotedString | Word(alphas, alphanums)
+            Word(NUMS) | quoted_string | Word(alphas, alphanums)
         )
-        literal.setParseAction(Literal)
+        literal.set_parse_action(Literal)
 
         # These are the other 'root' expressions,
         # the selection keywords (resname, resid, mass, etc)
         selection_keyword = keywords(SelectionKeyword)
-        selection_keyword.setParseAction(SelectionKeyword)
+        selection_keyword.set_parse_action(SelectionKeyword)
         base_expression = MatchFirst([selection_keyword, literal])
 
         # range condition matches expressions such as 'mass 1 to 20'
         range_condition = Group(
             selection_keyword + literal + Keyword("to") + literal,
         )
-        range_condition.setParseAction(RangeCondition)
+        range_condition.set_parse_action(RangeCondition)
 
         # matches expression such as `resname GLU ASP ARG` and also
         # handles implicit equality `resname ALA`
         in_list_condition = Group(selection_keyword + OneOrMore(literal))
-        in_list_condition.setParseAction(InListCondition)
+        in_list_condition.set_parse_action(InListCondition)
 
         expression = range_condition | in_list_condition | base_expression
-        logical_expr = infixNotation(
+        logical_expr = infix_notation(
             expression,
             infix(UnaryInfixOperand) + infix(BinaryInfixOperand) + infix(RegexInfixOperand),
         )
@@ -394,7 +394,7 @@ class parse_selection:
             self._initialize()
 
         try:
-            parse_result = self.expression.parseString(selection, parseAll=True)
+            parse_result = self.expression.parse_string(selection, parse_all=True)
         except ParseException as e:
             msg = str(e)
             lines = [


### PR DESCRIPTION
Found a few pyparsing's deprecated aliases... which are in camelCase. Updating them here to the "PEP8" non-deprecated versions, which are underscored/snake_case.

https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#api-changes