### PR TITLE
Add bridge_anchors option to image_molecules

### DIFF
--- a/mdtraj/core/trajectory.py
+++ b/mdtraj/core/trajectory.py
@@ -2337,13 +2337,19 @@ class Trajectory:
     def _have_unitcell(self):
         return self._unitcell_lengths is not None and self._unitcell_angles is not None
 
-    def _sort_bonds(self):
+    def _sort_bonds(self, extra_bonds=None):
         """Sort bonds for wrapping molecules correctly.
 
         Each molecule is built in a continuous chain along the bonds, which
         prevents atoms from being imaged to multiple distinct locations.
         The returned list of bonds defines each molecule as a minimum spanning
         tree of the molecular graph.
+
+        Parameters
+        ----------
+        extra_bonds : array_like of shape (k, 2), optional
+            Additional atom-index pairs to add to the graph before building the
+            spanning tree, to stitch separate molecules into one component.
 
         Returns
         -------
@@ -2354,6 +2360,10 @@ class Trajectory:
             [[b0.index, b1.index] for b0, b1 in self._topology.bonds],
             dtype=np.int32,
         )
+        if extra_bonds is not None and len(extra_bonds) > 0:
+            bonds = np.concatenate(
+                [bonds, np.asarray(extra_bonds, dtype=np.int32).reshape(-1, 2)],
+            )
         # Build an adjacency list for the molecular graph
         adj = defaultdict(list)
         for bond in bonds:
@@ -2383,6 +2393,56 @@ class Trajectory:
                             sorted_bonds.append([current_atom, neighbor])
 
         return np.array(sorted_bonds, dtype=np.int32)
+
+    def _anchor_bridge_bonds(self, anchor_molecules, frame=0):
+        """Bonds connecting anchor molecules at their closest real-space contacts.
+
+        Returns one bond per edge of a spanning tree over the anchor molecules,
+        so that ``make_whole`` reassembles them as a single connected complex.
+        Contacts are measured in real space (``periodic=False``) on a made-whole
+        copy of ``frame``, since the minimum-image closest contact can be a pair
+        that is adjacent only through the periodic boundary.
+
+        Parameters
+        ----------
+        anchor_molecules : list of atom sets
+            The anchor molecules to bridge together.
+        frame : int, default=0
+            The frame used to measure interface contacts.
+
+        Returns
+        -------
+        bridges : list of (int, int)
+            Atom-index pairs, one per edge of the spanning tree.
+        """
+        groups = [np.fromiter((a.index for a in mol), dtype=np.int32) for mol in anchor_molecules]
+        bridges = []
+        if len(groups) < 2:
+            return bridges
+
+        whole_ref = self[frame].make_molecules_whole(inplace=False)
+
+        # Join the next molecule through its closest contact to the connected set.
+        connected = {0}
+        while len(connected) < len(groups):
+            best = None
+            for i in range(len(groups)):
+                if i in connected:
+                    continue
+                for j in connected:
+                    a1, a2, dist = distance.find_closest_contact(
+                        whole_ref,
+                        groups[i],
+                        groups[j],
+                        frame=0,
+                        periodic=False,
+                    )
+                    if best is None or dist < best[0]:
+                        best = (dist, i, int(a1), int(a2))
+            _, new_group, a1, a2 = best
+            bridges.append((a1, a2))
+            connected.add(new_group)
+        return bridges
 
     def make_molecules_whole(self, inplace=False, sorted_bonds=None):
         """Only make molecules whole
@@ -2428,6 +2488,7 @@ class Trajectory:
         other_molecules=None,
         sorted_bonds=None,
         make_whole=True,
