### PR TITLE
Fix PyPI upload GitHub Action Process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,9 @@ jobs:
     environment:
       name: pypi
       url: https://pypi.org/p/mdtraj
-    if: github.event_name == 'release'
+    if: |
+        github.repository == 'mdtraj/mdtraj' &&
+        github.event_name == 'release'
     permissions:
         # IMPORTANT: this permission is mandatory for trusted publishing
         id-token: write


### PR DESCRIPTION
Use `pattern:` instead of `name:`

Bug from #1980. We might be able to manually dispatch this and it should hopefully push the right wheels up. If not we can just manually upload the wheels.

Last release it didn't trigger properly so it never got to this point...

Added an extra conditional so forks won't try to upload either.

EDIT: I manually uploaded the wheels and source.