### PR TITLE
Guard against empty atom indices producing NaNs in superpose

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -1114,6 +1114,8 @@ class Trajectory:
 
         if atom_indices is None:
             atom_indices = slice(None)
+        elif len(atom_indices) == 0:
+            raise ValueError("Number of atom indices must be greater than 0")
 
         if ref_atom_indices is None:
             ref_atom_indices = atom_indices

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -321,16 +321,14 @@ def test_superpose_with_empty_atom_raises_exception():
     n_frames = 5
     n_atoms = 20
 
-    xyz = rng.standard_normal((n_frames, n_atoms, 3)).astype(np.float32)
-    original = md.Trajectory(xyz=xyz, topology=None)
+    xyz = rng.standard_normal((n_frames, n_atoms, 3), dtype=np.float32)
+    traj = md.Trajectory(xyz=xyz, topology=None)
 
-    # Superpose with empty atom_indices list, previously this would lead to NaN positions
-    query = md.Trajectory(xyz=xyz.copy(), topology=None)
     with pytest.raises(ValueError, match="Number of atom indices must be greater than 0"):
-        query.superpose(original, frame=0, atom_indices=[])
+        traj.superpose(traj, frame=0, atom_indices=[])
 
     # Super posing with valid indices should behave as expected afterwards
-    query.superpose(original, frame=0, atom_indices=[0])
+    traj.superpose(traj, frame=0, atom_indices=[0])
 
     # Coordinates should be finite after superposing
-    assert np.all(np.isfinite(query.xyz))
+    assert np.all(np.isfinite(traj.xyz))

--- a/tests/test_rmsd.py
+++ b/tests/test_rmsd.py
@@ -314,3 +314,23 @@ def test_rmsd_atom_indices_vs_ref_indices():
     md.rmsd(trj_1, trj_2, atom_indices=[0], ref_atom_indices=[1])
     md.rmsd(trj_2, trj_1, atom_indices=[1], ref_atom_indices=[0])
     # if this don't fail then it's good no matter the result
+
+
+def test_superpose_with_empty_atom_raises_exception():
+    # Test that superpose with an empty atom_indices list produces NaN coordinates
+    n_frames = 5
+    n_atoms = 20
+
+    xyz = rng.standard_normal((n_frames, n_atoms, 3)).astype(np.float32)
+    original = md.Trajectory(xyz=xyz, topology=None)
+
+    # Superpose with empty atom_indices list, previously this would lead to NaN positions
+    query = md.Trajectory(xyz=xyz.copy(), topology=None)
+    with pytest.raises(ValueError, match="Number of atom indices must be greater than 0"):
+        query.superpose(original, frame=0, atom_indices=[])
+
+    # Super posing with valid indices should behave as expected afterwards
+    query.superpose(original, frame=0, atom_indices=[0])
+
+    # Coordinates should be finite after superposing
+    assert np.all(np.isfinite(query.xyz))


### PR DESCRIPTION
* Minor issue, but it is good to avoid the compute and to raise a meaningful error