### PR TITLE
Fix to allow mdtraj.load() to load urls ending with pdb file extensions

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -333,17 +333,11 @@ def load_frame(filename, index, top=None, atom_indices=None, **kwargs):
     if extension not in _TOPOLOGY_EXTS:
         kwargs["top"] = top
 
-    # Check to see if files exists for elements that are not considered URLs
-    url_check = _are_urls(filename)
-    if not all(url_check):
-        check_filename = (
-            filename if len(url_check) == 1 else [name for name, status in zip(filename, url_check) if not status]
-        )
-
+    if not _is_url(filename):
         if loader.__name__ not in ["load_dtr"]:
-            _assert_files_exist(check_filename)
+            _assert_files_exist(filename)
         else:
-            _assert_files_or_dirs_exist(check_filename)
+            _assert_files_or_dirs_exist(filename)
 
     return loader(filename, frame=index, **kwargs)
 
@@ -450,11 +444,19 @@ def load(filename_or_filenames, discard_overlapping_frames=False, **kwargs):
             f"with extensions in {FormatRegistry.loaders.keys()}",
         )
 
-    if not _is_url(top):
+    # Check to see if files exists for elements that are not considered URLs
+    url_check = _are_urls(filename_or_filenames)
+    if not all(url_check):
+        check_filenames = (
+            filename_or_filenames
+            if len(url_check) == 1
+            else [name for name, status in zip(filename_or_filenames, url_check) if not status]
+        )
+
         if loader.__name__ not in ["load_dtr"]:
-            _assert_files_exist(filename_or_filenames)
+            _assert_files_exist(check_filenames)
         else:
-            _assert_files_or_dirs_exist(filename_or_filenames)
+            _assert_files_or_dirs_exist(check_filenames)
 
     if extension not in _TOPOLOGY_EXTS:
         # standard_names is a valid keyword argument only for files containing topologies

--- a/tests/test_pdb.py
+++ b/tests/test_pdb.py
@@ -286,15 +286,18 @@ def test_1vii_url_and_gz(get_fn):
 
 
 @flaky_pdb_dl
-def test_load_mixture_from_url(get_fn):
+def test_1vii_load_from_mixture(get_fn):
     # load pdb from URL and locally
     t1 = load(["https://www.rcsb.org/pdb/files/1vii.pdb.gz", get_fn("1vii.pdb.gz")])
     t2 = load_pdb(get_fn("1vii.pdb"))
+    t3 = load([get_fn("1vii.pdb"), "https://www.rcsb.org/pdb/files/1vii.pdb", get_fn("1vii.pdb")])
 
     eq(t1.n_frames, 2)
     eq(t2.n_frames, 1)
+    eq(t3.n_frames, 3)
 
     eq(t1.n_atoms, t2.n_atoms)
+    eq(t1.n_atoms, t3.n_atoms)
 
 
 def test_segment_id(get_fn):


### PR DESCRIPTION
Due to some overly-strict file-existence checks, you cannot open a url with a ".pdb" extension using generic `mdtraj.load()`. You have to go via `mdtraj.load_pdb()`.

This loosens it up. Though, due to how things work with the `mdtraj.load()` logic, I think we actually download the first file twice, if it happens to be a URL (an extra time for parsing topology).

## Before Fix
```
In [1]: import mdtraj

In [2]: a = mdtraj.load_pdb('https://files.rcsb.org/download/7X7S.pdb.gz')
/home/jml230/git/mdtraj/mdtraj/formats/pdb/pdbfile.py:214: UserWarning: Unlikely unit cell vectors detected in PDB file likely resulting from a dummy CRYST1 record. Discarding unit cell vectors.
  warnings.warn(

In [3]: a = mdtraj.load('https://files.rcsb.org/download/7X7S.pdb.gz')
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
Cell In[3], line 1
----> 1 a = mdtraj.load('https://files.rcsb.org/download/7X7S.pdb.gz')

File ~/git/mdtraj/mdtraj/core/trajectory.py:413, in load(filename_or_filenames, discard_overlapping_frames, **kwargs)
    410 # These topology formats do not support the 'top' keyword
    411 # This is to prevent the loader from reading the topology twice.
    412 if extension not in [".h5", ".hdf5", ".mol2"]:
--> 413     kwargs["top"] = _parse_topology(top, **topkwargs)
    415 # get the right loader
    416 try:
    417     # loader = _LoaderRegistry[extension][0]

File ~/git/mdtraj/mdtraj/core/trajectory.py:174, in _parse_topology(top, **kwargs)
    172 match _get_extension(top):
    173     case ".pdb" | ".pdb.gz" | ".pdbx" | ".pdbx.gz" | ".cif" | ".cif.gz" | ".mmcif" | ".mmcif.gz":
--> 174         _traj = load_frame(top, 0, **kwargs)
    175         topology = _traj.topology
    176     case ".h5" | ".lh5":

File ~/git/mdtraj/mdtraj/core/trajectory.py:316, in load_frame(filename, index, top, atom_indices, **kwargs)
    313     kwargs["top"] = top
    315 if loader.__name__ not in ["load_dtr"]:
--> 316     _assert_files_exist(filename)
    317 else:
    318     _assert_files_or_dirs_exist(filename)

File ~/git/mdtraj/mdtraj/core/trajectory.py:115, in _assert_files_exist(filenames)
    113 for fn in filenames:
    114     if not (os.path.exists(fn) and os.path.isfile(fn)):
--> 115         raise OSError("No such file: %s" % fn)

OSError: No such file: https://files.rcsb.org/download/7X7S.pdb.gz
```

## After Fix
```
In [1]: import mdtraj

In [2]: a = mdtraj.load_pdb('https://files.rcsb.org/download/7X7S.pdb.gz')
/home/jml230/git/mdtraj/mdtraj/formats/pdb/pdbfile.py:214: UserWarning: Unlikely unit cell vectors detected in PDB file likely resulting from a dummy CRYST1 record. Discarding unit cell vectors.
  warnings.warn(

In [3]: a = mdtraj.load('https://files.rcsb.org/download/7X7S.pdb.gz')
/home/jml230/git/mdtraj/mdtraj/formats/pdb/pdbfile.py:214: UserWarning: Unlikely unit cell vectors detected in PDB file likely resulting from a dummy CRYST1 record. Discarding unit cell vectors.
  warnings.warn(
```