+        bridge_anchors=False,
     ):
         """Recenter and apply periodic boundary conditions to the molecules in each frame of the trajectory.
 
@@ -2454,6 +2515,14 @@ class Trajectory:
             topology. Only relevant if ``make_whole`` is True.
         make_whole : bool
             Whether to make molecules whole.
+        bridge_anchors : bool, default=False
+            If True, treat all anchor molecules as a single connected complex,
+            stitched together at their real-space interface contacts, instead of
+            keeping them together with the per-pair minimum-image heuristic. Use
+            this for elongated multi-chain complexes (e.g. protein dimers) that
+            span more than half the box, which the default heuristic splits
+            across the periodic boundary. Requires ``make_whole=True`` and is
+            incompatible with a user-supplied ``sorted_bonds``.
 
         Returns
         -------
@@ -2472,6 +2541,23 @@ class Trajectory:
         if anchor_molecules is None:
             anchor_molecules = self.topology.guess_anchor_molecules()
 
+        anchor_bridge_bonds = None
+        if bridge_anchors:
+            if not make_whole:
+                raise ValueError("bridge_anchors=True requires make_whole=True")
+            if sorted_bonds is not None:
+                raise ValueError(
+                    "bridge_anchors=True is incompatible with a user-supplied sorted_bonds",
+                )
+            # Merge the anchors into one connected complex to bypass the per-pair
+            # minimum-image heuristic, which splits complexes longer than half the box.
+            anchor_bridge_bonds = self._anchor_bridge_bonds(anchor_molecules)
+            merged_anchor = set().union(*anchor_molecules)
+            if other_molecules is None:
+                molecules = self._topology.find_molecules()
+                other_molecules = [mol for mol in molecules if not (mol & merged_anchor)]
+            anchor_molecules = [merged_anchor]
+
         if other_molecules is None:
             # Determine other molecules by which molecules are not anchor molecules
             molecules = self._topology.find_molecules()
@@ -2488,7 +2574,7 @@ class Trajectory:
         else:
             result = self[:]
         if make_whole and sorted_bonds is None:
-            sorted_bonds = self._sort_bonds()
+            sorted_bonds = self._sort_bonds(extra_bonds=anchor_bridge_bonds)
         elif not make_whole:
             sorted_bonds = None
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -932,6 +932,94 @@ def test_image_molecules(get_fn):
     t.image_molecules(inplace=True, anchor_molecules=anchor_molecules)
 
 
+@pytest.fixture
+def elongated_dimer_traj():
+    """A two-chain complex that spans more than half the periodic box.
+
+    Chain A spans x=0.0..1.8 and chain B spans x=2.0..3.9 in a 4.0 nm box, so
+    the genuine interface is A1--B0 (0.2 nm) but the minimum-image closest
+    contact is the wrap-around pair A0--B1 (0.1 nm), which image_molecules'
+    default heuristic uses to image chain B to the wrong periodic copy.
+    """
+    top = md.Topology()
+    cA = top.add_chain()
+    rA = top.add_residue("ALA", cA)
+    a0 = top.add_atom("A0", element.carbon, rA)
+    a1 = top.add_atom("A1", element.carbon, rA)
+    top.add_bond(a0, a1)
+    cB = top.add_chain()
+    rB = top.add_residue("ALA", cB)
+    b0 = top.add_atom("B0", element.carbon, rB)
+    b1 = top.add_atom("B1", element.carbon, rB)
+    top.add_bond(b0, b1)
+
+    xyz = np.array(
+        [[[0.0, 0, 0], [1.8, 0, 0], [2.0, 0, 0], [3.9, 0, 0]]],
+        dtype=np.float32,
+    )
+    traj = md.Trajectory(xyz, top)
+    traj.unitcell_vectors = (np.eye(3, dtype=np.float32) * 4.0)[None]
+    return traj
+
+
+def test_image_molecules_bridge_anchors(elongated_dimer_traj):
+    traj = elongated_dimer_traj
+    anchors = traj.topology.find_molecules()
+    assert len(anchors) == 2
+
+    # The interface distance (last atom of chain A, first atom of chain B) in
+    # the intact, made-whole complex.
+    intact = traj.make_molecules_whole(inplace=False)
+    intact_interface = np.linalg.norm(intact.xyz[0, 1] - intact.xyz[0, 2])
+    np.testing.assert_allclose(intact_interface, 0.2, atol=1e-5)
+
+    # The default heuristic splits the complex across the periodic boundary.
+    default = traj.image_molecules(inplace=False, anchor_molecules=anchors)
+    default_interface = np.linalg.norm(default.xyz[0, 1] - default.xyz[0, 2])
+    assert default_interface > 1.0
+
+    # bridge_anchors=True reassembles the whole complex deterministically, so
+    # every pairwise distance among the anchor atoms matches the intact complex.
+    bridged = traj.image_molecules(
+        inplace=False,
+        anchor_molecules=anchors,
+        bridge_anchors=True,
+    )
+    bridged_interface = np.linalg.norm(bridged.xyz[0, 1] - bridged.xyz[0, 2])
+    np.testing.assert_allclose(bridged_interface, intact_interface, atol=1e-5)
+
+    def pairwise(xyz):
+        diff = xyz[:, None, :] - xyz[None, :, :]
+        return np.linalg.norm(diff, axis=-1)
+
+    np.testing.assert_allclose(
+        pairwise(bridged.xyz[0]),
+        pairwise(intact.xyz[0]),
+        atol=1e-5,
+    )
+
+
+def test_image_molecules_bridge_anchors_validation(elongated_dimer_traj):
+    traj = elongated_dimer_traj
+    anchors = traj.topology.find_molecules()
+
+    with pytest.raises(ValueError, match="requires make_whole"):
+        traj.image_molecules(
+            inplace=False,
+            anchor_molecules=anchors,
+            bridge_anchors=True,
+            make_whole=False,
+        )
+
+    with pytest.raises(ValueError, match="sorted_bonds"):
+        traj.image_molecules(
+            inplace=False,
+            anchor_molecules=anchors,
+            bridge_anchors=True,
+            sorted_bonds=traj._sort_bonds(),
+        )
+
+
 def test_load_pdb_no_standard_names(get_fn):
     # Minimal test. Standard_names=False will force load_pdb.py
     # to NOT replace any non-standard atom or residue names in the topology


### PR DESCRIPTION
image_molecules keeps separate anchor molecules together with a single-closest-contact minimum-image heuristic, which picks the wrong periodic image when the assembled complex spans more than half the box along an axis, splitting elongated multi-chain complexes (e.g. protein dimers) across the periodic boundary.

The new bridge_anchors option treats all anchor molecules as a single connected complex: they are stitched together at their real-space interface contacts (measured on a made-whole reference) so make_whole reassembles the whole complex deterministically, bypassing the per-pair minimum-image heuristic. _sort_bonds now accepts extra_bonds so the bridges are folded into the existing spanning-tree make_whole path.

Defaults to False, so existing behaviour is unchanged.