### PR TITLE
Fix high RAM usage in Baker-Hubbard on large trajectories

### DIFF
--- a/mdtraj/geometry/hbond.py
+++ b/mdtraj/geometry/hbond.py
@@ -23,7 +23,9 @@
 import numpy as np
 
 from mdtraj.geometry import _geometry, compute_distances
+from mdtraj.geometry.distance import compute_distances_core
 from mdtraj.utils import ensure_type
+from mdtraj.utils.reduction import block_reduce
 
 __all__ = ["wernet_nilsson", "baker_hubbard", "kabsch_sander"]
 
@@ -152,6 +154,7 @@ def baker_hubbard(
     sidechain_only=False,
     distance_cutoff=0.25,
     angle_cutoff=120,
+    block_size_bytes=512 * 1024 * 1024,
 ):
     """Identify hydrogen bonds based on cutoffs for the Donor-H...Acceptor
     distance and angle.
@@ -184,6 +187,10 @@ def baker_hubbard(
         Angle cutoff of the angle theta in degrees.
         The criterion employed is any contact with an angle theta greater than the
         angle_cutoff is accepted.
+    block_size_bytes : int, default=536870912
+        Target per-block memory budget (in bytes) used by the internal
+        blockwise reduction. Lower values reduce peak RAM usage at the
+        cost of more block iterations.
 
     Returns
     -------
@@ -249,21 +256,85 @@ def baker_hubbard(
         sidechain_only=sidechain_only,
     )
 
-    mask, distances, angles = _compute_bounded_geometry(
-        traj,
-        bond_triplets,
-        distance_cutoff,
-        [1, 2],
-        [0, 1, 2],
-        freq=freq,
-        periodic=periodic,
+    n_frames = traj.n_frames
+    threshold_count = freq * n_frames
+    unitcell_vectors = traj.unitcell_vectors if periodic else None
+
+    if bond_triplets.size == 0 or n_frames == 0:
+        return np.zeros((0, 3), dtype=int)
+
+    # Pass 1: prefilter candidates by H-A distance prevalence.
+    pairs_ha = bond_triplets[:, [1, 2]]
+
+    def map_ha_distance_presence_block(
+        xyz_block: np.ndarray,
+        unitcell_vectors: np.ndarray | None = None,
+    ) -> np.ndarray:
+        ha_nm = compute_distances_core(
+            xyz_block,
+            pairs_ha,
+            unitcell_vectors=unitcell_vectors,
+            periodic=periodic,
+            opt=True,
+        )
+        return ha_nm < distance_cutoff
+
+    count_dist_ok = block_reduce(
+        traj.xyz,
+        block_size_bytes=block_size_bytes,
+        block_func=map_ha_distance_presence_block,
+        dtype=np.uint32,
+        out_shape=(bond_triplets.shape[0],),
+        sliced_kwargs={"unitcell_vectors": unitcell_vectors} if unitcell_vectors is not None else None,
     )
 
-    # Find triplets that meet the criteria
-    presence = np.logical_and(distances < distance_cutoff, angles > angle_cutoff)
-    mask[mask] = np.mean(presence, axis=0) > freq
+    mask_dist = count_dist_ok > threshold_count
+    triplets2 = bond_triplets[mask_dist]
+    if triplets2.size == 0:
+        return np.zeros((0, 3), dtype=int)
 
-    return bond_triplets.compress(mask, axis=0)
+    # Pass 2: evaluate the full Baker-Hubbard criterion on filtered candidates.
+    n_triplets2 = triplets2.shape[0]
+    pair_ha = triplets2[:, [1, 2]]
+    pair_dh = triplets2[:, [0, 1]]
+    pair_da = triplets2[:, [0, 2]]
+    pair_all = np.vstack((pair_ha, pair_dh, pair_da))
+
+    def map_full_bh_presence_block(
+        xyz_block: np.ndarray,
+        unitcell_vectors: np.ndarray | None = None,
+    ) -> np.ndarray:
+        d_all = compute_distances_core(
+            xyz_block,
+            pair_all,
+            unitcell_vectors=unitcell_vectors,
+            periodic=periodic,
+            opt=True,
+        )
+        ha_nm = d_all[:, :n_triplets2]
+        dh_nm = d_all[:, n_triplets2 : 2 * n_triplets2]
+        da_nm = d_all[:, 2 * n_triplets2 :]
+
+        denom = 2.0 * dh_nm * ha_nm
+        cosines = np.ones_like(denom, dtype=np.float32)
+        valid = denom > 0
+        if np.any(valid):
+            cosines[valid] = (dh_nm[valid] ** 2 + ha_nm[valid] ** 2 - da_nm[valid] ** 2) / denom[valid]
+        np.clip(cosines, -1.0, 1.0, out=cosines)
+        angles = np.arccos(cosines)
+        return np.logical_and(ha_nm < distance_cutoff, angles > angle_cutoff)
+
+    count_present = block_reduce(
+        traj.xyz,
+        block_size_bytes=block_size_bytes,
+        block_func=map_full_bh_presence_block,
+        dtype=np.uint32,
+        out_shape=(n_triplets2,),
+        sliced_kwargs={"unitcell_vectors": unitcell_vectors} if unitcell_vectors is not None else None,
+    )
+
+    mask_final = count_present > threshold_count
+    return np.asarray(triplets2[mask_final], dtype=int)
 
 
 def kabsch_sander(traj):

--- a/mdtraj/utils/reduction.py
+++ b/mdtraj/utils/reduction.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def block_reduce(
+    X: np.ndarray,
+    block_size_bytes: int,
+    block_func: Callable[..., np.ndarray],
+    *,
+    dtype=np.uint32,
+    out_shape: tuple[int, ...],
+    static_kwargs: dict | None = None,
+    sliced_kwargs: dict[str, np.ndarray] | None = None,
+) -> np.ndarray:  # noqa: C901, PLR0912
+    """Apply ``block_func`` on row blocks and reduce via ``sum(axis=0)``.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Input array where the first axis is processed in blocks.
+    block_size_bytes : int
+        Target memory budget for one block.
+    block_func : Callable[..., np.ndarray]
+        Mapping function called as ``block_func(block, **kwargs)``.
+    dtype : np.dtype, default=np.uint32
+        Accumulator dtype for the final reduction.
+    out_shape : tuple[int, ...]
+        Output shape after reducing over block rows.
+    static_kwargs : dict, optional
+        Keyword arguments passed to every block unchanged.
+    sliced_kwargs : dict[str, np.ndarray], optional
+        Keyword arguments sliced on axis 0 in sync with ``X``.
+    """
+    n_rows = int(X.shape[0])
+    if n_rows == 0:
+        raise ValueError("block_reduce requires n_rows > 0")
+
+    static_kwargs = {} if static_kwargs is None else static_kwargs
+    sliced_kwargs = {} if sliced_kwargs is None else sliced_kwargs
+    out = np.zeros(out_shape, dtype=dtype)
+
+    # Block size is derived from one output row footprint and byte budget.
+    row_nbytes = max(1, int(out.nbytes))
+    rows_per_block = max(1, min(n_rows, block_size_bytes // row_nbytes))
+
+    for key, value in sliced_kwargs.items():
+        if not isinstance(value, np.ndarray):
+            raise TypeError(f"sliced_kwargs['{key}'] must be np.ndarray")
+        if value.shape[0] != n_rows:
+            raise ValueError(
+                f"sliced_kwargs['{key}'] first dimension must be {n_rows}, got {value.shape[0]}",
+            )
+
+    for start in range(0, n_rows, rows_per_block):
+        stop = min(n_rows, start + rows_per_block)
+        block = X[start:stop]
+
+        kwargs_for_block = dict(static_kwargs)
+        for key, value in sliced_kwargs.items():
+            kwargs_for_block[key] = value[start:stop]
+
+        mapped = block_func(block, **kwargs_for_block)
+        block_sum = mapped.sum(axis=0, dtype=dtype)
+
+        if block_sum.shape != out.shape:
+            raise ValueError(
+                f"block_reduce got inconsistent reduced shape: expected {out.shape}, got {block_sum.shape}",
+            )
+        np.add(out, block_sum, out=out)
+
+    return out

--- a/tests/test_hbonds.py
+++ b/tests/test_hbonds.py
@@ -22,10 +22,12 @@
 
 
 import numpy as np
+import pytest
 import scipy.sparse
 
 import mdtraj as md
 from mdtraj.testing import eq
+from mdtraj.utils.reduction import block_reduce
 
 
 def test_hbonds(get_fn):
@@ -124,6 +126,84 @@ def test_baker_hubbard_3(get_fn):
         md.baker_hubbard(t, exclude_water=False, angle_cutoff=180),
     )
     eq(np.array([[0, 1, 3]]), md.baker_hubbard(t, exclude_water=False))
+
+
+def test_baker_hubbard_entry_points_equivalent(get_fn):
+    t = md.load(get_fn("2EQQ.pdb"))
+    eq(md.baker_hubbard(t), md.geometry.hbond.baker_hubbard(t))
+
+
+def test_baker_hubbard_triplet_semantics(get_fn):
+    t = md.load(get_fn("2EQQ.pdb"))
+    hbonds = md.baker_hubbard(t)
+
+    assert hbonds.ndim == 2
+    assert hbonds.shape[1] == 3
+    for d_i, h_i, a_i in hbonds:
+        assert t.topology.atom(d_i).element.symbol in ["O", "N"]
+        assert t.topology.atom(h_i).element.symbol == "H"
+        assert t.topology.atom(a_i).element.symbol in ["O", "N"]
+
+
+def test_baker_hubbard_freq_strict_boundary(get_fn):
+    t = md.load(get_fn("2waters_baker_hubbard.pdb"))
+    traj = md.join([t] * 10, check_topology=True)
+
+    # Disable the known bond in half of frames.
+    traj.xyz[5:, 3, :] += np.array([1.0, 1.0, 1.0], dtype=traj.xyz.dtype)
+
+    eq(
+        np.zeros((0, 3), dtype=int),
+        md.baker_hubbard(traj, exclude_water=False, periodic=False, freq=0.5),
+    )
+    eq(
+        np.array([[0, 1, 3]]),
+        md.baker_hubbard(traj, exclude_water=False, periodic=False, freq=0.49),
+    )
+
+
+@pytest.mark.parametrize("fn, periodic", [("2EQQ.pdb", False), ("4ZUO.pdb", True)])
+def test_baker_hubbard_block_size_invariance(get_fn, fn, periodic):
+    t = md.load(get_fn(fn))
+    baseline = md.baker_hubbard(t, periodic=periodic)
+    small_block = md.baker_hubbard(t, periodic=periodic, block_size_bytes=1024)
+    eq(baseline, small_block)
+
+
+def test_block_reduce_matches_direct_sum_with_static_and_sliced_kwargs():
+    X = np.arange(24, dtype=np.float32).reshape(6, 4)
+    weights = np.arange(6, dtype=np.float32).reshape(6, 1)
+    bias = 2.5
+
+    def map_block(block: np.ndarray, weights: np.ndarray, bias: float) -> np.ndarray:
+        return block + weights + bias
+
+    out = block_reduce(
+        X,
+        block_size_bytes=16,
+        block_func=map_block,
+        dtype=np.float64,
+        out_shape=(4,),
+        static_kwargs={"bias": bias},
+        sliced_kwargs={"weights": weights},
+    )
+
+    expected = (X + weights + bias).sum(axis=0, dtype=np.float64)
+    np.testing.assert_allclose(out, expected)
+
+
+def test_block_reduce_raises_on_incompatible_sliced_kwargs():
+    X = np.arange(12, dtype=np.float32).reshape(3, 4)
+    bad = np.arange(8, dtype=np.float32).reshape(2, 4)
+
+    with pytest.raises(ValueError, match="first dimension must be"):
+        block_reduce(
+            X,
+            block_size_bytes=1024,
+            block_func=lambda block, bad: block + bad[: block.shape[0]],
+            out_shape=(4,),
+            sliced_kwargs={"bad": bad},
+        )
 
 
 def test_wernet_nilsson_0(get_fn):


### PR DESCRIPTION
# Motivation

For large systems such as the 7cmd protein benchmark, we need to run MD analysis across all chains simultaneously.

In the current `baker_hubbard` implementation:

- number of frames scales as **O(M)**
- number of atoms scales as **O(N)**
- number of donor–hydrogen–acceptor (DHA) triplets scales approximately as **O(N²)**

The current implementation evaluates hydrogen-bond criteria over all frames and all triplets at once, creating intermediate arrays with complexity:

$$
O(M \cdot N^2)
$$

For large trajectories this becomes prohibitively memory intensive.

In practice, for a trajectory file of roughly **5 GB**, temporary allocations during `baker_hubbard` can exceed **40 GB**, leading to an Out-Of-Memory (OOM) failure before computation completes.

---

# Proposed Approach

The main observation is that hydrogen-bond evaluation is independent across frames.

Instead of processing the entire trajectory at once, this PR processes frames in fixed-size blocks using two sequential `block_reduce` passes.

## First pass

Compute distance masks blockwise and eliminate triplets that do not satisfy:

```python
distance < distance_cutoff
```

This significantly reduces the number of candidate triplets that need further processing.

## Second pass

For the remaining candidates, evaluate the angular criterion blockwise:

```python
angle > angle_cutoff
```

Counts from each block are accumulated into the final occupancy array.

This avoids constructing full `(n_frames × n_triplets)` intermediate matrices for the whole trajectory.

---

# Why Blockwise Processing

A naïve frame-by-frame implementation significantly reduces performance because it loses the benefits of NumPy vectorization and introduces excessive Python-level overhead.

The blockwise strategy preserves vectorized computation while keeping memory bounded.

Experimental results:

| Method | Runtime |
|---|---|
| Current baseline | ~36 s |
| Frame-by-frame | ~100 s |
| Blockwise | ~42 s |

The blockwise implementation remains close to baseline performance while eliminating OOM failures on large systems.

Additionally, performance improves as block size increases, up to the available memory limit.

---

# Memory Strategy

The block size is determined from a configurable memory budget (`block_size_bytes`).

Default value:

```python
block_size_bytes = 512 * 1024 * 1024
```

This keeps peak temporary allocations bounded and adapts processing to machine memory constraints.

For smaller proteins, memory usage remains effectively identical to the current implementation.

---

# Implementation Details

## Summary

- Optimize `baker_hubbard` memory usage using a blockwise two-pass reduction algorithm
- Avoid allocating full frame-by-triplet matrices
- Add reusable internal helper:
  - `block_reduce` in `mdtraj/utils/reduction.py`
- Preserve backward compatibility for:
  - API behavior
  - outputs
- Add configurable `block_size_bytes`
- Add unit tests

---

# Design Rationale

The goal of this PR is not to change the Baker–Hubbard algorithm itself, but to improve its scalability for large trajectories by reducing peak memory usage while retaining vectorized execution characteristics.